### PR TITLE
Reverse mixin order, otherwise StorageMixin is ineffective.

### DIFF
--- a/storages/compat.py
+++ b/storages/compat.py
@@ -21,8 +21,8 @@ else:
         def get_available_name(self, name, max_length=None):
             return super(StorageMixin, self).get_available_name(name)
 
-    class Storage(DjangoStorage, StorageMixin):
+    class Storage(StorageMixin, DjangoStorage):
         pass
 
-    class FileSystemStorage(DjangoFileSystemStorage, StorageMixin):
+    class FileSystemStorage(StorageMixin, DjangoFileSystemStorage):
         pass


### PR DESCRIPTION
StorageMixin is supposed to isolate the new `max_length` feature to
Django-1.8 and later, but it wasn't actually doing anything because the MRO
is backwards.