### PR TITLE
Adding Option to Amazon S3 Backend Docs

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -27,7 +27,7 @@ Your Amazon Web Services storage bucket name, as a string.
 
 ``AWS_DEFAULT_ACL`` (optional)
 
-If set to ``private`` changes files uploaded from the default ``public-read`` to privzte. 
+If set to ``private`` changes uploaded file's Access Control List from the default permission ``public-read`` to give owner full control and remove read access from everyone else. 
 
 ``AWS_AUTO_CREATE_BUCKET`` (optional)
 


### PR DESCRIPTION
Adds to the S3 document the documentation for the ability to change from the S3 django-storages default of 'public-read' to 'private', which is the standard Amazon S3 default. 