### PR TITLE
Fix TZ awareness in S3Boto3Storage

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -28,3 +28,6 @@ DEFAULT_FILE_STORAGE = 'backends.s3boto.S3BotoStorage'
 AWS_IS_GZIPPED = True
 GS_IS_GZIPPED = True
 SECRET_KEY = 'hailthesunshine'
+
+USE_TZ = True
+TIME_ZONE = 'America/Chicago'


### PR DESCRIPTION
Django expects a naive datetime from the [modified_time()] method.
Django 1.10 adds a [get_modified_time()] method which respects USE_TZ.

This commit fixes modified_time(), adds get_modified_time(), and adds
relevant tests.

[modified_time()]: https://docs.djangoproject.com/en/1.10/ref/files/storage/#django.core.files.storage.Storage.modified_time
[get_modified_time()]: https://docs.djangoproject.com/en/1.10/ref/files/storage/#django.core.files.storage.Storage.get_modified_time