### PR TITLE
Ripping out ridiculous 'always' warning filter

### DIFF
--- a/storages/__init__.py
+++ b/storages/__init__.py
@@ -1,4 +1,1 @@
 __version__ = '1.2.1'
-
-import warnings
-warnings.simplefilter('always')


### PR DESCRIPTION
`warnings.simplefilter('always')`
- This filter applies not just to the `storages` package, but to the entire Django project in which it's being used.
- This filter causes warnings to be printed to the console [**every single time** the code runs past them](https://docs.python.org/3.4/library/warnings.html#the-warnings-filter).

For example, the project I work on uses Django's `strip_tags()` function to create the `text/plain` part of multipart emails, and when using Django 1.6 and Python 3.3+, there are two `DeprecationWarning`s about impending changes to the `HTMLParser` API when `strip_tags()` is used:

```
/home/vagrant/.venv/lib/python3.4/site-packages/django/utils/html.py:121: DeprecationWarning: The strict argument and mode are deprecated.
  HTMLParser.__init__(self, strict=False)
/home/vagrant/.venv/lib/python3.4/site-packages/django/utils/html.py:121: DeprecationWarning: The value of convert_charrefs will become True in 3.5. You are encouraged to set the value explicitly.
  HTMLParser.__init__(self, strict=False)
```

These usages live in the Django codebase and are out of my control.  Without `django-storages-redux` installed, I see these warnings **once** at the beginning of my unit test runs.  After installing `django-storages-redux`, I see these warnings for **nearly every test** (almost 2,000 tests --> almost 4,000 warnings printed).