### PR TITLE
Update s3boto.py - adding bucket_alias

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ March 2013 despite a wealth of bugfixes that were applied in that year-long
 gap. There is plenty of community support for the django-storages project
 (especially the S3BotoStorage piece) and I have a personal need for a Python3
 compatible version.
-
+https://github.com/nlundquist/django-storages
 All of the Python3 comptaible forks that currently exist (and there are a few)
 are lacking in some way. This can be anything from the fact that they don't
 release to PyPi, have no ongoing testing, didn't apply many important bugfixes
@@ -51,6 +51,12 @@ Documentation
 The original documentation for django-storages is located at http://django-storages.readthedocs.org/.
 Stay tuned for forthcoming documentation updates.
 
+API Changes
+===========
+Any signifigant API changes added during this fork are noted below while new documentation is assembled:
+
+- `Added S3BotoStorage bucket_alias kawrg & AWS_STORAGE_BUCKET_ALIASES setting
+  <https://github.com/jschneier/django-storages/issues/22>`_
 
 Contributing
 ============
@@ -64,4 +70,3 @@ Contributing
    correctly.
 #. Bug me until I can merge your pull request. Also, don't forget to add
    yourself to ``AUTHORS``.
-

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -245,7 +245,7 @@ class S3BotoStorage(Storage):
     # rolled over into a temporary file on disk. Default is 0: Do not roll over.
     max_memory_size = setting('AWS_S3_MAX_MEMORY_SIZE', 0)
 
-    def __init__(self, acl=None, bucket=None, **settings):
+    def __init__(self, acl=None, bucket=None, bucket_alias=None, **settings):
         # check if some of the settings we've provided as class attributes
         # need to be overwritten with values passed in here
         for name, value in settings.items():
@@ -257,6 +257,8 @@ class S3BotoStorage(Storage):
             self.default_acl = acl
         if bucket is not None:
             self.bucket_name = bucket
+        if bucket_alias is not None:
+            self.bucket_name = setting('AWS_STORAGE_BUCKET_ALIASES', {})[bucket_alias]
 
         self.location = (self.location or '').lstrip('/')
         # Backward-compatibility: given the anteriority of the SECURE_URL setting


### PR DESCRIPTION
Adding bucket_alias kwarg to workaround inflexibility of explicit kwargs serialization in Django 1.7. Work towards resolving #22
