### PR TITLE
Fix S3Boto3Storage to avoid race conditions in a multi-threaded WSGI environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ django-storages change log
 ******************
 
 * Actually use ``SFTP_STORAGE_HOST`` in ``SFTPStorage`` backend (`#204`_ thanks @jbittel)
+* Fix ``S3Boto3Storage`` to avoid race conditions in a multi-threaded WSGI environment
 
 .. _#204: https://github.com/jschneier/django-storages/pull/204
 

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -14,7 +14,7 @@ from django.utils.six import BytesIO
 from django.utils.timezone import localtime
 
 try:
-    from boto3 import resource
+    import boto3.session
     from boto3 import __version__ as boto3_version
     from botocore.client import Config
     from botocore.exceptions import ClientError
@@ -199,7 +199,6 @@ class S3Boto3Storage(Storage):
     mode and supports streaming(buffering) data in chunks to S3
     when writing.
     """
-    connection_class = staticmethod(resource)
     connection_service_name = 's3'
     default_content_type = 'application/octet-stream'
     connection_response_error = ClientError
@@ -285,7 +284,8 @@ class S3Boto3Storage(Storage):
         # urllib/requests libraries read. See https://github.com/boto/boto3/issues/338
         # and http://docs.python-requests.org/en/latest/user/advanced/#proxies
         if self._connection is None:
-            self._connection = self.connection_class(
+            session = boto3.session.Session()
+            self._connection = session.resource(
                 self.connection_service_name,
                 aws_access_key_id=self.access_key,
                 aws_secret_access_key=self.secret_key,

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -21,8 +21,7 @@ __all__ = (
 
 
 class S3Boto3TestCase(TestCase):
-    @mock.patch('storages.backends.s3boto3.resource')
-    def setUp(self, resource):
+    def setUp(self):
         self.storage = s3boto3.S3Boto3Storage()
         self.storage._connection = mock.MagicMock()
 


### PR DESCRIPTION
Use a different boto3 session for each instance of the S3 connection.

---

Resurrecting from PR #200 as upstream does not appear to be moving on a change. This fixes the race as far as django-storages is concerned.