### PR TITLE
change Google Storage setting to gzip from is_gzipped

### DIFF
--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -55,7 +55,7 @@ class GSBotoStorage(S3BotoStorage):
     calling_format = setting('GS_CALLING_FORMAT', SubdomainCallingFormat())
     secure_urls = setting('GS_SECURE_URLS', True)
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
-    is_gzipped = setting('GS_IS_GZIPPED', False)
+    gzip = setting('GS_IS_GZIPPED', False)
     preload_metadata = setting('GS_PRELOAD_METADATA', False)
     gzip_content_types = setting('GS_GZIP_CONTENT_TYPES', (
         'text/css',

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -26,5 +26,5 @@ MIDDLEWARE_CLASSES = (
 
 DEFAULT_FILE_STORAGE = 'backends.s3boto.S3BotoStorage'
 AWS_IS_GZIPPED = True
+GS_IS_GZIPPED = True
 SECRET_KEY = 'hailthesunshine'
-

--- a/tests/test_gs.py
+++ b/tests/test_gs.py
@@ -1,0 +1,32 @@
+from django.test import TestCase
+from django.core.files.base import ContentFile
+
+from storages.backends import gs, s3boto
+
+try:
+    from unittest import mock
+except ImportError:  # Python 3.2 and below
+    import mock
+
+
+class GSBotoTestCase(TestCase):
+    @mock.patch('storages.backends.gs.GSConnection')
+    def setUp(self, GSConnection):
+        self.storage = gs.GSBotoStorage()
+        self.storage._connection = mock.MagicMock()
+
+
+class GSStorageTestCase(GSBotoTestCase):
+    def test_gs_gzip(self):
+        s3boto.S3BotoStorage.gzip = False
+        name = 'test_storage_save.css'
+        content = ContentFile("I should be gzip'd")
+        self.storage.save(name, content)
+        key = self.storage.bucket.get_key.return_value
+        key.set_metadata.assert_called_with('Content-Type', 'text/css')
+        key.set_contents_from_file.assert_called_with(
+            content,
+            headers={'Content-Type': 'text/css', 'Content-Encoding': 'gzip'},
+            policy=self.storage.default_acl,
+            rewind=True,
+        )


### PR DESCRIPTION
The property name for GSBotoStorage must be the same as S3BotoStorage.