### PR TITLE
S3/Cloudfront Storage

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -44,6 +44,21 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
 
     STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
+
+CloudFront
+~~~~~~~~~~
+
+If you're using S3 as a CDN (via CloudFront), you'll probably want this storage
+to serve those files using that::
+
+    AWS_S3_CUSTOM_DOMAIN = 'cdn.mydomain.com'
+
+Keep in mind you'll have to configure CloudFront to use the proper bucket as an
+origin manually for this to work.
+
+If you need to use multiple storages that are served via CloudFront, pass the
+`custom_domain` parameter to their constructors.
+
 Fields
 ------
 


### PR DESCRIPTION
These changesets add a new class: S3CloudFrontStorage.

It's designed for uploading static files into S3, and have them served via CloudFront (which will need to be configured via the AWS control panel first).

This is ideal for both static files, and media files that will be served to many clients, as an alternative, eg: nginx.

---

Please let me know if there's something out of order with coding-style, or documentation. I've been using this quite a bit on a client project recently, and decided to strip it out, and submit it upstream (eg: here).