### PR TITLE
fix FTP LIST command output handling and add FTPStorageFile.name

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -15,6 +15,7 @@
 #     file = models.FileField(upload_to='a/b/c/', storage=fs)
 
 import os
+import re
 from datetime import datetime
 import ftplib
 
@@ -162,11 +163,14 @@ class FTPStorage(Storage):
                 if self.list_size_col_no is None:
                     # need to determine which column specifies file size
                     # due to very non-standard nature of LIST command
-                    # the only good way to do this is to find a column with
-                    # file date's month part (3 symbol shortened name of a month)
-                    # which always goes after size column
-                    for i in range(1, len(words)):
-                        if len(words[i]) == 3 and words[i].isalpha():
+                    # the only good way to do this is to find columns with
+                    # file's date (3 symbol shortened name of a month, 
+                    # day of month and time or year) which always go after 
+                    # size column
+                    for i in range(2, len(words)-3):
+                        if (len(words[i]) == 3 and words[i].isalpha() and
+                                words[i+1].isdigit() and 
+                                re.match(r'^\d\d:?\d\d', words[i+2])):
                             self.list_size_col_no = i - 1
                             # filenames might contain spaces so maxsplit has 
                             # to be adjusted to i + 3

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -174,7 +174,7 @@ class FTPStorage(Storage):
                             self.list_maxsplit = i + 3
                             break
                     # resplit line if maxsplit doesn't match len(words)
-                    if len(words) != self.list_maxsplit:
+                    if len(words) > self.list_maxsplit + 1:
                         words = line.split(None, self.list_maxsplit)
                 if words[0][0] == 'd':
                     dirs[words[-1]] = 0

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -63,7 +63,7 @@ from storages.compat import urlparse, BytesIO
 
 class SFTPStorage(Storage):
 
-    def __init__(self):
+    def __init__(self, location=settings.SFTP_STORAGE_ROOT):
         self._host = settings.SFTP_STORAGE_HOST
 
         # if present, settings.SFTP_STORAGE_PARAMS should be a dict with params
@@ -80,7 +80,7 @@ class SFTPStorage(Storage):
         self._gid = getattr(settings, 'SFTP_STORAGE_GID', None)
         self._known_host_file = getattr(settings, 'SFTP_KNOWN_HOST_FILE', None)
 
-        self._root_path = settings.SFTP_STORAGE_ROOT
+        self._root_path = location
         self._base_url = settings.MEDIA_URL
 
         # for now it's all posix paths.  Maybe someday we'll support figuring
@@ -240,6 +240,10 @@ class SFTPStorageFile(File):
         self._is_dirty = False
         self.file = BytesIO()
         self._is_read = False
+
+    @property
+    def name(self):
+        return self._name
 
     @property
     def size(self):


### PR DESCRIPTION
Apparently current ftp backend implementation doesn't handle filenames with whitespace :D 
