### PR TITLE
Add Google Cloud Storage backend using the gcloud-python library

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,6 +27,8 @@ By order of apparition, thanks:
     * Michael Barrientos (S3 with Boto3)
     * piglei (patches)
     * Matt Braymer-Hayes (S3 with Boto3)
+    * Eirik Martiniussen Sylliaas (Google Cloud Storage native support)
+    * Jody McIntyre (Google Cloud Storage native support)
 
 Extra thanks to Marty for adding this in Django,
 you can buy his very interesting book (Pro Django).

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -1,0 +1,190 @@
+Google Cloud Storage
+====================
+
+Usage
+*****
+
+This backend provides support for Google Cloud Storage using the
+library provided by Google.
+
+It's possible to access Google Cloud Storage in S3 compatibility mode
+using other libraries in django-storages, but this is the only library
+offering native support.
+
+By default this library will use the credentials associated with the
+current instance for authentication. To override this, see the
+settings below.
+
+
+Settings
+--------
+
+To use gcloud set::
+
+    DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
+
+``GS_BUCKET_NAME``
+
+Your Google Storage bucket name, as a string.
+
+``GS_PROJECT_ID`` (optional)
+
+Your Google Cloud project ID. If unset, falls back to the default
+inferred from the environment.
+
+``GS_CREDENTIALS`` (optional)
+
+The OAuth 2 credentials to use for the connection. If unset, falls
+back to the default inferred from the environment.
+
+``GS_AUTO_CREATE_BUCKET`` (optional, default is ``False``)
+
+If True, attempt to create the bucket if it does not exist.
+
+``GS_DEFAULT_ACL`` (optional)
+
+If set to ``private`` changes uploaded file's Access Control List from the default permission ``public-read`` to give owner full control and remove read access from everyone else. 
+
+``GS_BUCKET_ACL`` (optional)
+
+ACL used when creating a new bucket; defaults to ``GS_DEFAULT_ACL``.
+
+``GS_FILE_CHARSET`` (optional)
+
+Allows overriding the character set used in filenames.
+
+``GS_FILE_OVERWRITE`` (optional: default is ``True``)
+
+By default files with the same name will overwrite each other. Set this to ``False`` to have extra characters appended.
+
+``GS_MAX_MEMORY_SIZE`` (optional)
+
+The maximum amount of memory a returned file can take up before being
+rolled over into a temporary file on disk. Default is 0: Do not roll over.
+
+Fields
+------
+
+Once you're done, default_storage will be Google Cloud Storage::
+
+    >>> from django.core.files.storage import default_storage
+    >>> print default_storage.__class__
+    <class 'storages.backends.gcloud.GoogleCloudStorage'>
+
+This way, if you define a new FileField, it will use the Google Cloud Storage::
+
+    >>> from django.db import models
+    >>> class Resume(models.Model):
+    ...     pdf = models.FileField(upload_to='pdfs')
+    ...     photos = models.ImageField(upload_to='photos')
+    ...
+    >>> resume = Resume()
+    >>> print resume.pdf.storage
+    <storages.backends.gcloud.GoogleCloudStorage object at ...>
+
+Storage
+-------
+
+Standard file access options are available, and work as expected::
+
+    >>> default_storage.exists('storage_test')
+    False
+    >>> file = default_storage.open('storage_test', 'w')
+    >>> file.write('storage contents')
+    >>> file.close()
+
+    >>> default_storage.exists('storage_test')
+    True
+    >>> file = default_storage.open('storage_test', 'r')
+    >>> file.read()
+    'storage contents'
+    >>> file.close()
+
+    >>> default_storage.delete('storage_test')
+    >>> default_storage.exists('storage_test')
+    False
+
+Model
+-----
+
+An object without a file has limited functionality::
+
+    >>> obj1 = MyStorage()
+    >>> obj1.normal
+    <FieldFile: None>
+    >>> obj1.normal.size
+    Traceback (most recent call last):
+    ...
+    ValueError: The 'normal' attribute has no file associated with it.
+
+Saving a file enables full functionality::
+
+    >>> obj1.normal.save('django_test.txt', ContentFile('content'))
+    >>> obj1.normal
+    <FieldFile: tests/django_test.txt>
+    >>> obj1.normal.size
+    7
+    >>> obj1.normal.read()
+    'content'
+
+Files can be read in a little at a time, if necessary::
+
+    >>> obj1.normal.open()
+    >>> obj1.normal.read(3)
+    'con'
+    >>> obj1.normal.read()
+    'tent'
+    >>> '-'.join(obj1.normal.chunks(chunk_size=2))
+    'co-nt-en-t'
+
+Save another file with the same name::
+
+    >>> obj2 = MyStorage()
+    >>> obj2.normal.save('django_test.txt', ContentFile('more content'))
+    >>> obj2.normal
+    <FieldFile: tests/django_test_.txt>
+    >>> obj2.normal.size
+    12
+
+Push the objects into the cache to make sure they pickle properly::
+
+    >>> cache.set('obj1', obj1)
+    >>> cache.set('obj2', obj2)
+    >>> cache.get('obj2').normal
+    <FieldFile: tests/django_test_.txt>
+
+Deleting an object deletes the file it uses, if there are no other objects still using that file::
+
+    >>> obj2.delete()
+    >>> obj2.normal.save('django_test.txt', ContentFile('more content'))
+    >>> obj2.normal
+    <FieldFile: tests/django_test_.txt>
+
+Default values allow an object to access a single file::
+
+    >>> obj3 = MyStorage.objects.create()
+    >>> obj3.default
+    <FieldFile: tests/default.txt>
+    >>> obj3.default.read()
+    'default content'
+
+But it shouldn't be deleted, even if there are no more objects using it::
+
+    >>> obj3.delete()
+    >>> obj3 = MyStorage()
+    >>> obj3.default.read()
+    'default content'
+
+Verify the fix for #5655, making sure the directory is only determined once::
+
+    >>> obj4 = MyStorage()
+    >>> obj4.random.save('random_file', ContentFile('random content'))
+    >>> obj4.random
+    <FieldFile: .../random_file>
+
+Clean up the temporary files::
+
+    >>> obj1.normal.delete()
+    >>> obj2.normal.delete()
+    >>> obj3.default.delete()
+    >>> obj4.random.delete()

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -41,13 +41,17 @@ back to the default inferred from the environment.
 
 If True, attempt to create the bucket if it does not exist.
 
