### PR TITLE
Remove unnecessary '-' parsing from boto3 version

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -24,7 +24,7 @@ except ImportError:
 
 from storages.utils import setting
 
-boto3_version_info = tuple([int(i) for i in boto3_version.split('-')[0].split('.')])
+boto3_version_info = tuple([int(i) for i in boto3_version.split('.')])
 
 if boto3_version_info[:2] < (1, 2):
     raise ImproperlyConfigured("The installed Boto3 library must be 1.2.0 or "


### PR DESCRIPTION
boto3 version has never contained a '-'. Likely copied over from boto which did
use '-' at one time.