### PR TITLE
Change doc project name to let build it on rtfd fixes #42

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,9 +71,9 @@ Issues are tracked via GitHub issues at the `project issue page
 
 Documentation
 =============
-The original documentation for django-storages is located at http://django-storages.readthedocs.org/.
-Stay tuned for forthcoming documentation updates.
-
+The documentation for this fork lives at
+http://django-storages-redux.readthedocs.org/, the `django-storages` being already
+taken by the original fork.
 
 Contributing
 ============
@@ -87,4 +87,3 @@ Contributing
    correctly.
 #. Bug me until I can merge your pull request. Also, don't forget to add
    yourself to ``AUTHORS``.
-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'django-storages'
+project = u'django-storages-redux'
 copyright = u'2011-2013, David Larlet, et. al.'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 Django>=1.6.2
 pytest==2.6.4
 boto>=2.32.0
-dropbox>=3.24,<4.0
+dropbox>=3.24
 mock

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 Django>=1.6.2
 pytest==2.6.4
 boto>=2.32.0
-dropbox>=3.24
+dropbox>=3.24,<4.0
 mock


### PR DESCRIPTION
I think by updating the project name in the config, that should let you build it on readthedocs without conflicting with the original fork. That is what was done from [the other well known project](https://github.com/macropin/django-registration/blob/master/docs/conf.py#L40) you mentioned.