### PR TITLE
[documentation][S3] adding AWS_AUTO_CREATE_BUCKET

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -25,6 +25,11 @@ Your Amazon Web Services secret access key, as a string.
 
 Your Amazon Web Services storage bucket name, as a string.
 
+``AWS_AUTO_CREATE_BUCKET`` (optional)
+
+If set to ``True`` the bucket specified in ``AWS_STORAGE_BUCKET_NAME`` is automatically created.
+
+
 ``AWS_HEADERS`` (optional)
 
 If you'd like to set headers sent with each file of the storage::


### PR DESCRIPTION
I think adding AWS_AUTO_CREATE_BUCKET setting in S3's documentation could save some time for people using this package.