### PR TITLE
s3boto modified_time fails for new file 

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -1,6 +1,9 @@
 import os
 import posixpath
 import mimetypes
+from boto.utils import ISO8601
+from boto.utils import ISO8601_MS
+
 from gzip import GzipFile
 import datetime
 from tempfile import SpooledTemporaryFile
@@ -476,6 +479,12 @@ class S3BotoStorage(Storage):
         if entry is None:
             entry = self.bucket.get_key(self._encode_name(name))
         # Parse the last_modified string to a local datetime object.
+        if not entry.last_modified:
+            try:
+                entry.last_modified = datetime.datetime.now().strftime(ISO8601)
+            except ValueError:
+                entry.last_modified = datetime.datetime.now().strftime(ISO8601_MS)
+
         return parse_ts_extended(entry.last_modified)
 
     def url(self, name, headers=None, response_headers=None):


### PR DESCRIPTION
This isn't actually my fix - I stumbled across it when trying to debug an issue with Mezzanine's usage of Django-Storages and involves a case where last_modified is not set for newly uploaded files.

https://bitbucket.org/david/django-storages/issue/163/s3boto-modified_time-fails-for-new-file

The PR towards original django-storages that I borrowed this fix from...  seems like it's over a year old and never merged.  

https://bitbucket.org/david/django-storages/pull-request/96/if-entrylast_modified-is-none-set-to/diff
