### PR TITLE
Added host setting to GSBotoStorage (fixes #124)

### DIFF
--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -63,6 +63,7 @@ class GSBotoStorage(S3BotoStorage):
         'application/x-javascript',
     ))
     url_protocol = setting('GS_URL_PROTOCOL', 'http:')
+    host = setting('GS_HOST', GSConnection.DefaultHost)
 
     def _save_content(self, key, content, headers):
         # only pass backwards incompatible arguments if they vary from the default


### PR DESCRIPTION
GSBotoStorage inherits this method from its parent class, S3BotoStorage:
```
def connection(self):
        if self._connection is None:
            self._connection = self.connection_class(
                self.access_key,
                self.secret_key,
                is_secure=self.use_ssl,
                calling_format=self.calling_format,
                host=self.host,
                port=self.port,
                proxy=self.proxy,
                proxy_port=self.proxy_port
            )
        return self._connection
```

Note the `host=self.host`.

The value of this setting for GSBotoStorage used to be derived from S3BotoStorage as well. The value in the parent class was: `host = setting('AWS_S3_HOST', S3Connection.DefaultHost)`, which resolved to 's3.amazonaws.com' instead of the correct 'storage.googleapis.com'.

This fixed #124 for me.