### PR TITLE
All storage classes are deconstructible

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -7,6 +7,7 @@ from time import mktime
 from django.core.files.base import ContentFile
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import Storage
+from django.utils.deconstruct import deconstructible
 
 try:
     import azure  # noqa
@@ -30,6 +31,7 @@ def clean_name(name):
     return os.path.normpath(name).replace("\\", "/")
 
 
+@deconstructible
 class AzureStorage(Storage):
     account_name = setting("AZURE_ACCOUNT_NAME")
     account_key = setting("AZURE_ACCOUNT_KEY")

--- a/storages/backends/couchdb.py
+++ b/storages/backends/couchdb.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import Storage
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.deconstruct import deconstructible
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.six import BytesIO
 
@@ -22,6 +23,7 @@ DEFAULT_SERVER = getattr(settings, 'COUCHDB_DEFAULT_SERVER', 'http://couchdb.loc
 STORAGE_OPTIONS = getattr(settings, 'COUCHDB_STORAGE_OPTIONS', {})
 
 
+@deconstructible
 class CouchDBStorage(Storage):
     """
     CouchDBStorage - a Django Storage class for CouchDB.

--- a/storages/backends/database.py
+++ b/storages/backends/database.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.files import File
 from django.core.files.storage import Storage
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.deconstruct import deconstructible
 from django.utils.six import BytesIO
 from django.utils.six.moves.urllib import parse as urlparse
 
@@ -17,6 +18,7 @@ except ImportError:
 REQUIRED_FIELDS = ('db_table', 'fname_column', 'blob_column', 'size_column', 'base_url')
 
 
+@deconstructible
 class DatabaseStorage(Storage):
     """
     Class DatabaseStorage provides storing files in the database.

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -17,6 +17,7 @@ from shutil import copyfileobj
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
+from django.utils.deconstruct import deconstructible
 from django.utils._os import safe_join
 
 from storages.utils import setting
@@ -46,6 +47,7 @@ class DropBoxFile(File):
         return self._file
 
 
+@deconstructible
 class DropBoxStorage(Storage):
     """DropBox Storage class for Django pluggable storage system."""
 

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -22,6 +22,7 @@ from django.conf import settings
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.deconstruct import deconstructible
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.six import BytesIO
 
@@ -32,6 +33,7 @@ class FTPStorageException(Exception):
     pass
 
 
+@deconstructible
 class FTPStorage(Storage):
     """FTP Storage class for Django pluggable storage system."""
 

--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.deconstruct import deconstructible
 from django.utils.six import BytesIO
 
 from storages.backends.s3boto import S3BotoStorage, S3BotoStorageFile
@@ -30,6 +31,7 @@ class GSBotoStorageFile(S3BotoStorageFile):
         self.key.close()
 
 
+@deconstructible
 class GSBotoStorage(S3BotoStorage):
     connection_class = GSConnection
     connection_response_error = GSResponseError

--- a/storages/backends/hashpath.py
+++ b/storages/backends/hashpath.py
@@ -3,9 +3,11 @@ import hashlib
 import os
 
 from django.core.files.storage import FileSystemStorage
+from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_text, force_bytes
 
 
+@deconstructible
 class HashPathStorage(FileSystemStorage):
     """
     Creates a hash from the uploaded file to build the path.

--- a/storages/backends/image.py
+++ b/storages/backends/image.py
@@ -3,6 +3,7 @@ import os
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import FileSystemStorage
+from django.utils.deconstruct import deconstructible
 
 try:
     from PIL import ImageFile as PILImageFile
@@ -11,6 +12,7 @@ except ImportError:
     \nSee http://www.pythonware.com/products/pil/")
 
 
+@deconstructible
 class ImageStorage(FileSystemStorage):
     """
     A FileSystemStorage which normalizes extensions for images.

--- a/storages/backends/mogile.py
+++ b/storages/backends/mogile.py
@@ -4,6 +4,7 @@ import mimetypes
 
 from django.conf import settings
 from django.core.cache import cache
+from django.utils.deconstruct import deconstructible
 from django.utils.text import force_text
 from django.http import HttpResponse, HttpResponseNotFound
 from django.core.exceptions import ImproperlyConfigured
@@ -16,6 +17,7 @@ except ImportError:
     \nSee http://mogilefs.pbworks.com/Client-Libraries")
 
 
+@deconstructible
 class MogileFSStorage(Storage):
     """MogileFS filesystem storage"""
     def __init__(self, base_url=settings.MEDIA_URL):

--- a/storages/backends/overwrite.py
+++ b/storages/backends/overwrite.py
@@ -1,6 +1,8 @@
 from django.core.files.storage import FileSystemStorage
+from django.utils.deconstruct import deconstructible
 
 
+@deconstructible
 class OverwriteStorage(FileSystemStorage):
     """
     Comes from http://www.djangosnippets.org/snippets/976/

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -15,12 +15,14 @@ from datetime import datetime
 from django.conf import settings
 from django.core.files.base import File
 from django.core.files.storage import Storage
+from django.utils.deconstruct import deconstructible
 from django.utils.six import BytesIO
 from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.utils import setting
 
 
+@deconstructible
 class SFTPStorage(Storage):
 
     def __init__(self, host, params=None, interactive=None, file_mode=None,

--- a/storages/backends/symlinkorcopy.py
+++ b/storages/backends/symlinkorcopy.py
@@ -2,6 +2,7 @@ import os
 
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
+from django.utils.deconstruct import deconstructible
 
 __doc__ = """
 I needed to efficiently create a mirror of a directory tree (so that
@@ -26,6 +27,7 @@ a temporary directory, e.g. /tmp/image.jpg.
 """
 
 
+@deconstructible
 class SymlinkOrCopyStorage(FileSystemStorage):
     """Stores symlinks to files instead of actual files whenever possible
 


### PR DESCRIPTION
Dear Josh,

I start using this library recently, and want to thank you for maintaining it! And also thangs to all authors and participants for their contribution!

I found that some of the storages doesn't decorated by `@deconstructible`. But this is required in case of passing storage as a parameter into FileField.

Can it be included in future versions?