### PR TITLE
Added AWS_EXTRA_HEADERS option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ setuptools*
 __pycache__
 .coverage
 .cache
+.idea

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -40,6 +40,16 @@ If you'd like to set headers sent with each file of the storage::
         'Cache-Control': 'max-age=86400',
     }
 
+
+``AWS_EXTRA_HEADERS`` (optional)
+
+This option allows to set additional headers for files matching special regex
+For example if you want to add "Cache-Control" header for all png images add
+
+AWS_EXTRA_HEADERS = [
+  (".*png", {"Cache-Control": "max-age=86400"})
+]
+
 To allow ``django-admin.py`` collectstatic to automatically put your static files in your bucket set the following in your settings.py::
 
     STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -338,3 +338,17 @@ class S3BotoStorageTests(S3BotoTestCase):
         self.storage.file_overwrite = False
         self.storage.exists = lambda name: False
         self.storage.get_available_name('gogogo', max_length=255)
+
+    def test_get_headers_default(self):
+        result = self.storage.get_headers("filename")
+        self.assertEqual(result, {})
+
+    def test_get_extra_headers(self):
+        extra_headers = [
+            ("storage/img/.*", {"extra header": "value"})
+        ]
+        self.storage.extra_headers = extra_headers
+        result = self.storage.get_extra_headers("storage/img/testimage")
+        self.assertDictEqual(result, extra_headers[0][1])
+        result = self.storage.get_extra_headers("storage/not/matching/file")
+        self.assertDictEqual(result, {})


### PR DESCRIPTION
We found it useful to add special headers for files from specific path (e.g. user avatars)
I added AWS_EXTRA_HEADERS and created get_headers method for S3BotoStorage
