### PR TITLE
Enable GZipping of SVG files automatically in S3Boto Storage

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -226,6 +226,7 @@ class S3BotoStorage(Storage):
         'text/javascript',
         'application/javascript',
         'application/x-javascript',
+        'image/svg+xml',
     ))
     url_protocol = setting('AWS_S3_URL_PROTOCOL', 'http:')
     host = setting('AWS_S3_HOST', S3Connection.DefaultHost)


### PR DESCRIPTION
SVG images are mostly text and they compress really well, this should improve performance for SVG static files