### PR TITLE
Be more precise about recursive includes.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include AUTHORS CHANGELOG.rst LICENSE README.rst requirements*.txt
-recursive-include tests *
-recursive-include docs *
+recursive-include tests *.py
+recursive-include docs Makefile conf.py make.bat *.rst


### PR DESCRIPTION
The tarball on PyPI has some artifacts in the `tests` folder right now (`.pyc`
files) which should not be shipped. Changing the directives to be more precise
as to what gets includes fixes this for future release tarballs.