### PR TITLE
Fix exists and add modified_time in FTP storage

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -185,7 +185,7 @@ class FTPStorage(Storage):
     def exists(self, name):
         self._start_connection()
         try:
-            if os.path.basename(name) in self._connection.nlst(
+            if name in self._connection.nlst(
                 os.path.dirname(name) + '/'
             ):
                 return True

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -185,9 +185,10 @@ class FTPStorage(Storage):
     def exists(self, name):
         self._start_connection()
         try:
-            if name in self._connection.nlst(
+            nlst = self._connection.nlst(
                 os.path.dirname(name) + '/'
-            ):
+            )
+            if name in nlst or os.path.basename(name) in nlst:
                 return True
             else:
                 return False

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -174,7 +174,7 @@ class FTPStorage(Storage):
             # workaround for broken FTP servers returning responses
             # starting with e.g. 1904... instead of 2004...
             if len(s) == 15 and s[:2] == '19':
-                s = repr(1900 + int(s[2:5])) + s[5:]
+                s = str(1900 + int(s[2:5])) + s[5:]
             return datetime.strptime(s, '%Y%m%d%H%M%S')
         raise FTPStorageException(
                 'Error getting modification time of file %s' % name

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -252,7 +252,6 @@ class FTPStorageFile(File):
         if not self._is_read:
             self._storage._start_connection()
             self.file = self._storage._read(self._name)
-            self._storage._end_connection()
             self._is_read = True
 
         return self.file.read(num_bytes)


### PR DESCRIPTION
Apparently various FTP servers are inconsistent in NLST command output. Some output only filenames, others output paths. This fix supports both.