### PR TITLE
Use Python 3.5 image to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: python
+python:
+  - 3.5
 
 env:
   - TOX_ENV=py27-django17


### PR DESCRIPTION
Travis already supports for Python 3.5 to build.