### PR TITLE
Initialize apache-libcloud driver with user_id and key as kwargs

### DIFF
--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -40,8 +40,8 @@ class LibCloudStorage(Storage):
 
             Driver = get_driver(provider_type)
             self.driver = Driver(
-                self.provider['user'],
-                self.provider['key'],
+                user_id=self.provider['user'],
+                key=self.provider['key'],
                 **extra_kwargs
             )
         except Exception as e:


### PR DESCRIPTION
Currently the apache-libcloud backend initializes the LibcloudDriver with user_id and key as positional arguments, which limits them to a small subset of drivers (those with libcloud's ConnectionUserAndKey as a base class). 

This update switches user_id and key to kwargs, so it should add support for several other drivers such as libcloud.storages.types.Provider.LOCAL.

I've only checked if this works with rackspace cloudfiles and local. Having support for libcloud.storages local is useful for my development/testing environments.