### PR TITLE
Apply smart_text on file names in python2.7 [s3boto3]

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.encoding import force_text, smart_str, filepath_to_uri, force_bytes
+from django.utils.encoding import force_text, smart_text, filepath_to_uri, force_bytes
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.six import BytesIO
 from django.utils.timezone import localtime
@@ -399,7 +399,7 @@ class S3Boto3Storage(Storage):
                                       name)
 
     def _encode_name(self, name):
-        return smart_str(name, encoding=self.file_name_charset)
+        return smart_text(name, encoding=self.file_name_charset)
 
     def _decode_name(self, name):
         return force_text(name, encoding=self.file_name_charset)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from datetime import datetime
 import gzip
 try:
@@ -161,7 +164,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         """
         Test opening a file in write mode
         """
-        name = 'test_open_for_writing.txt'
+        name = 'test_open_for_writïng.txt'
         content = 'new content'
 
         # Set the encryption flag used for multipart uploads
@@ -317,6 +320,18 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.assertEqual(parsed_url.path,
                          "/whacky%20%26%20filename.mp4")
         self.assertFalse(self.storage.bucket.meta.client.generate_presigned_url.called)
+
+    def test_special_characters(self):
+        self.storage.custom_domain = "mock.cloudfront.net"
+
+        name = "ãlöhâ.jpg"
+        content = ContentFile('new content')
+        self.storage.save(name, content)
+        self.storage.bucket.Object.assert_called_once_with(name)
+
+        url = self.storage.url(name)
+        parsed_url = urlparse.urlparse(url)
+        self.assertEqual(parsed_url.path, "/%C3%A3l%C3%B6h%C3%A2.jpg")
 
     def test_strip_signing_parameters(self):
         expected = 'http://bucket.s3-aws-region.amazonaws.com/foo/bar'


### PR DESCRIPTION
Not a 100% sure it's the best approach, but there it is: my attempt to address #216.

I feel that `_encode_name` and `_decode_name` are starting to lose their naming/meaning values since they now end up doing almost the same thing.

Also, I didn't know what to precisely test. The only thing I know for sure is that the test I added fail without the switch from `smart_str` to `smart_text`.