-``GS_DEFAULT_ACL`` (optional)
+``GS_AUTO_CREATE_ACL`` (optional, default is ``projectPrivate``)
 
-If set to ``private`` changes uploaded file's Access Control List from the default permission ``public-read`` to give owner full control and remove read access from everyone else. 
+ACL used when creating a new bucket, from the
+`list of predefined ACLs <https://cloud.google.com/storage/docs/access-control/lists#predefined-acl>`_.
+(A "JSON API" ACL is preferred but an "XML API/gsutil" ACL will be
+translated.)
 
-``GS_BUCKET_ACL`` (optional)
-
-ACL used when creating a new bucket; defaults to ``GS_DEFAULT_ACL``.
+Note that the ACL you select must still give the service account
+running the gcloud backend to have OWNER permission on the bucket. If
+you're using the default service account, this means you're restricted
+to the ``projectPrivate`` ACL.
 
 ``GS_FILE_CHARSET`` (optional)
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -8,10 +8,10 @@ from storages.compat import Storage
 from storages.utils import setting
 
 try:
-    from gcloud.storage.client import Client
-    from gcloud.storage.bucket import Bucket
-    from gcloud.storage.blob import Blob
-    from gcloud.exceptions import NotFound
+    from google.cloud.storage.client import Client
+    from google.cloud.storage.bucket import Bucket
+    from google.cloud.storage.blob import Blob
+    from google.cloud.exceptions import NotFound
 except ImportError:
     raise ImproperlyConfigured("Could not load Google Storage bindings.\n"
                                "See https://github.com/GoogleCloudPlatform/gcloud-python")

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -53,10 +53,11 @@ class GoogleCloudFile(File):
     def read(self, num_bytes=None):
         if 'r' not in self._mode:
             raise AttributeError("File was not opened in read mode.")
-        if num_bytes is not None:
-            return super(GoogleCloudFile, self).read(num_bytes)
-        else:
-            return super(GoogleCloudFile, self).read()
+
+        if num_bytes is None:
+            num_bytes = -1
+
+        return super(GoogleCloudFile, self).read(num_bytes)
 
     def write(self, content):
         if 'w' not in self._mode:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -5,7 +5,7 @@ from django.core.files.base import File
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, force_text, smart_str
 from storages.compat import Storage
-from storages.utils import setting
+from storages.utils import clean_name, setting
 
 try:
     from google.cloud.storage.client import Client
@@ -141,16 +141,7 @@ class GoogleCloudStorage(Storage):
         """
         Cleans the name so that Windows style paths work
         """
-        # Normalize Windows style paths
-        clean_name = name.replace('\\', '/')
-
-        # os.path.normpath() can strip trailing slashes so we implement
-        # a workaround here.
-        if name.endswith('/') and not clean_name.endswith('/'):
-            # Add a trailing slash as it was stripped.
-            return clean_name + '/'
-        else:
-            return clean_name
+        return clean_name(name)
 
     def _encode_name(self, name):
         return smart_str(name, encoding=self.file_name_charset)

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -21,7 +21,9 @@ class GoogleCloudFile(File):
         self.name = name
         self._mode = mode
         self._storage = storage
-        self.blob = Blob(self.name, storage.bucket)
+        self.blob = storage.bucket.get_blob(name)
+        if not self.blob and 'w' in mode:
+            self.blob = Blob(self.name, storage.bucket)
         self._file = None
         self._is_dirty = False
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -1,4 +1,3 @@
-import mimetypes
 from tempfile import SpooledTemporaryFile
 
 from django.core.exceptions import ImproperlyConfigured
@@ -64,10 +63,7 @@ class GoogleCloudFile(File):
         if self._file is not None:
             if self._is_dirty:
                 self.file.seek(0)
-                content_type, _ = mimetypes.guess_type(self.name)
-                content_type = getattr(self.file, 'content_type', content_type)
-                size = getattr(self.file, 'size')
-                self.blob.upload_from_file(self.file, content_type=content_type, size=size)
+                self.blob.upload_from_file(self.file)
             self._file.close()
             self._file = None
 
@@ -172,14 +168,12 @@ class GoogleCloudStorage(Storage):
     def _save(self, name, content):
         cleaned_name = self._clean_name(name)
         name = self._normalize_name(cleaned_name)
-        content_type, _ = mimetypes.guess_type(name)
-        content_type = getattr(content, 'content_type', content_type)
         size = getattr(content, 'size')
 
         content.name = cleaned_name
         encoded_name = self._encode_name(name)
         file = self.file_class(encoded_name, 'rw', self)
-        file.blob.upload_from_file(content, content_type=content_type, size=size)
+        file.blob.upload_from_file(content, size=size)
         return cleaned_name
 
     def delete(self, name):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -3,6 +3,7 @@ from tempfile import SpooledTemporaryFile
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
+from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, force_text, smart_str
 from storages.compat import Storage
 from storages.utils import setting
@@ -71,6 +72,7 @@ class GoogleCloudFile(File):
             self._file = None
 
 
