### PR TITLE
Bugfix gs connection

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -278,14 +278,8 @@ class S3BotoStorage(Storage):
     def connection(self):
         if self._connection is None:
             self._connection = self.connection_class(
-                self.access_key,
-                self.secret_key,
-                is_secure=self.use_ssl,
+                self.access_key, self.secret_key,
                 calling_format=self.calling_format,
-                host=self.host,
-                port=self.port,
-                proxy=self.proxy,
-                proxy_port=self.proxy_port
             )
         return self._connection
 
@@ -499,4 +493,4 @@ class S3BotoStorage(Storage):
         if self.file_overwrite:
             name = self._clean_name(name)
             return name
-        return super(S3BotoStorage, self).get_available_name(name, max_length)
+        return super(S3BotoStorage, self).get_available_name(name, max_length=max_length)

--- a/storages/compat.py
+++ b/storages/compat.py
@@ -21,7 +21,7 @@ else:
         def get_available_name(self, name, max_length=None):
             return super(StorageMixin, self).get_available_name(name)
 
-    class Storage(DjangoStorage, StorageMixin):
+    class Storage(StorageMixin, DjangoStorage):
         pass
 
     class FileSystemStorage(DjangoFileSystemStorage, StorageMixin):


### PR DESCRIPTION
The `S3BotoStorage` class is overriding connection variables, this causes subclasses to use  `s3.amazonaws.com` as the host connection and fail authentication. 

Also reordered `Storage` class so it finds the overridden `get_available_name` instead of the one for super class.