### PR TITLE
Use compressed content instead of changing original object

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -375,9 +375,8 @@ class S3BotoStorage(Storage):
         finally:
             zfile.close()
         zbuf.seek(0)
-        content.file = zbuf
         content.seek(0)
-        return content
+        return zbuf
 
     def _open(self, name, mode='rb'):
         name = self._normalize_name(self._clean_name(name))


### PR DESCRIPTION
This fixes a bug  that the upload of  a file is not possible when gzip is activated (https://github.com/divio/django-filer/issues/885)

When gzip activated, the current version changes the actual object and overwrites its current file
with the gzipped datastream. When the object instance is simultaneously used by other "algorithms" (e.g. django-filer) this ends in wrong  behavior/exceptions.