+@deconstructible
 class GoogleCloudStorage(Storage):
     client_class = Client
     bucket_class = Bucket

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -13,7 +13,7 @@ try:
     from google.cloud.storage.blob import Blob
     from google.cloud.exceptions import NotFound
 except ImportError:
-    raise ImproperlyConfigured("Could not load Google Storage bindings.\n"
+    raise ImproperlyConfigured("Could not load Google Cloud Storage bindings.\n"
                                "See https://github.com/GoogleCloudPlatform/gcloud-python")
 
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -2,9 +2,9 @@ from tempfile import SpooledTemporaryFile
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
+from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, force_text, smart_str
-from storages.compat import Storage
 from storages.utils import clean_name, safe_join, setting
 
 try:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -141,7 +141,7 @@ class GoogleCloudStorage(Storage):
         name = self._normalize_name(clean_name(name))
         file_object = GoogleCloudFile(name, mode, self)
         if not file_object.blob:
-            raise IOError('File does not exist: %s' % name)
+            raise IOError(u'File does not exist: %s' % name)
         return file_object
 
     def _save(self, name, content):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -18,7 +18,7 @@ except ImportError:
 
 
 class GoogleCloudFile(File):
-    def __init__(self, name, mode, storage, buffer_size=None):
+    def __init__(self, name, mode, storage):
         self.name = name
         self._mode = mode
         self._storage = storage
@@ -197,7 +197,7 @@ class GoogleCloudStorage(Storage):
         blob = self.bucket.get_blob(name)
 
         if blob is None:
-            raise NotFound('File does not exist')
+            raise NotFound(u'File does not exist: {}'.format(name))
 
         return blob
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -50,16 +50,19 @@ class GoogleCloudFile(File):
 
     file = property(_get_file, _set_file)
 
-    def read(self, *args, **kwargs):
+    def read(self, num_bytes=None):
         if 'r' not in self._mode:
             raise AttributeError("File was not opened in read mode.")
-        return super(GoogleCloudFile, self).read(*args, **kwargs)
+        if num_bytes is not None:
+            return super(GoogleCloudFile, self).read(num_bytes)
+        else:
+            return super(GoogleCloudFile, self).read()
 
-    def write(self, content, *args, **kwargs):
+    def write(self, content):
         if 'w' not in self._mode:
             raise AttributeError("File was not opened in write mode.")
         self._is_dirty = True
-        return super(GoogleCloudFile, self).write(force_bytes(content), *args, **kwargs)
+        return super(GoogleCloudFile, self).write(force_bytes(content))
 
     def close(self):
         if self._file is not None:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -5,6 +5,7 @@ from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, force_text, smart_str
+from django.utils import timezone
 from storages.utils import clean_name, safe_join, setting
 
 try:
@@ -208,7 +209,13 @@ class GoogleCloudStorage(Storage):
     def modified_time(self, name):
         name = self._normalize_name(clean_name(name))
         blob = self._get_blob(self._encode_name(name))
-        return blob.updated
+        return timezone.make_naive(blob.updated)
+
+    def get_modified_time(self, name):
+        name = self._normalize_name(clean_name(name))
+        blob = self._get_blob(self._encode_name(name))
+        updated = blob.updated
+        return updated if setting('USE_TZ') else timezone.make_naive(updated)
 
     def url(self, name):
         # Preserve the trailing slash after normalizing the path.

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -145,9 +145,6 @@ class GoogleCloudStorage(Storage):
     def _encode_name(self, name):
         return smart_str(name, encoding=self.file_name_charset)
 
-    def _decode_name(self, name):
-        return force_text(name, encoding=self.file_name_charset)
-
     def _open(self, name, mode='rb'):
         name = self._normalize_name(self._clean_name(name))
         file_object = self.file_class(name, mode, self)

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -79,8 +79,7 @@ class GoogleCloudStorage(Storage):
     credentials = setting('GS_CREDENTIALS', None)
     bucket_name = setting('GS_BUCKET_NAME', None)
     auto_create_bucket = setting('GS_AUTO_CREATE_BUCKET', False)
-    default_acl = setting('GS_DEFAULT_ACL', 'public-read')
-    bucket_acl = setting('GS_BUCKET_ACL', default_acl)
+    auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
     # The max amount of memory a returned file can take up before being
@@ -121,8 +120,7 @@ class GoogleCloudStorage(Storage):
         except NotFound:
             if self.auto_create_bucket:
                 bucket = self.client.create_bucket(name)
-                bucket.acl.all().grant(self.bucket_acl)
-                bucket.acl.save()
+                bucket.acl.save_predefined(self.auto_create_acl)
                 return bucket
             raise ImproperlyConfigured("Bucket %s does not exist. Buckets "
                                        "can be automatically created by "

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -9,7 +9,6 @@ from storages.utils import clean_name, setting
 
 try:
     from google.cloud.storage.client import Client
-    from google.cloud.storage.bucket import Bucket
     from google.cloud.storage.blob import Blob
     from google.cloud.exceptions import NotFound
 except ImportError:
@@ -71,7 +70,6 @@ class GoogleCloudFile(File):
 @deconstructible
 class GoogleCloudStorage(Storage):
     client_class = Client
-    bucket_class = Bucket
     file_class = GoogleCloudFile
 
     not_found_exception = NotFound

--- a/storages/backends/google.py
+++ b/storages/backends/google.py
@@ -1,0 +1,241 @@
+import mimetypes
+from tempfile import SpooledTemporaryFile
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import File
+from django.utils.encoding import force_bytes, force_text, smart_str
+from storages.compat import Storage
+from storages.utils import setting
+
+try:
+    from gcloud.storage.client import Client
+    from gcloud.storage.bucket import Bucket
+    from gcloud.storage.blob import Blob
+    from gcloud.exceptions import NotFound
+except ImportError:
+    raise ImproperlyConfigured("Could not load Google Storage bindings.\n"
+                               "See https://github.com/GoogleCloudPlatform/gcloud-python")
+
+
+class GoogleCloudFile(File):
+    def __init__(self, name, mode, storage, buffer_size=None):
+        self.name = name
+        self._mode = mode
+        self._storage = storage
+        self.blob = Blob(self.name, storage.bucket)
+        self._file = None
+        self._is_dirty = False
+
+    @property
+    def size(self):
+        return self.blob.size
+
+    def _get_file(self):
+        if self._file is None:
+            self._file = SpooledTemporaryFile(
+                max_size=self._storage.max_memory_size,
+                suffix=".GSStorageFile",
+                dir=setting("FILE_UPLOAD_TEMP_DIR", None)
+            )
+            if 'r' in self._mode:
+                self._is_dirty = False
+                self.blob.download_to_file(self._file)
+                self._file.seek(0)
+        return self._file
+
+    def _set_file(self, value):
+        self._file = value
+
+    file = property(_get_file, _set_file)
+
+    def read(self, *args, **kwargs):
+        if 'r' not in self._mode:
+            raise AttributeError("File was not opened in read mode.")
+        return super(GoogleCloudFile, self).read(*args, **kwargs)
+
+    def write(self, content, *args, **kwargs):
+        if 'w' not in self._mode:
+            raise AttributeError("File was not opened in write mode.")
+        self._is_dirty = True
+        return super(GoogleCloudFile, self).write(force_bytes(content), *args, **kwargs)
+
+    def close(self):
+        if self._file is not None:
+            if self._is_dirty:
+                self.file.seek(0)
+                content_type, _ = mimetypes.guess_type(self.name)
+                content_type = getattr(self.file, 'content_type', content_type)
+                size = getattr(self.file, 'size')
+                self.blob.upload_from_file(self.file, content_type=content_type, size=size)
+            self._file.close()
+            self._file = None
+
+
+class GoogleCloudStorage(Storage):
+    client_class = Client
+    bucket_class = Bucket
+    file_class = GoogleCloudFile
+
+    not_found_exception = NotFound
+
+    project_id = setting('GS_PROJECT_ID', None)
+    credentials = setting('GS_CREDENTIALS', None)
+    bucket_name = setting('GS_BUCKET_NAME', None)
+    auto_create_bucket = setting('GS_AUTO_CREATE_BUCKET', False)
+    default_acl = setting('GS_DEFAULT_ACL', 'public-read')
+    bucket_acl = setting('GS_BUCKET_ACL', default_acl)
+    file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
+    file_overwrite = setting('GS_FILE_OVERWRITE', True)
+    # The max amount of memory a returned file can take up before being
+    # rolled over into a temporary file on disk. Default is 0: Do not roll over.
+    max_memory_size = setting('GS_MAX_MEMORY_SIZE', 0)
+
+    def __init__(self, **settings):
+        # check if some of the settings we've provided as class attributes
+        # need to be overwritten with values passed in here
+        for name, value in settings.items():
+            if hasattr(self, name):
+                setattr(self, name, value)
+
+        self._bucket = None
+        self._client = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            self._client = self.client_class(
+                project=self.project_id,
+                credentials=self.credentials
+            )
+        return self._client
+
+    @property
+    def bucket(self):
+        if self._bucket is None:
+            self._bucket = self._get_or_create_bucket(self.bucket_name)
+        return self._bucket
+
+    def _get_or_create_bucket(self, name):
+        """
+        Retrieves a bucket if it exists, otherwise creates it.
+        """
+        try:
+            return self.client.get_bucket(name)
+        except self.not_found_exception:
+            if self.auto_create_bucket:
+                bucket = self.client.create_bucket(name)
+                bucket.acl.all().grant(self.bucket_acl)
+                bucket.acl.save()
+                return bucket
+            raise ImproperlyConfigured("Bucket %s does not exist. Buckets "
+                                       "can be automatically created by "
+                                       "setting GS_AUTO_CREATE_BUCKET to "
+                                       "``True``." % name)
+
+    def _normalize_name(self, name):
+        """
+        No normalizing supported. This can be implemented later.
+        TODO: Implement normalizing, like the s3boto backend.
+        """
+        return name
+
+    def _clean_name(self, name):
+        """
+        Cleans the name so that Windows style paths work
+        """
+        # Normalize Windows style paths
+        clean_name = name.replace('\\', '/')
+
+        # os.path.normpath() can strip trailing slashes so we implement
+        # a workaround here.
+        if name.endswith('/') and not clean_name.endswith('/'):
+            # Add a trailing slash as it was stripped.
+            return clean_name + '/'
+        else:
+            return clean_name
+
+    def _encode_name(self, name):
+        return smart_str(name, encoding=self.file_name_charset)
+
+    def _decode_name(self, name):
+        return force_text(name, encoding=self.file_name_charset)
+
+    def _open(self, name, mode='rb'):
+        name = self._normalize_name(self._clean_name(name))
+        file_object = self.file_class(name, mode, self)
+        if not file_object.blob:
+            raise IOError('File does not exist: %s' % name)
+        return file_object
+
+    def _save(self, name, content):
+        cleaned_name = self._clean_name(name)
+        name = self._normalize_name(cleaned_name)
+        content_type, _ = mimetypes.guess_type(name)
+        content_type = getattr(content, 'content_type', content_type)
+        size = getattr(content, 'size')
+
+        content.name = cleaned_name
+        encoded_name = self._encode_name(name)
+        file = self.file_class(encoded_name, 'rw', self)
+        file.blob.upload_from_file(content, content_type=content_type, size=size)
+        return cleaned_name
+
+    def delete(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        self.bucket.delete_blob(self._encode_name(name))
+
+    def exists(self, name):
+        if not name:  # root element aka the bucket
+            try:
+                self.bucket
+                return True
+            except ImproperlyConfigured:
+                return False
+
+        name = self._normalize_name(self._clean_name(name))
+        return bool(self.bucket.get_blob(self._encode_name(name)))
+
+    def listdir(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        # for the bucket.list and logic below name needs to end in /
+        # But for the root path "" we leave it as an empty string
+        if name and not name.endswith('/'):
+            name += '/'
+
+        files_list = list(self.bucket.list_blobs(prefix=self._encode_name(name)))
+        files = []
+        dirs = set()
+
+        base_parts = name.split("/")[:-1]
+        for item in files_list:
+            parts = item.name.split("/")
+            parts = parts[len(base_parts):]
+            if len(parts) == 1 and parts[0]:
+                # File
+                files.append(parts[0])
+            elif len(parts) > 1 and parts[0]:
+                # Directory
+                dirs.add(parts[0])
+        return list(dirs), files
+
+    def size(self, name):
+        name = self._encode_name(self._normalize_name(self._clean_name(name)))
+        blob = self.bucket.get_blob(self._encode_name(name))
+        return blob.size if blob else 0
+
+    def modified_time(self, name):
+        name = self._normalize_name(self._clean_name(name))
+        blob = self.bucket.get_blob(self._encode_name(name))
+        return blob.updated if blob else None
+
+    def url(self, name):
+        # Preserve the trailing slash after normalizing the path.
+        name = self._normalize_name(self._clean_name(name))
+        blob = self.bucket.get_blob(self._encode_name(name))
+        return blob.public_url if blob else None
+
+    def get_available_name(self, name, max_length=None):
+        if self.file_overwrite:
+            name = self._clean_name(name)
+            return name
+        return super(GoogleCloudStorage, self).get_available_name(name, max_length)

--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -1,3 +1,13 @@
+# DEPRECATION NOTICE: This backend is deprecated in favour of the
+# "gcloud" backend.  This backend uses Google Cloud Storage's XML
+# Interoperable API which uses keyed-hash message authentication code
+# (a.k.a. developer keys) that are linked to your Google account.  The
+# interoperable API is really meant for migration to Google Cloud
+# Storage. The biggest problem with the developer keys is security and
+# privacy. Developer keys should not be shared with anyone as they can
+# be used to gain access to other Google Cloud Storage buckets linked
+# to your Google account.
+
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.deconstruct import deconstructible
 from django.utils.six import BytesIO

--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -1,12 +1,13 @@
-# DEPRECATION NOTICE: This backend is deprecated in favour of the
-# "gcloud" backend.  This backend uses Google Cloud Storage's XML
-# Interoperable API which uses keyed-hash message authentication code
-# (a.k.a. developer keys) that are linked to your Google account.  The
-# interoperable API is really meant for migration to Google Cloud
-# Storage. The biggest problem with the developer keys is security and
-# privacy. Developer keys should not be shared with anyone as they can
-# be used to gain access to other Google Cloud Storage buckets linked
-# to your Google account.
+import warnings
+warnings.warn("DEPRECATION NOTICE: This backend is deprecated in favour of the "
+              "\"gcloud\" backend.  This backend uses Google Cloud Storage's XML "
+              "Interoperable API which uses keyed-hash message authentication code "
+              "(a.k.a. developer keys) that are linked to your Google account.  The "
+              "interoperable API is really meant for migration to Google Cloud "
+              "Storage.  The biggest problem with the developer keys is security and "
+              "privacy.  Developer keys should not be shared with anyone as they can "
+              "be used to gain access to other Google Cloud Storage buckets linked "
+              "to your Google account.")
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.deconstruct import deconstructible

--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -7,7 +7,7 @@ warnings.warn("DEPRECATION NOTICE: This backend is deprecated in favour of the "
               "Storage.  The biggest problem with the developer keys is security and "
               "privacy.  Developer keys should not be shared with anyone as they can "
               "be used to gain access to other Google Cloud Storage buckets linked "
-              "to your Google account.")
+              "to your Google account.", DeprecationWarning)
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.deconstruct import deconstructible

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -1,5 +1,4 @@
 import os
-import posixpath
 import mimetypes
 from datetime import datetime
 from gzip import GzipFile
@@ -24,7 +23,7 @@ except ImportError:
     raise ImproperlyConfigured("Could not load Boto's S3 bindings.\n"
                                "See https://github.com/boto/boto")
 
-from storages.utils import setting
+from storages.utils import clean_name, setting
 
 boto_version_info = tuple([int(i) for i in boto_version.split('-')[0].split('.')])
 
@@ -348,15 +347,7 @@ class S3BotoStorage(Storage):
         """
         Cleans the name so that Windows style paths work
         """
-        # Normalize Windows style paths
-        clean_name = posixpath.normpath(name).replace('\\', '/')
-
-        # os.path.normpath() can strip trailing slashes so we implement
-        # a workaround here.
-        if name.endswith('/') and not clean_name.endswith('/'):
-            # Add a trailing slash as it was stripped.
-            clean_name += '/'
-        return clean_name
+        return clean_name(name)
 
     def _normalize_name(self, name):
         """

--- a/storages/utils.py
+++ b/storages/utils.py
@@ -2,6 +2,8 @@ import posixpath
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.encoding import force_text
+from django.utils.six.moves.urllib import parse as urlparse
 
 
 def setting(name, default=None, strict=False):
@@ -35,6 +37,43 @@ def clean_name(name):
     # a workaround here.
     if name.endswith('/') and not clean_name.endswith('/'):
         # Add a trailing slash as it was stripped.
-        return clean_name + '/'
-    else:
-        return clean_name
+        clean_name = clean_name + '/'
+
+    # Given an empty string, os.path.normpath() will return ., which we don't want
+    if clean_name == '.':
+        clean_name = ''
+
+    return clean_name
+
+
+def safe_join(base, *paths):
+    """
+    A version of django.utils._os.safe_join for S3 paths.
+
+    Joins one or more path components to the base path component
+    intelligently. Returns a normalized version of the final path.
+
+    The final path must be located inside of the base path component
+    (otherwise a ValueError is raised).
+
+    Paths outside the base path indicate a possible security
+    sensitive operation.
+    """
+    base_path = force_text(base)
+    base_path = base_path.rstrip('/')
+    paths = [force_text(p) for p in paths]
+
+    final_path = base_path
+    for path in paths:
+        final_path = urlparse.urljoin(final_path.rstrip('/') + '/', path)
+
+    # Ensure final_path starts with base_path and that the next character after
+    # the final path is '/' (or nothing, in which case final_path must be
+    # equal to base_path).
+    base_path_len = len(base_path)
+    if (not final_path.startswith(base_path) or
+            final_path[base_path_len:base_path_len + 1] not in ('', '/')):
+        raise ValueError('the joined path is located outside of the base path'
+                         ' component')
+
+    return final_path.lstrip('/')

--- a/storages/utils.py
+++ b/storages/utils.py
@@ -1,3 +1,5 @@
+import posixpath
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -20,3 +22,19 @@ def setting(name, default=None, strict=False):
         msg = "You must provide settings.%s" % name
         raise ImproperlyConfigured(msg)
     return getattr(settings, name, default)
+
+
+def clean_name(name):
+    """
+    Cleans the name so that Windows style paths work
+    """
+    # Normalize Windows style paths
+    clean_name = posixpath.normpath(name).replace('\\', '/')
+
+    # os.path.normpath() can strip trailing slashes so we implement
+    # a workaround here.
+    if name.endswith('/') and not clean_name.endswith('/'):
+        # Add a trailing slash as it was stripped.
+        return clean_name + '/'
+    else:
+        return clean_name

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -37,7 +37,7 @@ class GCloudStorageTests(GCloudTestCase):
         """
         Test opening a file and reading from it
         """
-        data = 'This is some test read data.'
+        data = b'This is some test read data.'
 
         f = self.storage.open(self.filename)
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -1,0 +1,210 @@
+try:
+    from unittest import mock
+except ImportError:  # Python 3.2 and below
+    import mock
+
+import datetime
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import ContentFile
+from django.test import TestCase
+
+from google.cloud.storage.blob import Blob
+
+from storages.backends import gcloud
+
+
+class GCloudTestCase(TestCase):
+    def setUp(self):
+        self.bucket_name = 'test_bucket'
+        self.filename = 'test_file.txt'
+
+        self.storage = gcloud.GoogleCloudStorage(bucket_name=self.bucket_name)
+        self.storage.client_class = mock.MagicMock
+
+
+class GCloudStorageTests(GCloudTestCase):
+
+    def test_clean_name(self):
+        """
+        Test the base case of _clean_name - more tests are performed in
+        test_utils
+        """
+        path = self.storage._clean_name("path/to/somewhere")
+        self.assertEqual(path, "path/to/somewhere")
+
+    def test_open_read(self):
+        """
+        Test opening a file and reading from it
+        """
+        data = 'This is some test read data.'
+
+        f = self.storage.open(self.filename)
+        self.storage._client.get_bucket.assert_called_with(self.bucket_name)
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+        f.blob.download_to_file = lambda tmpfile: tmpfile.write(data)
+        self.assertEqual(f.read(), data)
+
+    def test_open_read_nonexistent(self):
+        self.storage._bucket = mock.MagicMock()
+        self.storage._bucket.get_blob.return_value = None
+
+        self.assertRaises(IOError, self.storage.open, self.filename)
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+    @mock.patch('storages.backends.gcloud.Blob')
+    def test_open_write(self, MockBlob):
+        """
+        Test opening a file and writing to it
+        """
+        data = 'This is some test write data.'
+
+        # Simulate the file not existing before the write
+        self.storage._bucket = mock.MagicMock()
+        self.storage._bucket.get_blob.return_value = None
+
+        f = self.storage.open(self.filename, 'wb')
+        MockBlob.assert_called_with(self.filename, self.storage._bucket)
+
+        f.write(data)
+        tmpfile = f._file
+        # File data is not actually written until close(), so do that.
+        f.close()
+
+        MockBlob().upload_from_file.assert_called_with(tmpfile)
+
+    def test_save(self):
+        data = 'This is some test content.'
+        content = ContentFile(data)
+
+        self.storage.save(self.filename, content)
+
+        self.storage._client.get_bucket.assert_called_with(self.bucket_name)
+        self.storage._bucket.get_blob().upload_from_file.assert_called_with(
+            content, size=len(data))
+
+    def test_delete(self):
+        self.storage.delete(self.filename)
+
+        self.storage._client.get_bucket.assert_called_with(self.bucket_name)
+        self.storage._bucket.delete_blob.assert_called_with(self.filename)
+
+    def test_exists(self):
+        self.storage._bucket = mock.MagicMock()
+        self.assertTrue(self.storage.exists(self.filename))
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+        self.storage._bucket.reset_mock()
+        self.storage._bucket.get_blob.return_value = None
+        self.assertFalse(self.storage.exists(self.filename))
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+    def test_exists_no_bucket(self):
+        # exists('') should return False if the bucket doesn't exist
+        self.storage._client = mock.MagicMock()
+        self.storage._client.get_bucket.side_effect = self.storage.not_found_exception(
+            'dang')
+        self.assertFalse(self.storage.exists(''))
+
+    def test_exists_bucket(self):
+        # exists('') should return True if the bucket exists
+        self.assertTrue(self.storage.exists(''))
+
+    def test_exists_bucket_auto_create(self):
+        # exists('') should automatically create the bucket if
+        # auto_create_bucket is configured
+        self.storage.auto_create_bucket = True
+        self.storage._client = mock.MagicMock()
+        self.storage._client.get_bucket.side_effect = self.storage.not_found_exception(
+            'dang')
+
+        self.assertTrue(self.storage.exists(''))
+        self.storage._client.create_bucket.assert_called_with(self.bucket_name)
+
+    def test_listdir(self):
+        file_names = ["some/path/1.txt", "2.txt", "other/path/3.txt", "4.txt"]
+
+        self.storage._bucket = mock.MagicMock()
+        self.storage._bucket.list_blobs.return_value = []
+        for name in file_names:
+            blob = mock.MagicMock(spec=Blob)
+            blob.name = name
+            self.storage._bucket.list_blobs.return_value.append(blob)
+
+        dirs, files = self.storage.listdir('')
+
+        self.assertEqual(len(dirs), 2)
+        for directory in ["some", "other"]:
+            self.assertTrue(directory in dirs,
+                            """ "%s" not in directory list "%s".""" % (
+                                directory, dirs))
+
+        self.assertEqual(len(files), 2)
+        for filename in ["2.txt", "4.txt"]:
+            self.assertTrue(filename in files,
+                            """ "%s" not in file list "%s".""" % (
+                                filename, files))
+
+    def test_listdir_subdir(self):
+        file_names = ["some/path/1.txt", "some/2.txt"]
+
+        self.storage._bucket = mock.MagicMock()
+        self.storage._bucket.list_blobs.return_value = []
+        for name in file_names:
+            blob = mock.MagicMock(spec=Blob)
+            blob.name = name
+            self.storage._bucket.list_blobs.return_value.append(blob)
+
+        dirs, files = self.storage.listdir('some/')
+
+        self.assertEqual(len(dirs), 1)
+        self.assertTrue('path' in dirs,
+                        """ "path" not in directory list "%s".""" % (dirs,))
+
+        self.assertEqual(len(files), 1)
+        self.assertTrue('2.txt' in files,
+                        """ "2.txt" not in files list "%s".""" % (files,))
+
+    def test_size(self):
+        size = 1234
+
+        self.storage._bucket = mock.MagicMock()
+        blob = mock.MagicMock()
+        blob.size = size
+        self.storage._bucket.get_blob.return_value = blob
+
+        self.assertEqual(self.storage.size(self.filename), size)
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+    def test_modified_time(self):
+        date = datetime.datetime(2017, 1, 2, 3, 4, 5, 678)
+
+        self.storage._bucket = mock.MagicMock()
+        blob = mock.MagicMock()
+        blob.updated = date
+        self.storage._bucket.get_blob.return_value = blob
+
+        self.assertEqual(self.storage.modified_time(self.filename), date)
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+    def test_url(self):
+        url = 'https://example.com/mah-bukkit/{}'.format(self.filename)
+
+        self.storage._bucket = mock.MagicMock()
+        blob = mock.MagicMock()
+        blob.public_url = url
+        self.storage._bucket.get_blob.return_value = blob
+
+        self.assertEqual(self.storage.url(self.filename), url)
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+    def test_get_available_name(self):
+        self.storage.file_overwrite = True
+        self.assertEqual(self.storage.get_available_name(self.filename), self.filename)
+
+        self.storage._bucket = mock.MagicMock()
+        self.storage._bucket.get_blob.return_value = None
+        self.storage.file_overwrite = False
+        self.assertEqual(self.storage.get_available_name(self.filename), self.filename)
+        self.storage._bucket.get_blob.assert_called_with(self.filename)

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -47,6 +47,17 @@ class GCloudStorageTests(GCloudTestCase):
         f.blob.download_to_file = lambda tmpfile: tmpfile.write(data)
         self.assertEqual(f.read(), data)
 
+    def test_open_read_num_bytes(self):
+        data = b'This is some test read data.'
+        num_bytes = 10
+
+        f = self.storage.open(self.filename)
+        self.storage._client.get_bucket.assert_called_with(self.bucket_name)
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
+        f.blob.download_to_file = lambda tmpfile: tmpfile.write(data)
+        self.assertEqual(f.read(num_bytes), data[0:num_bytes])
+
     def test_open_read_nonexistent(self):
         self.storage._bucket = mock.MagicMock()
         self.storage._bucket.get_blob.return_value = None

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -70,30 +70,10 @@ class S3BotoStorageTests(S3BotoTestCase):
 
     def test_clean_name(self):
         """
-        Test the base case of _clean_name
+        Test the base case of _clean_name - more tests are performed in
+        test_utils
         """
         path = self.storage._clean_name("path/to/somewhere")
-        self.assertEqual(path, "path/to/somewhere")
-
-    def test_clean_name_normalize(self):
-        """
-        Test the normalization of _clean_name
-        """
-        path = self.storage._clean_name("path/to/../somewhere")
-        self.assertEqual(path, "path/somewhere")
-
-    def test_clean_name_trailing_slash(self):
-        """
-        Test the _clean_name when the path has a trailing slash
-        """
-        path = self.storage._clean_name("path/to/somewhere/")
-        self.assertEqual(path, "path/to/somewhere/")
-
-    def test_clean_name_windows(self):
-        """
-        Test the _clean_name when the path has a trailing slash
-        """
-        path = self.storage._clean_name("path\\to\\somewhere")
         self.assertEqual(path, "path/to/somewhere")
 
     def test_storage_url_slashes(self):

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -17,7 +17,6 @@ from boto.utils import parse_ts, ISO8601
 from storages.backends import s3boto
 
 __all__ = (
-    'SafeJoinTest',
     'S3BotoStorageTests',
 )
 
@@ -27,43 +26,6 @@ class S3BotoTestCase(TestCase):
     def setUp(self, S3Connection):
         self.storage = s3boto.S3BotoStorage()
         self.storage._connection = mock.MagicMock()
-
-
-class SafeJoinTest(TestCase):
-    def test_normal(self):
-        path = s3boto.safe_join("", "path/to/somewhere", "other", "path/to/somewhere")
-        self.assertEqual(path, "path/to/somewhere/other/path/to/somewhere")
-
-    def test_with_dot(self):
-        path = s3boto.safe_join("", "path/./somewhere/../other", "..",
-                                ".", "to/./somewhere")
-        self.assertEqual(path, "path/to/somewhere")
-
-    def test_base_url(self):
-        path = s3boto.safe_join("base_url", "path/to/somewhere")
-        self.assertEqual(path, "base_url/path/to/somewhere")
-
-    def test_base_url_with_slash(self):
-        path = s3boto.safe_join("base_url/", "path/to/somewhere")
-        self.assertEqual(path, "base_url/path/to/somewhere")
-
-    def test_suspicious_operation(self):
-        self.assertRaises(ValueError,
-                          s3boto.safe_join, "base", "../../../../../../../etc/passwd")
-
-    def test_trailing_slash(self):
-        """
-        Test safe_join with paths that end with a trailing slash.
-        """
-        path = s3boto.safe_join("base_url/", "path/to/somewhere/")
-        self.assertEqual(path, "base_url/path/to/somewhere/")
-
-    def test_trailing_slash_multi(self):
-        """
-        Test safe_join with multiple paths that end with a trailing slash.
-        """
-        path = s3boto.safe_join("base_url/", "path/to/" "somewhere/")
-        self.assertEqual(path, "base_url/path/to/somewhere/")
 
 
 class S3BotoStorageTests(S3BotoTestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,3 +44,40 @@ class CleanNameTests(TestCase):
         """
         path = utils.clean_name("path\\to\\somewhere")
         self.assertEqual(path, "path/to/somewhere")
+
+
+class SafeJoinTest(TestCase):
+    def test_normal(self):
+        path = utils.safe_join("", "path/to/somewhere", "other", "path/to/somewhere")
+        self.assertEqual(path, "path/to/somewhere/other/path/to/somewhere")
+
+    def test_with_dot(self):
+        path = utils.safe_join("", "path/./somewhere/../other", "..",
+                                ".", "to/./somewhere")
+        self.assertEqual(path, "path/to/somewhere")
+
+    def test_base_url(self):
+        path = utils.safe_join("base_url", "path/to/somewhere")
+        self.assertEqual(path, "base_url/path/to/somewhere")
+
+    def test_base_url_with_slash(self):
+        path = utils.safe_join("base_url/", "path/to/somewhere")
+        self.assertEqual(path, "base_url/path/to/somewhere")
+
+    def test_suspicious_operation(self):
+        self.assertRaises(ValueError,
+                          utils.safe_join, "base", "../../../../../../../etc/passwd")
+
+    def test_trailing_slash(self):
+        """
+        Test safe_join with paths that end with a trailing slash.
+        """
+        path = utils.safe_join("base_url/", "path/to/somewhere/")
+        self.assertEqual(path, "base_url/path/to/somewhere/")
+
+    def test_trailing_slash_multi(self):
+        """
+        Test safe_join with multiple paths that end with a trailing slash.
+        """
+        path = utils.safe_join("base_url/", "path/to/" "somewhere/")
+        self.assertEqual(path, "base_url/path/to/somewhere/")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,3 +14,33 @@ class SettingTest(TestCase):
         self.assertEqual(utils.setting('FOO', 'bar'), 'bar')
         with self.assertRaises(ImproperlyConfigured):
             utils.setting('FOO', strict=True)
+
+
+class CleanNameTests(TestCase):
+    def test_clean_name(self):
+        """
+        Test the base case of clean_name
+        """
+        path = utils.clean_name("path/to/somewhere")
+        self.assertEqual(path, "path/to/somewhere")
+
+    def test_clean_name_normalize(self):
+        """
+        Test the normalization of clean_name
+        """
+        path = utils.clean_name("path/to/../somewhere")
+        self.assertEqual(path, "path/somewhere")
+
+    def test_clean_name_trailing_slash(self):
+        """
+        Test the clean_name when the path has a trailing slash
+        """
+        path = utils.clean_name("path/to/somewhere/")
+        self.assertEqual(path, "path/to/somewhere/")
+
+    def test_clean_name_windows(self):
+        """
+        Test the clean_name when the path has a trailing slash
+        """
+        path = utils.clean_name("path\\to\\somewhere")
+        self.assertEqual(path, "path/to/somewhere")

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,4 @@ deps =
     boto3>=1.2.3
     dropbox>=3.24
     paramiko
+    google-cloud-storage>=0.22.0


### PR DESCRIPTION
Based on https://github.com/jschneier/django-storages/pull/146

This uses the native `gcloud-python` library, which is recommended by Google for production setups and allows finer-grained authentication than current solutions (which only work when Google Cloud Storage is used in S3 compatibility mode).

* [x] Review code (see: https://github.com/jschneier/django-storages/pull/146#issuecomment-266873319)
* [x] Add tests
* [x] Add documentation