### PR TITLE
Optionally override querystring_expire in S3BotoStorage.url

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -473,17 +473,26 @@ class S3BotoStorage(Storage):
         # Parse the last_modified string to a local datetime object.
         return parse_ts(entry.last_modified)
 
-    def url(self, name, headers=None, response_headers=None):
+    def url(self, name, headers=None, response_headers=None, expire=None):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(self._clean_name(name))
         if self.custom_domain:
             return "%s//%s/%s" % (self.url_protocol,
                                   self.custom_domain, filepath_to_uri(name))
-        return self.connection.generate_url(self.querystring_expire,
-                                            method='GET', bucket=self.bucket.name, key=self._encode_name(name),
-                                            headers=headers,
-                                            query_auth=self.querystring_auth, force_http=not self.secure_urls,
-                                            response_headers=response_headers)
+
+        if expire is None:
+            expire = self.querystring_expire
+
+        return self.connection.generate_url(
+            expire,
+            method='GET',
+            bucket=self.bucket.name,
+            key=self._encode_name(name),
+            headers=headers,
+            query_auth=self.querystring_auth,
+            force_http=not self.secure_urls,
+            response_headers=response_headers,
+        )
 
     def get_available_name(self, name, max_length=None):
         """ Overwrite existing file with the same name. """

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -263,9 +263,7 @@ class S3BotoStorageTests(S3BotoTestCase):
         url = 'http://aws.amazon.com/%s' % name
         self.storage.connection.generate_url.return_value = url
 
-        self.assertEquals(self.storage.url(name), url)
-        self.storage.connection.generate_url.assert_called_with(
-            self.storage.querystring_expire,
+        kwargs = dict(
             method='GET',
             bucket=self.storage.bucket.name,
             key=name,
@@ -273,6 +271,20 @@ class S3BotoStorageTests(S3BotoTestCase):
             force_http=not self.storage.secure_urls,
             headers=None,
             response_headers=None,
+        )
+
+        self.assertEquals(self.storage.url(name), url)
+        self.storage.connection.generate_url.assert_called_with(
+            self.storage.querystring_expire,
+            **kwargs
+        )
+
+        custom_expire = 123
+
+        self.assertEquals(self.storage.url(name, expire=custom_expire), url)
+        self.storage.connection.generate_url.assert_called_with(
+            custom_expire,
+            **kwargs
         )
 
     def test_generated_url_is_encoded(self):


### PR DESCRIPTION
It's often inconvenient to instantiate a new instance of `S3BotoStorage` just to change the expiration of URLs.  Instead I'd like to (optionally) pass the new expiration with each call to `S3BotoStorage.url`.

```python
pic = MyModel.objects.get(...).picture
pic.storage.url(pic.name)  # default expiration
pic.storage.url(pic.name, expire=600)  # custom expiration
```

Happy to make adjustments or take another approach. Thanks!