### PR TITLE
Libcloud fixes

### DIFF
--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -145,7 +145,6 @@ class LibCloudFile(File):
         self._mode = mode
         self._is_dirty = False
         self.file = BytesIO()
-        self.start_range = 0
 
     @property
     def size(self):
@@ -156,9 +155,8 @@ class LibCloudFile(File):
     def read(self, num_bytes=None):
         if num_bytes is None:
             args = []
-            self.start_range = 0
         else:
-            args = [self.start_range, self.start_range + num_bytes - 1]
+            args = [0, num_bytes - 1]
         data = self._storage._read(self._name, *args)
         self.file = BytesIO(data)
         return self.file.getvalue()

--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -127,7 +127,7 @@ class LibCloudStorage(Storage):
         remote_file = LibCloudFile(name, self, mode=mode)
         return remote_file
 
-    def _read(self, name, start_range=None, end_range=None):
+    def _read(self, name):
         obj = self._get_object(name)
         # TOFIX : we should be able to read chunk by chunk
         return next(self.driver.download_object_as_stream(obj, obj.size))
@@ -153,13 +153,9 @@ class LibCloudFile(File):
         return self._size
 
     def read(self, num_bytes=None):
-        if num_bytes is None:
-            args = []
-        else:
-            args = [0, num_bytes - 1]
-        data = self._storage._read(self._name, *args)
+        data = self._storage._read(self._name)
         self.file = BytesIO(data)
-        return self.file.getvalue()
+        return self.file.read(num_bytes)
 
     def write(self, content):
         if 'w' not in self._mode:


### PR DESCRIPTION
This fixes a few issues I've encountered with the ``apache_libcloud`` backend (using Rackspace Cloud Files). These fixes follow the implemlementation of the S3 backend.

 - ``file.read(n)`` was returning the whole file regardless of the num_bytes parameter
 - Accessing ``file.name`` no longer gives an ``AttributeError``
 - Initialising the ``.file`` attribute to an empty ``BytesIO`` object caused errors when trying to load the file into ``Pillow``