### PR TITLE
Allow newer versions of pytest-cov for tests

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,5 +1,5 @@
 Django>=1.7
-pytest-cov==2.2.1
+pytest-cov>=2.2.1
 boto>=2.32.0
 boto3>=1.2.3
 dropbox>=3.24

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     django110: Django>=1.10, <1.11
     py27: mock==1.0.1
     boto>=2.32.0
-    pytest-cov==2.2.1
+    pytest-cov>=2.2.1
     boto3>=1.2.3
     dropbox>=3.24
     paramiko


### PR DESCRIPTION
Newer version has removed deprecated code. Fixes deprecation warning when running tests with warnings enabled like:

```
.../django-storages/lib64/python3.5/site-packages/pytest_cov/plugin.py:37: DeprecationWarning: type argument to addoption() is a string 'int'. For parsearg this should be a type. (options: ('--cov-fail-under',))
  help='Fail if the total coverage is less than MIN.')
```