### PR TITLE
Use a different instance of boto3 Session per thread.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 django-storages change log
 ==========================
 
+1.5.2 (XXXX-XX-XX)
+******************
+
+* Fix ``S3Boto3Storage`` to avoid race conditions in a multithreaded WSGI environment
+
 1.5.1 (2016-09-13)
 ******************
 
@@ -301,4 +306,3 @@ since March 2013.
 
 .. _#89: https://bitbucket.org/david/django-storages/issue/89/112-broke-the-mosso-backend
 .. _pull request #5: https://bitbucket.org/david/django-storages/pull-request/5/fixed-path-bug-and-added-testcase-for
-

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -14,7 +14,7 @@ from django.utils.six import BytesIO
 from django.utils.timezone import localtime
 
 try:
-    from boto3 import resource
+    import boto3.session
     from boto3 import __version__ as boto3_version
     from botocore.client import Config
     from botocore.exceptions import ClientError
@@ -62,6 +62,11 @@ def safe_join(base, *paths):
                          ' component')
 
     return final_path.lstrip('/')
+
+
+def resource(*args, **kwargs):
+    session = boto3.session.Session()
+    return session.resource(*args, **kwargs)
 
 
 @deconstructible


### PR DESCRIPTION
The default mod_wsgi configuration runs in 15 threads. Per the
documentation, boto3 is _not_ thread-safe by default. The library
recommends using a different instance of Session per thread. This avoids
race conditions in the library.

https://boto3.readthedocs.io/en/latest/guide/resources.html#multithreading