### PR TITLE
S3Boto3Storage: fix for file-like objects without name, multipart upload support

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+django_find_project = false
+norecursedirs = .tox .git .idea docs storages
+python_files=test_*.py tests.py
+env =
+    DJANGO_SETTINGS_MODULE=tests.settings
+    PYTHONDONTWRITEBYTECODE=1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,5 @@
 Django>=1.7
+pytest-env
 pytest-cov==2.2.1
 boto>=2.32.0
 boto3>=1.2.3


### PR DESCRIPTION
In fact, it's partially solves problem. If we pass subclass of `File` class and forgot override `__bool__` method - an error based on empty name still can occur.
