### PR TITLE
Removed mention of compatibility with Django 1.4 which still receives extended support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,7 @@ for the fork are given in the next section.
 At the moment the only tested Python 3 compatible backend is the S3 Boto one
 but some of them should work without issue (hashpath, symlink, overwrite).
 
-This library maintains compatibility for all currently supported versions of
-Django.
+This library is compatible with Django >= 1.5.
 
 Why Fork?
 =========


### PR DESCRIPTION
Specifically, `force_bytes` is not available in `Django` 1.4.

https://github.com/jschneier/django-storages/blob/1.2.1/storages/backends/s3boto.py#L12