### PR TITLE
add support for LibCloudStorage with Django1.7 migration features

### DIFF
--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -8,7 +8,7 @@ from django.core.files.storage import Storage
 from django.core.files.base import File
 from django.core.exceptions import ImproperlyConfigured
 
-from storages.compat import BytesIO
+from storages.compat import BytesIO, deconstructible
 
 try:
     from libcloud.storage.providers import get_driver
@@ -16,7 +16,7 @@ try:
 except ImportError:
     raise ImproperlyConfigured("Could not load libcloud")
 
-
+@deconstructible
 class LibCloudStorage(Storage):
     """Django storage derived class using apache libcloud to operate
     on supported providers"""


### PR DESCRIPTION
I've tested this with Rackspace via ApacheLibCloud using the following settings:

DEFAULT_LIBCLOUD_PROVIDER = 'rs_test'
LIBCLOUD_PROVIDERS = {
    'rs_test': {
        'type': 'libcloud.storage.types.Provider.CLOUDFILES_US',
        'user': os.environ['RACKSPACE_USERNAME'],
        'key': os.environ['RACKSPACE_API_KEY'],
        'bucket': 'storages_test'
    },
}

I also tested that 'python manage.py makemigrations <appname>' works after making this change (it didn't before).
