### PR TITLE
Add location to the create_bucket parameters

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -218,6 +218,7 @@ class S3BotoStorage(Storage):
     querystring_expire = setting('AWS_QUERYSTRING_EXPIRE', 3600)
     reduced_redundancy = setting('AWS_REDUCED_REDUNDANCY', False)
     location = setting('AWS_LOCATION', '')
+    origin = setting('AWS_ORIGIN', '')
     encryption = setting('AWS_S3_ENCRYPTION', False)
     custom_domain = setting('AWS_S3_CUSTOM_DOMAIN')
     calling_format = setting('AWS_S3_CALLING_FORMAT', SubdomainCallingFormat())
@@ -328,7 +329,7 @@ class S3BotoStorage(Storage):
             return self.connection.get_bucket(name, validate=self.auto_create_bucket)
         except self.connection_response_error:
             if self.auto_create_bucket:
-                bucket = self.connection.create_bucket(name, location=self.location)
+                bucket = self.connection.create_bucket(name, location=self.origin)
                 bucket.set_acl(self.bucket_acl)
                 return bucket
             raise ImproperlyConfigured("Bucket %s does not exist. Buckets "

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -328,7 +328,7 @@ class S3BotoStorage(Storage):
             return self.connection.get_bucket(name, validate=self.auto_create_bucket)
         except self.connection_response_error:
             if self.auto_create_bucket:
-                bucket = self.connection.create_bucket(name)
+                bucket = self.connection.create_bucket(name, location=self.location)
                 bucket.set_acl(self.bucket_acl)
                 return bucket
             raise ImproperlyConfigured("Bucket %s does not exist. Buckets "

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -15,7 +15,7 @@ from django.utils.six.moves.urllib import parse as urlparse
 
 try:
     from boto import __version__ as boto_version
-    from boto.s3.connection import S3Connection, SubdomainCallingFormat
+    from boto.s3.connection import S3Connection, SubdomainCallingFormat, Location
     from boto.exception import S3ResponseError
     from boto.s3.key import Key as S3Key
     from boto.utils import parse_ts, ISO8601
@@ -218,7 +218,7 @@ class S3BotoStorage(Storage):
     querystring_expire = setting('AWS_QUERYSTRING_EXPIRE', 3600)
     reduced_redundancy = setting('AWS_REDUCED_REDUNDANCY', False)
     location = setting('AWS_LOCATION', '')
-    origin = setting('AWS_ORIGIN', '')
+    origin = setting('AWS_ORIGIN', Location.DEFAULT)
     encryption = setting('AWS_S3_ENCRYPTION', False)
     custom_domain = setting('AWS_S3_CUSTOM_DOMAIN')
     calling_format = setting('AWS_S3_CALLING_FORMAT', SubdomainCallingFormat())


### PR DESCRIPTION
We're developing a EU project using this package, to interface nicely with AWS S3 storage. When trying to create a bucket automatically, this error is thrown:

```
S3ResponseError: S3ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Error>
    <Code>IllegalLocationConstraintException</Code>
    <Message>The unspecified location constraint is incompatible for the region specific endpoint this request was sent to.</Message>
    <RequestId>XXX</RequestId>
    <HostId>XXX</HostId>
</Error>
```

Turns out the `create_bucket` can take a `location` argument, but it's not in use currently.

From [the documentation](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region): 

> If you use a region other than the US East (N. Virginia) endpoint to create a bucket, you must set the LocationConstraint bucket parameter to the same region.

The bucket location is already parsed from the django settings, inside the `location` property of the `S3BotoStorage` object. This change simply add the location argument when creating the bucket.