### PR TITLE
use encryption setting for S3BotoStorageFile multipart uploads

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -146,7 +146,8 @@ class S3BotoStorageFile(File):
             self._multipart = self._storage.bucket.initiate_multipart_upload(
                 self.key.name,
                 headers=upload_headers,
-                reduced_redundancy=self._storage.reduced_redundancy
+                reduced_redundancy=self._storage.reduced_redundancy,
+                encrypt_key=self._storage.encryption,
             )
         if self.buffer_size <= self._buffer_file_size:
             self._flush_write_buffer()

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -165,6 +165,8 @@ class S3BotoStorageTests(S3BotoTestCase):
         name = 'test_open_for_writing.txt'
         content = 'new content'
 
+        # Set the encryption flag used for multipart uploads
+        self.storage.encryption = True
         # Set the ACL header used when creating/writing data.
         self.storage.bucket.connection.provider.acl_header = 'x-amz-acl'
         # Set the mocked key's bucket
@@ -183,6 +185,7 @@ class S3BotoStorageTests(S3BotoTestCase):
                 'x-amz-acl': 'public-read',
             },
             reduced_redundancy=self.storage.reduced_redundancy,
+            encrypt_key=True,
         )
 
         # Save the internal file before closing


### PR DESCRIPTION
S3BotoStorageFile's write method was not initiating the multipart upload with encryption on, even when ```AWS_S3_ENCRYPTION``` was True in the settings