### PR TITLE
copy content size on to BytesIO when gzip'ing with S3

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -372,6 +372,7 @@ class S3BotoStorage(Storage):
         finally:
             zfile.close()
         zbuf.seek(0)
+        zbuf.size = zfile.size # django expects this to be more file-like
         content.file = zbuf
         content.seek(0)
         return content


### PR DESCRIPTION
Django expects the underlying file-like object to have a `.size` attribute in some circumstances, specifically:  https://github.com/django/django/blob/1.8.1/django/db/models/fields/files.py#L107 - this will be used to look up size instead of the asking the storage instance when the corresponding model instance hasn't been saved or committed yet. Or something. I could provide you with a giant stacktrace to illustrate the problem, but this has probably been broken for a long, long time so I'm just gonna fix it. :-)

Revived my long-dead puppy on Python 2.7 at least.
