### PR TITLE
Check to ensure the appropriate attributes are set before return.

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -510,8 +510,12 @@ class S3Boto3Storage(Storage):
         name = self._normalize_name(self._clean_name(name))
         if self.entries:
             entry = self.entries.get(name)
+
             if entry:
-                return entry.content_length
+                if hasattr(entry, 'content_length'):
+                    return entry.content_length
+                if hasattr(entry, 'size'):
+                    return entry.size
             return 0
         return self.bucket.Object(self._encode_name(name)).content_length
 


### PR DESCRIPTION
It appears 'content_length' isn't always returned as an 'entry' attribute. While I'm by no means an S3 wizard, I did notice that in these instances, 'size' was returned in files I examined.

This was done while using django-storages with the Wagtail CMS, and has fixed this error:

```
Traceback:  

File "/blah/blah/lib/python3.5/site-packages/django/core/handlers/exception.py" in inner
  39.             response = get_response(request)

File "/blah/blah/lib/python3.5/site-packages/django/core/handlers/base.py" in _legacy_get_response
  249.             response = self._get_response(request)

File "/blah/blah/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  187.                 response = self.process_exception_by_middleware(e, request)

File "/blah/blah/lib/python3.5/site-packages/django/core/handlers/base.py" in _get_response
  185.                 response = wrapped_callback(request, *callback_args, **callback_kwargs)

File "/blah/blah/lib/python3.5/site-packages/django/views/decorators/cache.py" in _cache_controlled
  43.             response = viewfunc(request, *args, **kw)

File "/blah/blah/lib/python3.5/site-packages/wagtail/wagtailadmin/decorators.py" in decorated_view
  24.             return view_func(request, *args, **kwargs)

File "/blah/blah/lib/python3.5/site-packages/wagtail/wagtailadmin/utils.py" in wrapped_view_func
  103.                 return view_func(request, *args, **kwargs)

File "/blah/blah/lib/python3.5/site-packages/wagtail/wagtaildocs/views/documents.py" in edit
  157.             filesize = doc.file.size

File "/blah/blah/lib/python3.5/site-packages/django/db/models/fields/files.py" in _get_size
  76.         return self.storage.size(self.name)

File "/blah/blah/lib/python3.5/site-packages/storages/backends/s3boto3.py" in size
  514.                 return entry.content_length

Exception Type: AttributeError at /cms/documents/edit/34/ Exception Value: 's3.ObjectSummary' object has no attribute 'content_length'
```