### PR TITLE
New S3 Boto3 backend (closes #57)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ By order of apparition, thanks:
     * Josh Schneier (Fork maintainer, Bugfixes, Py3K)
     * Anthony Monthe (Dropbox)
     * EunPyo (Andrew) Hong (Azure)
+    * Michael Barrientos (S3 with Boto3)
 
 Extra thanks to Marty for adding this in Django,
 you can buy his very interesting book (Pro Django).

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,6 @@
 Django>=1.7
 pytest==2.6.4
 boto>=2.32.0
+boto3>=1.2.3
 dropbox>=3.24
 mock

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -1,0 +1,560 @@
+import os
+import posixpath
+import mimetypes
+from gzip import GzipFile
+from tempfile import SpooledTemporaryFile
+
+from django.core.files.base import File
+from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
+from django.utils.encoding import force_text, smart_str, filepath_to_uri, force_bytes
+
+try:
+    from boto3 import resource
+    from boto3 import __version__ as boto3_version
+    from botocore.client import Config
+    from botocore.exceptions import ClientError
+except ImportError:
+    raise ImproperlyConfigured("Could not load Boto3's S3 bindings.\n"
+                               "See https://github.com/boto/boto3")
+
+from storages.utils import setting
+from storages.compat import urlparse, BytesIO, deconstructible, Storage
+
+boto3_version_info = tuple([int(i) for i in boto3_version.split('-')[0].split('.')])
+
+if boto3_version_info[:2] < (1, 2):
+    raise ImproperlyConfigured("The installed Boto3 library must be 1.2.0 or "
+                               "higher.\nSee https://github.com/boto/boto3")
+
+
+def safe_join(base, *paths):
+    """
+    A version of django.utils._os.safe_join for S3 paths.
+
+    Joins one or more path components to the base path component
+    intelligently. Returns a normalized version of the final path.
+
+    The final path must be located inside of the base path component
+    (otherwise a ValueError is raised).
+
+    Paths outside the base path indicate a possible security
+    sensitive operation.
+    """
+    base_path = force_text(base)
+    base_path = base_path.rstrip('/')
+    paths = [force_text(p) for p in paths]
+
+    final_path = base_path
+    for path in paths:
+        final_path = urlparse.urljoin(final_path.rstrip('/') + "/", path)
+
+    # Ensure final_path starts with base_path and that the next character after
+    # the final path is '/' (or nothing, in which case final_path must be
+    # equal to base_path).
+    base_path_len = len(base_path)
+    if (not final_path.startswith(base_path) or
+            final_path[base_path_len:base_path_len + 1] not in ('', '/')):
+        raise ValueError('the joined path is located outside of the base path'
+                         ' component')
+
+    return final_path.lstrip('/')
+
+
+@deconstructible
+class S3Boto3StorageFile(File):
+
+    """
+    The default file object used by the S3Boto3Storage backend.
+
+    This file implements file streaming using boto's multipart
+    uploading functionality. The file can be opened in read or
+    write mode.
+
+    This class extends Django's File class. However, the contained
+    data is only the data contained in the current buffer. So you
+    should not access the contained file object directly. You should
+    access the data via this class.
+
+    Warning: This file *must* be closed using the close() method in
+    order to properly write the file to S3. Be sure to close the file
+    in your application.
+    """
+    # TODO: Read/Write (rw) mode may be a bit undefined at the moment. Needs testing.
+    # TODO: When Django drops support for Python 2.5, rewrite to use the
+    #       BufferedIO streams in the Python 2.6 io module.
+    buffer_size = setting('AWS_S3_FILE_BUFFER_SIZE', 5242880)
+
+    def __init__(self, name, mode, storage, buffer_size=None):
+        self._storage = storage
+        self.name = name[len(self._storage.location):].lstrip('/')
+        self._mode = mode
+        self.obj = storage.bucket.Object(storage._encode_name(name))
+        # TODO: Is this explicitly necessary? Done to emulate old
+        # behavior, but the code would misbehave already if self.obj is None.
+        if 'w' not in mode:
+            try:
+                self.obj.load()
+            except storage.connection_response_error:
+                self.obj = None
+        self._is_dirty = False
+        self._file = None
+        self._multipart = None
+        # 5 MB is the minimum part size (if there is more than one part).
+        # Amazon allows up to 10,000 parts.  The default supports uploads
+        # up to roughly 50 GB.  Increase the part size to accommodate
+        # for files larger than this.
+        if buffer_size is not None:
+            self.buffer_size = buffer_size
+        self._write_counter = 0
+
+    @property
+    def size(self):
+        return self.obj.content_length
+
+    def _get_file(self):
+        if self._file is None:
+            self._file = SpooledTemporaryFile(
+                max_size=self._storage.max_memory_size,
+                suffix=".S3Boto3StorageFile",
+                dir=setting("FILE_UPLOAD_TEMP_DIR", None)
+            )
+            if 'r' in self._mode:
+                self._is_dirty = False
+                self._file.write(self.obj.get()['Body'].read())
+                self._file.seek(0)
+            if self._storage.gzip and self.obj.content_encoding == 'gzip':
+                self._file = GzipFile(mode=self._mode, fileobj=self._file)
+        return self._file
+
+    def _set_file(self, value):
+        self._file = value
+
+    file = property(_get_file, _set_file)
+
+    def read(self, *args, **kwargs):
+        if 'r' not in self._mode:
+            raise AttributeError("File was not opened in read mode.")
+        return super(S3Boto3StorageFile, self).read(*args, **kwargs)
+
+    def write(self, content, *args, **kwargs):
+        if 'w' not in self._mode:
+            raise AttributeError("File was not opened in write mode.")
+        self._is_dirty = True
+        if self._multipart is None:
+            parameters = self._storage.object_parameters.copy()
+            parameters['ACL'] = self._storage.default_acl
+            parameters['ContentType'] = (mimetypes.guess_type(self.obj.key)[0] or
+                                         self._storage.default_content_type)
+            if self._storage.reduced_redundancy:
+                parameters['StorageClass'] = 'REDUCED_REDUNDANCY'
+            if self._storage.encryption:
+                parameters['ServerSideEncryption'] = 'AES256'
+            self._multipart = self.obj.initiate_multipart_upload(**parameters)
+        if self.buffer_size <= self._buffer_file_size:
+            self._flush_write_buffer()
+        return super(S3Boto3StorageFile, self).write(force_bytes(content), *args, **kwargs)
+
+    @property
+    def _buffer_file_size(self):
+        pos = self.file.tell()
+        self.file.seek(0, os.SEEK_END)
+        length = self.file.tell()
+        self.file.seek(pos)
+        return length
+
+    def _flush_write_buffer(self):
+        """
+        Flushes the write buffer.
+        """
+        if self._buffer_file_size:
+            self._write_counter += 1
+            self.file.seek(0)
+            part = self._multipart.Part(self._write_counter)
+            part.upload(Body=self.file.read())
+            self.file.close()
+            self._file = None
+
+    def close(self):
+        if self._is_dirty:
+            self._flush_write_buffer()
+            # TODO: Possibly cache the part ids as they're being uploaded
+            # instead of requesting parts from server. For now, emulating
+            # s3boto's behavior.
+            parts = [{'ETag': part.e_tag, 'PartNumber': part.part_number}
+                     for part in self._multipart.parts.all()]
+            self._multipart.complete(
+                MultipartUpload={'Parts': parts})
+        else:
+            if self._multipart is not None:
+                self._multipart.abort()
+
+
+@deconstructible
+class S3Boto3Storage(Storage):
+    """
+    Amazon Simple Storage Service using Boto3
+
+    This storage backend supports opening files in read or write
+    mode and supports streaming(buffering) data in chunks to S3
+    when writing.
+    """
+    connection_class = staticmethod(resource)
+    connection_service_name = 's3'
+    default_content_type = 'application/octet-stream'
+    connection_response_error = ClientError
+    file_class = S3Boto3StorageFile
+    # If config provided in init, signature_version and addressing_style settings/args are ignored.
+    config = None
+
+    # used for looking up the access and secret key from env vars
+    access_key_names = ['AWS_S3_ACCESS_KEY_ID', 'AWS_ACCESS_KEY_ID']
+    secret_key_names = ['AWS_S3_SECRET_ACCESS_KEY', 'AWS_SECRET_ACCESS_KEY']
+
+    access_key = setting('AWS_S3_ACCESS_KEY_ID', setting('AWS_ACCESS_KEY_ID'))
+    secret_key = setting('AWS_S3_SECRET_ACCESS_KEY', setting('AWS_SECRET_ACCESS_KEY'))
+    file_overwrite = setting('AWS_S3_FILE_OVERWRITE', True)
+    object_parameters = setting('AWS_S3_OBJECT_PARAMETERS', {})
+    bucket_name = setting('AWS_STORAGE_BUCKET_NAME')
+    auto_create_bucket = setting('AWS_AUTO_CREATE_BUCKET', False)
+    default_acl = setting('AWS_DEFAULT_ACL', 'public-read')
+    bucket_acl = setting('AWS_BUCKET_ACL', default_acl)
+    querystring_auth = setting('AWS_QUERYSTRING_AUTH', True)
+    querystring_expire = setting('AWS_QUERYSTRING_EXPIRE', 3600)
+    signature_version = setting('AWS_S3_SIGNATURE_VERSION')
+    reduced_redundancy = setting('AWS_REDUCED_REDUNDANCY', False)
+    location = setting('AWS_LOCATION', '')
+    encryption = setting('AWS_S3_ENCRYPTION', False)
+    custom_domain = setting('AWS_S3_CUSTOM_DOMAIN')
+    addressing_style = setting('AWS_S3_ADDRESSING_STYLE')
+    secure_urls = setting('AWS_S3_SECURE_URLS', True)
+    file_name_charset = setting('AWS_S3_FILE_NAME_CHARSET', 'utf-8')
+    gzip = setting('AWS_IS_GZIPPED', False)
+    preload_metadata = setting('AWS_PRELOAD_METADATA', False)
+    gzip_content_types = setting('GZIP_CONTENT_TYPES', (
+        'text/css',
+        'text/javascript',
+        'application/javascript',
+        'application/x-javascript',
+        'image/svg+xml',
+    ))
+    url_protocol = setting('AWS_S3_URL_PROTOCOL', 'http:')
+    endpoint_url = setting('AWS_S3_ENDPOINT_URL', None)
+    region_name = setting('AWS_S3_REGION_NAME', None)
+    use_ssl = setting('AWS_S3_USE_SSL', True)
+
+    # The max amount of memory a returned file can take up before being
+    # rolled over into a temporary file on disk. Default is 0: Do not roll over.
+    max_memory_size = setting('AWS_S3_MAX_MEMORY_SIZE', 0)
+
+    def __init__(self, acl=None, bucket=None, **settings):
+        # check if some of the settings we've provided as class attributes
+        # need to be overwritten with values passed in here
+        for name, value in settings.items():
+            if hasattr(self, name):
+                setattr(self, name, value)
+
+        # For backward-compatibility of old differing parameter names
+        if acl is not None:
+            self.default_acl = acl
+        if bucket is not None:
+            self.bucket_name = bucket
+
+        self.location = (self.location or '').lstrip('/')
+        # Backward-compatibility: given the anteriority of the SECURE_URL setting
+        # we fall back to https if specified in order to avoid the construction
+        # of unsecure urls.
+        if self.secure_urls:
+            self.url_protocol = 'https:'
+
+        self._entries = {}
+        self._bucket = None
+        self._connection = None
+
+        if not self.access_key and not self.secret_key:
+            self.access_key, self.secret_key = self._get_access_keys()
+
+        if not self.config:
+            self.config = Config(s3={'addressing_style': self.addressing_style},
+                                 signature_version=self.signature_version)
+
+    @property
+    def connection(self):
+        # TODO: Support host, port like in s3boto
+        # Note that proxies are handled by environment variables that the underlying
+        # urllib/requests libraries read. See https://github.com/boto/boto3/issues/338
+        # and http://docs.python-requests.org/en/latest/user/advanced/#proxies
+        if self._connection is None:
+            self._connection = self.connection_class(
+                self.connection_service_name,
+                aws_access_key_id=self.access_key,
+                aws_secret_access_key=self.secret_key,
+                region_name=self.region_name,
+                use_ssl=self.use_ssl,
+                endpoint_url=self.endpoint_url,
+                config=self.config
+            )
+        return self._connection
+
+    @property
+    def bucket(self):
+        """
+        Get the current bucket. If there is no current bucket object
+        create it.
+        """
+        if self._bucket is None:
+            self._bucket = self._get_or_create_bucket(self.bucket_name)
+        return self._bucket
+
+    @property
+    def entries(self):
+        """
+        Get the locally cached files for the bucket.
+        """
+        if self.preload_metadata and not self._entries:
+            self._entries = dict((self._decode_name(entry.key), entry)
+                                 for entry in self.bucket.objects.filter(prefix=self.location))
+        return self._entries
+
+    def _get_access_keys(self):
+        """
+        Gets the access keys to use when accessing S3. If none
+        are provided to the class in the constructor or in the
+        settings then get them from the environment variables.
+        """
+        def lookup_env(names):
+            for name in names:
+                value = os.environ.get(name)
+                if value:
+                    return value
+        access_key = self.access_key or lookup_env(self.access_key_names)
+        secret_key = self.secret_key or lookup_env(self.secret_key_names)
+        return access_key, secret_key
+
+    def _get_or_create_bucket(self, name):
+        """
+        Retrieves a bucket if it exists, otherwise creates it.
+        """
+        bucket = self.connection.Bucket(name)
+        if self.auto_create_bucket:
+            try:
+                # Directly call head_bucket instead of bucket.load() because head_bucket()
+                # fails on wrong region, while bucket.load() does not.
+                bucket.meta.client.head_bucket(Bucket=name)
+            except self.connection_response_error as err:
+                if err.response['ResponseMetadata']['HTTPStatusCode'] == 301:
+                    raise ImproperlyConfigured("Bucket %s exists, but in a different "
+                                               "region than we are connecting to. Set "
+                                               "the region to connect to by setting "
+                                               "AWS_S3_REGION_NAME to the correct region." % name)
+                    # Notes: When using the us-east-1 Standard endpoint, you can create
+                    # buckets in other regions. The same is not true when hitting region specific
+                    # endpoints. However, when you create the bucket not in the same region, the
+                    # connection will fail all future requests to the Bucket after the creation
+                    # (301 Moved Permanently).
+                    #
+                    # For simplicity, we enforce in S3Boto3Storage that any auto-created
+                    # bucket must match the region that the connection is for.
+                    #
+                    # Also note that Amazon specifically disallows "us-east-1" when passing bucket
+                    # region names; LocationConstraint *must* be blank to create in US Standard.
+                    bucket_params = {'ACL': self.bucket_acl}
+                    region_name = self.connection.meta.client.meta.region_name
+                    if region_name != 'us-east-1':
+                        bucket_params['CreateBucketConfiguration'] = {
+                            'LocationConstraint': region_name}
+                    bucket.create(ACL=self.bucket_acl)
+                else:
+                    raise ImproperlyConfigured("Bucket %s does not exist. Buckets "
+                                               "can be automatically created by "
+                                               "setting AWS_AUTO_CREATE_BUCKET to "
+                                               "``True``." % name)
+        return bucket
+
+    def _clean_name(self, name):
+        """
+        Cleans the name so that Windows style paths work
+        """
+        # Normalize Windows style paths
+        clean_name = posixpath.normpath(name).replace('\\', '/')
+
+        # os.path.normpath() can strip trailing slashes so we implement
+        # a workaround here.
+        if name.endswith('/') and not clean_name.endswith('/'):
+            # Add a trailing slash as it was stripped.
+            return clean_name + '/'
+        else:
+            return clean_name
+
+    def _normalize_name(self, name):
+        """
+        Normalizes the name so that paths like /path/to/ignored/../something.txt
+        work. We check to make sure that the path pointed to is not outside
+        the directory specified by the LOCATION setting.
+        """
+        try:
+            return safe_join(self.location, name)
+        except ValueError:
+            raise SuspiciousOperation("Attempted access to '%s' denied." %
+                                      name)
+
+    def _encode_name(self, name):
+        return smart_str(name, encoding=self.file_name_charset)
+
+    def _decode_name(self, name):
+        return force_text(name, encoding=self.file_name_charset)
+
+    def _compress_content(self, content):
+        """Gzip a given string content."""
+        zbuf = BytesIO()
+        zfile = GzipFile(mode='wb', compresslevel=6, fileobj=zbuf)
+        try:
+            zfile.write(force_bytes(content.read()))
+        finally:
+            zfile.close()
+        zbuf.seek(0)
+        # Boto 2 returned the InMemoryUploadedFile with the file pointer replaced,
+        # but Boto 3 seems to have issues with that. No need for fp.name in Boto3
+        # so just returning the BytesIO directly
+        return zbuf
+
+    def _open(self, name, mode='rb'):
+        name = self._normalize_name(self._clean_name(name))
+        f = self.file_class(name, mode, self)
+        if not f.obj:
+            raise IOError('File does not exist: %s' % name)
+        return f
+
+    def _save(self, name, content):
+        cleaned_name = self._clean_name(name)
+        name = self._normalize_name(cleaned_name)
+        parameters = self.object_parameters.copy()
+        content_type = getattr(content, 'content_type',
+                               mimetypes.guess_type(name)[0] or self.default_content_type)
+
+        # setting the content_type in the key object is not enough.
+        parameters.update({'ContentType': content_type})
+
+        if self.gzip and content_type in self.gzip_content_types:
+            content = self._compress_content(content)
+            parameters.update({'ContentEncoding': 'gzip'})
+
+        encoded_name = self._encode_name(name)
+        obj = self.bucket.Object(encoded_name)
+        if self.preload_metadata:
+            self._entries[encoded_name] = obj
+
+        self._save_content(obj, content, parameters=parameters)
+        # Note: In boto3, after a put, last_modified is automatically reloaded
+        # the next time it is accessed; no need to specifically reload it.
+        return cleaned_name
+
+    def _save_content(self, obj, content, parameters):
+        # only pass backwards incompatible arguments if they vary from the default
+        put_parameters = parameters.copy() if parameters else {}
+        if self.encryption:
+            put_parameters['ServerSideEncryption'] = 'AES256'
+        if self.reduced_redundancy:
+            put_parameters['StorageClass'] = 'REDUCED_REDUNDANCY'
+        if self.default_acl:
+            put_parameters['ACL'] = self.default_acl
+        content.seek(0, os.SEEK_SET)
+        obj.put(Body=content, **put_parameters)
+
+    def delete(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        self.bucket.Object(self._encode_name(name)).delete()
+
+    def exists(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        if self.entries:
+            return name in self.entries
+        obj = self.bucket.Object(self._encode_name(name))
+        try:
+            obj.load()
+            return True
+        except self.connection_response_error:
+            return False
+
+    def listdir(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        # for the bucket.objects.filter and logic below name needs to end in /
+        # But for the root path "" we leave it as an empty string
+        if name and not name.endswith('/'):
+            name += '/'
+
+        files = []
+        dirs = set()
+        base_parts = name.split("/")[:-1]
+        for item in self.bucket.objects.filter(Prefix=self._encode_name(name)):
+            parts = item.key.split("/")
+            parts = parts[len(base_parts):]
+            if len(parts) == 1:
+                # File
+                files.append(parts[0])
+            elif len(parts) > 1:
+                # Directory
+                dirs.add(parts[0])
+        return list(dirs), files
+
+    def size(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        if self.entries:
+            entry = self.entries.get(name)
+            if entry:
+                return entry.content_length
+            return 0
+        return self.bucket.Object(self._encode_name(name)).content_length
+
+    def modified_time(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        entry = self.entries.get(name)
+        # only call self.bucket.Object() if the key is not found
+        # in the preloaded metadata.
+        if entry is None:
+            entry = self.bucket.Object(self._encode_name(name))
+        return entry.last_modified
+
+    def _strip_signing_parameters(self, url):
+        # Boto3 does not currently support generating URLs that are unsigned. Instead we
+        # take the signed URLs and strip any querystring params related to signing and expiration.
+        # Note that this may end up with URLs that are still invalid, especially if params are
+        # passed in that only work with signed URLs, e.g. response header params.
+        # The code attempts to strip all query parameters that match names of known parameters
+        # from v2 and v4 signatures, regardless of the actual signature version used.
+        split_url = urlparse.urlsplit(url)
+        qs = urlparse.parse_qsl(split_url.query, keep_blank_values=True)
+        blacklist = set(['x-amz-algorithm', 'x-amz-credential', 'x-amz-date',
+                         'x-amz-expires', 'x-amz-signedheaders', 'x-amz-signature',
+                         'x-amz-security-token', 'awsaccesskeyid', 'expires', 'signature'])
+        filtered_qs = ((key, val) for key, val in qs if key.lower() not in blacklist)
+        # Note: Parameters that did not have a value in the original query string will have
+        # an '=' sign appended to it, e.g ?foo&bar becomes ?foo=&bar=
+        joined_qs = ('='.join(keyval) for keyval in filtered_qs)
+        split_url = split_url._replace(query="&".join(joined_qs))
+        return split_url.geturl()
+
+    def url(self, name, parameters=None, expire=None):
+        # Preserve the trailing slash after normalizing the path.
+        # TODO: Handle force_http=not self.secure_urls like in s3boto
+        name = self._normalize_name(self._clean_name(name))
+        if self.custom_domain:
+            return "%s//%s/%s" % (self.url_protocol,
+                                  self.custom_domain, filepath_to_uri(name))
+        if expire is None:
+            expire = self.querystring_expire
+
+        params = parameters.copy() if parameters else {}
+        params['Bucket'] = self.bucket.name
+        params['Key'] = self._encode_name(name)
+        url = self.bucket.meta.client.generate_presigned_url('get_object', Params=params,
+                                                             ExpiresIn=expire)
+        if self.querystring_auth:
+            return url
+        return self._strip_signing_parameters(url)
+
+    def get_available_name(self, name, max_length=None):
+        """Overwrite existing file with the same name."""
+        if self.file_overwrite:
+            name = self._clean_name(name)
+            return name
+        return super(S3Boto3Storage, self).get_available_name(name, max_length)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -188,6 +188,15 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         multipart.complete.assert_called_once_with(
             MultipartUpload={'Parts': [{'ETag': '123', 'PartNumber': 1}]})
 
+    # def test_storage_exists_bucket(self):
+    #     bucket = self.storage._connection.Bucket.return_value
+    #     bucket.meta.client.head_bucket.side_effect = ClientError(
+    #         {'Error': {'Code': 123, 'Message': 'Fake'}}, 'load')
+    #     self.assertFalse(self.storage.exists(''))
+    #
+    #     self.storage.bucket.meta.client.head_bucket.side_effect = None
+    #     self.assertTrue(self.storage.exists(''))
+
     def test_storage_exists(self):
         obj = self.storage.bucket.Object.return_value
         self.assertTrue(self.storage.exists("file.txt"))

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -1,0 +1,304 @@
+import gzip
+import unittest
+try:
+    from unittest import mock
+except ImportError:  # Python 3.2 and below
+    import mock
+
+from django.test import TestCase
+from django.core.files.base import ContentFile
+import django
+
+from botocore.exceptions import ClientError
+
+from storages.compat import urlparse
+from storages.backends import s3boto3
+
+__all__ = (
+    'SafeJoinTest',
+    'S3Boto3StorageTests',
+)
+
+
+class S3Boto3TestCase(TestCase):
+    @mock.patch('storages.backends.s3boto3.resource')
+    def setUp(self, resource):
+        self.storage = s3boto3.S3Boto3Storage()
+        self.storage._connection = mock.MagicMock()
+
+
+class SafeJoinTest(TestCase):
+    def test_normal(self):
+        path = s3boto3.safe_join("", "path/to/somewhere", "other", "path/to/somewhere")
+        self.assertEquals(path, "path/to/somewhere/other/path/to/somewhere")
+
+    def test_with_dot(self):
+        path = s3boto3.safe_join("", "path/./somewhere/../other", "..",
+                                 ".", "to/./somewhere")
+        self.assertEquals(path, "path/to/somewhere")
+
+    def test_base_url(self):
+        path = s3boto3.safe_join("base_url", "path/to/somewhere")
+        self.assertEquals(path, "base_url/path/to/somewhere")
+
+    def test_base_url_with_slash(self):
+        path = s3boto3.safe_join("base_url/", "path/to/somewhere")
+        self.assertEquals(path, "base_url/path/to/somewhere")
+
+    def test_suspicious_operation(self):
+        self.assertRaises(ValueError,
+                          s3boto3.safe_join, "base", "../../../../../../../etc/passwd")
+
+    def test_trailing_slash(self):
+        """
+        Test safe_join with paths that end with a trailing slash.
+        """
+        path = s3boto3.safe_join("base_url/", "path/to/somewhere/")
+        self.assertEquals(path, "base_url/path/to/somewhere/")
+
+    def test_trailing_slash_multi(self):
+        """
+        Test safe_join with multiple paths that end with a trailing slash.
+        """
+        path = s3boto3.safe_join("base_url/", "path/to/" "somewhere/")
+        self.assertEquals(path, "base_url/path/to/somewhere/")
+
+
+class S3Boto3StorageTests(S3Boto3TestCase):
+
+    def test_clean_name(self):
+        """
+        Test the base case of _clean_name
+        """
+        path = self.storage._clean_name("path/to/somewhere")
+        self.assertEqual(path, "path/to/somewhere")
+
+    def test_clean_name_normalize(self):
+        """
+        Test the normalization of _clean_name
+        """
+        path = self.storage._clean_name("path/to/../somewhere")
+        self.assertEqual(path, "path/somewhere")
+
+    def test_clean_name_trailing_slash(self):
+        """
+        Test the _clean_name when the path has a trailing slash
+        """
+        path = self.storage._clean_name("path/to/somewhere/")
+        self.assertEqual(path, "path/to/somewhere/")
+
+    def test_clean_name_windows(self):
+        """
+        Test the _clean_name when the path has a trailing slash
+        """
+        path = self.storage._clean_name("path\\to\\somewhere")
+        self.assertEqual(path, "path/to/somewhere")
+
+    def test_storage_url_slashes(self):
+        """
+        Test URL generation.
+        """
+        self.storage.custom_domain = 'example.com'
+
+        # We expect no leading slashes in the path,
+        # and trailing slashes should be preserved.
+        self.assertEqual(self.storage.url(''), 'https://example.com/')
+        self.assertEqual(self.storage.url('path'), 'https://example.com/path')
+        self.assertEqual(self.storage.url('path/'), 'https://example.com/path/')
+        self.assertEqual(self.storage.url('path/1'), 'https://example.com/path/1')
+        self.assertEqual(self.storage.url('path/1/'), 'https://example.com/path/1/')
+
+    def test_storage_save(self):
+        """
+        Test saving a file
+        """
+        name = 'test_storage_save.txt'
+        content = ContentFile('new content')
+        self.storage.save(name, content)
+        self.storage.bucket.Object.assert_called_once_with(name)
+
+        obj = self.storage.bucket.Object.return_value
+        obj.put.assert_called_with(
+            Body=content,
+            ContentType='text/plain',
+            ACL=self.storage.default_acl,
+        )
+
+    def test_storage_save_gzip(self):
+        """
+        Test saving a file with gzip enabled.
+        """
+        self.storage.gzip = True
+        name = 'test_storage_save.css'
+        content = ContentFile("I should be gzip'd")
+        self.storage.save(name, content)
+        obj = self.storage.bucket.Object.return_value
+        obj.put.assert_called_with(
+            Body=mock.ANY,
+            ContentType='text/css',
+            ContentEncoding='gzip',
+            ACL=self.storage.default_acl
+        )
+        body = obj.put.call_args[1]['Body']
+        zfile = gzip.GzipFile(mode='rb', fileobj=body)
+        self.assertEquals(zfile.read(), b"I should be gzip'd")
+
+    def test_compress_content_len(self):
+        """
+        Test that file returned by _compress_content() is readable.
+        """
+        self.storage.gzip = True
+        content = ContentFile("I should be gzip'd")
+        content = self.storage._compress_content(content)
+        self.assertTrue(len(content.read()) > 0)
+
+    def test_storage_open_write(self):
+        """
+        Test opening a file in write mode
+        """
+        name = 'test_open_for_writing.txt'
+        content = 'new content'
+
+        # Set the encryption flag used for multipart uploads
+        self.storage.encryption = True
+        self.storage.reduced_redundancy = True
+        self.storage.default_acl = 'public-read'
+
+        file = self.storage.open(name, 'w')
+        self.storage.bucket.Object.assert_called_with(name)
+        obj = self.storage.bucket.Object.return_value
+        # Set the name of the mock object
+        obj.key = name
+
+        file.write(content)
+        obj.initiate_multipart_upload.assert_called_with(
+            ACL='public-read',
+            ContentType='text/plain',
+            ServerSideEncryption='AES256',
+            StorageClass='REDUCED_REDUNDANCY'
+        )
+
+        # Save the internal file before closing
+        multipart = obj.initiate_multipart_upload.return_value
+        multipart.parts.all.return_value = [mock.MagicMock(e_tag='123', part_number=1)]
+        file.close()
+        multipart.Part.assert_called_with(1)
+        part = multipart.Part.return_value
+        part.upload.assert_called_with(Body=content.encode('utf-8'))
+        multipart.complete.assert_called_once_with(
+            MultipartUpload={'Parts': [{'ETag': '123', 'PartNumber': 1}]})
+
+    def test_storage_exists(self):
+        obj = self.storage.bucket.Object.return_value
+        self.assertTrue(self.storage.exists("file.txt"))
+        self.storage.bucket.Object.assert_called_with("file.txt")
+        obj.load.assert_called_with()
+
+    def test_storage_exists_false(self):
+        obj = self.storage.bucket.Object.return_value
+        obj.load.side_effect = ClientError({'Error': {'Code': 123, 'Message': 'Fake'}}, 'load')
+        self.assertFalse(self.storage.exists("file.txt"))
+        self.storage.bucket.Object.assert_called_with("file.txt")
+        obj.load.assert_called_with()
+
+    def test_storage_delete(self):
+        self.storage.delete("path/to/file.txt")
+        self.storage.bucket.Object.assert_called_with('path/to/file.txt')
+        self.storage.bucket.Object.return_value.delete.assert_called_with()
+
+    def test_storage_listdir_base(self):
+        file_names = ["some/path/1.txt", "2.txt", "other/path/3.txt", "4.txt"]
+
+        result = []
+        for p in file_names:
+            obj = mock.MagicMock()
+            obj.key = p
+            result.append(obj)
+        self.storage.bucket.objects.filter.return_value = iter(result)
+
+        dirs, files = self.storage.listdir("")
+        self.storage.bucket.objects.filter.assert_called_with(Prefix="")
+
+        self.assertEqual(len(dirs), 2)
+        for directory in ["some", "other"]:
+            self.assertTrue(directory in dirs,
+                            """ "%s" not in directory list "%s".""" % (
+                                directory, dirs))
+
+        self.assertEqual(len(files), 2)
+        for filename in ["2.txt", "4.txt"]:
+            self.assertTrue(filename in files,
+                            """ "%s" not in file list "%s".""" % (
+                                filename, files))
+
+    def test_storage_listdir_subdir(self):
+        file_names = ["some/path/1.txt", "some/2.txt"]
+
+        result = []
+        for p in file_names:
+            obj = mock.MagicMock()
+            obj.key = p
+            result.append(obj)
+        self.storage.bucket.objects.filter.return_value = iter(result)
+
+        dirs, files = self.storage.listdir("some/")
+        self.storage.bucket.objects.filter.assert_called_with(Prefix="some/")
+
+        self.assertEqual(len(dirs), 1)
+        self.assertTrue('path' in dirs,
+                        """ "path" not in directory list "%s".""" % (dirs,))
+
+        self.assertEqual(len(files), 1)
+        self.assertTrue('2.txt' in files,
+                        """ "2.txt" not in files list "%s".""" % (files,))
+
+    def test_storage_size(self):
+        obj = self.storage.bucket.Object.return_value
+        obj.content_length = 4098
+
+        name = 'file.txt'
+        self.assertEqual(self.storage.size(name), obj.content_length)
+
+    def test_storage_url(self):
+        name = 'test_storage_size.txt'
+        url = 'http://aws.amazon.com/%s' % name
+        self.storage.bucket.meta.client.generate_presigned_url.return_value = url
+        self.storage.bucket.name = 'bucket'
+        self.assertEquals(self.storage.url(name), url)
+        self.storage.bucket.meta.client.generate_presigned_url.assert_called_with(
+            'get_object',
+            Params={'Bucket': self.storage.bucket.name, 'Key': name},
+            ExpiresIn=self.storage.querystring_expire
+        )
+
+        custom_expire = 123
+
+        self.assertEquals(self.storage.url(name, expire=custom_expire), url)
+        self.storage.bucket.meta.client.generate_presigned_url.assert_called_with(
+            'get_object',
+            Params={'Bucket': self.storage.bucket.name, 'Key': name},
+            ExpiresIn=custom_expire
+        )
+
+    def test_generated_url_is_encoded(self):
+        self.storage.custom_domain = "mock.cloudfront.net"
+        filename = "whacky & filename.mp4"
+        url = self.storage.url(filename)
+        parsed_url = urlparse.urlparse(url)
+        self.assertEqual(parsed_url.path,
+                         "/whacky%20%26%20filename.mp4")
+        self.assertFalse(self.storage.bucket.meta.client.generate_presigned_url.called)
+
+    @unittest.skipIf(django.VERSION >= (1, 8),
+                     'Only test backward compat of max_length for versions before 1.8')
+    def test_max_length_compat_okay(self):
+        self.storage.file_overwrite = False
+        self.storage.exists = lambda name: False
+        self.storage.get_available_name('gogogo', max_length=255)
+
+    def test_strip_signing_parameters(self):
+        expected = 'http://bucket.s3-aws-region.amazonaws.com/foo/bar'
+        self.assertEquals(self.storage._strip_signing_parameters(
+            '%s?X-Amz-Date=12345678&X-Amz-Signature=Signature' % expected), expected)
+        self.assertEquals(self.storage._strip_signing_parameters(
+            '%s?expires=12345678&signature=Signature' % expected), expected)

--- a/tox.ini
+++ b/tox.ini
@@ -16,5 +16,6 @@ deps =
     django19: Django>=1.9, <1.10
     py27: mock==1.0.1
     boto>=2.32.0
+    boto3>=1.2.3
     pytest==2.6.4
     dropbox>=3.24


### PR DESCRIPTION
This pull request implements https://github.com/jschneier/django-storages/issues/57 by adding a Boto 3 backend that tries to be a close-to-drop-in replacement for Boto 2. Due to the slight differences, I have kept it a separate backend, but with a lot of copy and paste code. Given that Boto 2 is heading towards maintenance mode according to https://github.com/boto/boto/commit/e3dd99695e8976fad88c1c55d69914199f1878db, I don't think it's worth trying to have 2 backends sharing code when the Boto 2 implementation looks on the way to being deprecated.

Note that this isn't just me blithely throwing away the Boto 2 implementation; the fundamental underlying operations are VERY different and worthy of a separate backend. Boto 2 operates on the assumption that you can set arbitrary headers by passing in a dictionary; Boto 3 restricts you to specific named parameters and as such the 2 approaches are very incompatible with one another. You can try to do minor mappings here and there to try to map some of the headers in the AWS_HEADERS setting, but trying to map every possible header value to the right argument name in the right method is pretty tedious and error prone. Instead, this pull request embraces Boto 3's use of parameters as its way of taking in these extra arguments, leaving the remapping up to the django-storages user who wants to switch backends. For the limited number of extra headers and parameters they'll use, this mapping is easier to do, and looking up in Boto 3's documentation for the parameter name is straightforward.

This pull request replaces https://github.com/jschneier/django-storages/issues/66, adding unit tests and incorporating changes due to pull requests accepted into Boto3/botocore. A substantially similar version of this (minus the recent merges from the past few days) has been run in production with Django 1.6.11 for several months without problems.

Also note that while I was at it, I made the necessary change to support #95 if you switch to this backend.

Because this is based on s3boto.py, you should be able to manually perform a diff of s3boto.py and the new s3boto3.py to understand the changes.

Changes:
* The AWS_HEADERS/storage.headers setting is replaced with AWS_S3_OBJECT_PARAMETERS/storage.object_parameters. The keys/values to this are intended to be the arguments to the http://boto3.readthedocs.org/en/latest/reference/services/s3.html#S3.Object.put boto3.Resource('s3').Object.put() method, which has all the arguments that would be used to generate the correct request headers. Note that this gives a little more access than just headers, since a user could also provide ACL and Content arguments in this dict.
* Unlike the s3boto implementation, s3boto3 backend does not currently support proxies (https://github.com/boto/botocore/issues/541), or alternate host/ports (https://github.com/boto/botocore/issues/601) because the underlying Boto3/Botocore library does not currently support it. It only kind of supports the endpoint URL
* If using s3v4, since botocore does not automatically redirect you to the correct region's endpoint nor sign properly unless it knows the region, there is an AWS_S3_REGION_NAME/storage.region_name setting to force the region.
* There's some behavior that was being done in the boto2 library that boto3 does not do, so equivalent code has been added to s3boto3 to do this. These include things like rewinding the file pointer, automatically checking for bucket and object existence, or directly writing the S3 contents to a file/file pointer. There's cases where Boto3 does not allow previous operations, like locally updating the last_modified attribute, which this new version performs by just reloading the object from the server.
* No need to parse timestamps, since boto3 already performs this conversion for you.

Known issues:
* For unsigned URLs (e.g. querystring_auth=False), Boto3 does not support this in its API (https://github.com/boto/boto3/issues/169). This implements compatibility by stripping off any signature parameters by parsing the querystring. Note that these parameter names will be different for s3v1/s3v4 URLs, but this implements it by stripping them all away.
* To support s3v4 URLs for endpoints that aren't v4 by default (most of them), there are 2 ways. The one I've used in production is  to have a ~/.aws/config file as generated by running "aws configure set default.s3.signature_version s3v4". If deploying in a configuration where there is no user home directory, the location of this config can be set with AWS_CONFIG_FILE environment variable. Another way involves setting the S3Boto3Storage.config variable with a Boto3 client config.

This has been tested using s3v4 signatures with both signed and unsigned URLs, along with response content disposition and KMS server-side encryption key arguments.