### PR TITLE
Fix of issues #137 and issue #138

### DIFF
--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -90,7 +90,13 @@ class DropBoxStorage(Storage):
         return remote_file
 
     def _save(self, name, content):
-        self.client.put_file(name, content)
+        name = name.replace ('\\','/')
+        try:
+            file_metadata = self.client.metadata(name)
+            the_rev = file_metadata['rev']
+        except:
+            the_rev = ''
+        self.client.put_file(name, content, overwrite=True, parent_rev=the_rev)
         return name
 
     def _read(self, name, num_bytes=None):


### PR DESCRIPTION
- #137 I've placed everything on the _save function given that "get_available_name" was not being called when file is written with open () method.
- #138 No file_overwrite variable is considered. Overwrite is forced, if the file has the same content, dropbox keeps the previous one so no overwrite is reflected.
