### PR TITLE
rackspace cloud files updates for libcloud

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,14 @@
-=====================
+===============
 django-storages
-=====================
+===============
 
 .. image:: https://travis-ci.org/jschneier/django-storages.png?branch=master
-        :target: https://travis-ci.org/jschneier/django-storages
+    :target: https://travis-ci.org/jschneier/django-storages
+    :alt: Build Status
+
+.. image:: https://pypip.in/v/django-storages-redux/badge.png
+    :target: https://pypi.python.org/pypi/django-storages-redux
+    :alt: PyPI Version
 
 
 About
@@ -12,7 +17,7 @@ django-storages was (is) a project to provide a variety of storage backends in
 a single library. This is its maintained, Python 3 compatible fork. The reasons
 for the fork are given in the next section.
 
-At the moment the only tested Python 3 comptaible backend is the S3 Boto one
+At the moment the only tested Python 3 compatible backend is the S3 Boto one
 but some of them should work without issue (hashpath, symlink, overwrite).
 
 This library maintains compatibility for all currently supported versions of
@@ -30,15 +35,15 @@ compatible version.
 All of the Python3 compatible forks that currently exist (and there are a few)
 are lacking in some way. This can be anything from the fact that they don't
 release to PyPi, have no ongoing testing, didn't apply many important bugfixes
-that have occurred on the bitbucket repo since forking or don't support older
+that have occurred on the Bitbucket repo since forking or don't support older
 versions of Python and Django (vital to finding bugs and keeping a large
 community). For this fork I've done the small bit of work necessary to get a
 tox + travis ci matrix going for all of the supported Python + Django versions.
 In many cases the various forks are lacking in a few of the above ways.
 
-Found a Bug? Something Unspported?
-==================================
-I suspect that a few of the storage engines in backends/ have been unspported
+Found a Bug? Something Unsupported?
+===================================
+I suspect that a few of the storage engines in backends/ have been unsupported
 for quite a long time. I personally only really need the S3Storage backend but
 welcome bug reports (and especially) patches and tests for some of the other
 backends.

--- a/docs/backends/apache_libcloud.rst
+++ b/docs/backends/apache_libcloud.rst
@@ -51,7 +51,7 @@ Amazon S3 store, and a third bucket (``bucket-3``) on Google::
             'bucket': 'bucket-2',
         },
         'google': {
-            'type': 'libcloud.storage.types.GOOGLE_STORAGE',
+            'type': 'libcloud.storage.types.Provider.GOOGLE_STORAGE',
             'user': '<Your Google APIv1 username>',
             'key': '<Your Google APIv1 Key>',
             'bucket': 'bucket-3',

--- a/docs/backends/apache_libcloud.rst
+++ b/docs/backends/apache_libcloud.rst
@@ -100,11 +100,13 @@ your storage provider:
 
     **Rackspace Cloudfiles**:
 
-        **type**: ``libcloud.storage.types.Provider.CLOUDFIULES_US`` or ``libcloud.storage.types.Provider.CLOUDFIULES_UK``,
+        **type**: ``libcloud.storage.types.Provider.CLOUDFILES``
 
         **user**: Your Rackspace user ID
 
         **key**: Your Rackspace access key
+
+	**region**: The region where your Rackspace container lives (*defaults to ORD*).	
 
 You can specify any bucket name you want; however, the bucket must exist before you
 can start using it. If you need to create the bucket, you can use the storage API.

--- a/docs/backends/apache_libcloud.rst
+++ b/docs/backends/apache_libcloud.rst
@@ -106,7 +106,13 @@ your storage provider:
 
         **key**: Your Rackspace access key
 
-	**region**: The region where your Rackspace container lives (*defaults to ORD*).	
+        **bucket**: The parent container for this provider
+
+        **region**: The region where your container lives (*defaults to ORD*)
+
+        **is_private_bucket**: Boolean indicating if the parent container is private
+
+        **temporary_url_timeout**: Length, in seconds, temporary CDN url's should persist for
 
 You can specify any bucket name you want; however, the bucket must exist before you
 can start using it. If you need to create the bucket, you can use the storage API.

--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -126,12 +126,12 @@ class LibCloudStorage(Storage):
         obj = self._get_object(name)
         timeout = temporary_url_timeout if temporary_url_timeout else self.temporary_url_timeout
         if self.is_private_bucket or temporary_url:
-            return self.driver.ex_get_object_temp_url(obj, timeout)
+            return self.driver.ex_get_object_temp_url(obj, timeout=timeout)
         else:
             try:
                 return self.driver.get_object_cdn_url(obj)
             except ContainerDoesNotExistError:
-                return self.driver.ex_get_object_temp_url(obj, timeout)
+                return self.driver.ex_get_object_temp_url(obj, timeout=timeout)
 
     def _open(self, name, mode='rb'):
         remote_file = LibCloudFile(name, self, mode=mode)


### PR DESCRIPTION
this pull request updates the libcloud interface.  

the specific updates are:

1. update liblcoud docs to specify correct rackspace driver `libcloud.storage.types.Provider.CLOUDFILES`
2. modify the url method to generate a temporary URL if container is private (as well as some new config options to support this)

hope this helps! 