### PR TITLE
Fix libcloud provider type for GCS in Docs

### DIFF
--- a/docs/backends/apache_libcloud.rst
+++ b/docs/backends/apache_libcloud.rst
@@ -51,7 +51,7 @@ Amazon S3 store, and a third bucket (``bucket-3``) on Google::
             'bucket': 'bucket-2',
         },
         'google': {
-            'type': 'libcloud.storage.types.GOOGLE_STORAGE',
+            'type': 'libcloud.storage.types.Provider.GOOGLE_STORAGE',
             'user': '<Your Google APIv1 username>',
             'key': '<Your Google APIv1 Key>',
             'bucket': 'bucket-3',


### PR DESCRIPTION
Otherwise we'll get `Unable to create libcloud driver type libcloud.storage.types.GOOGLE_STORAGE: Invalid module path` ...