### PR TITLE
Improve syntax of docs

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -14,63 +14,52 @@ To use s3boto set::
 
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
-``AWS_ACCESS_KEY_ID``
-
-Your Amazon Web Services access key, as a string.
-
-``AWS_SECRET_ACCESS_KEY``
-
-Your Amazon Web Services secret access key, as a string.
-
-``AWS_STORAGE_BUCKET_NAME``
-
-Your Amazon Web Services storage bucket name, as a string.
-
-``AWS_DEFAULT_ACL`` (optional)
-
-If set to ``private`` changes uploaded file's Access Control List from the default permission ``public-read`` to give owner full control and remove read access from everyone else. 
-
-``AWS_AUTO_CREATE_BUCKET`` (optional)
-
-If set to ``True`` the bucket specified in ``AWS_STORAGE_BUCKET_NAME`` is automatically created.
-
-
-``AWS_HEADERS`` (optional)
-
-If you'd like to set headers sent with each file of the storage::
-
-    # see http://developer.yahoo.com/performance/rules.html#expires
-    AWS_HEADERS = {
-        'Expires': 'Thu, 15 Apr 2010 20:00:00 GMT',
-        'Cache-Control': 'max-age=86400',
-    }
-
-``AWS_QUERYSTRING_AUTH`` (optional; default is ``True``)
-
-Setting ``AWS_QUERYSTRING_AUTH`` to ``False`` removes `query parameter
-authentication`_ from generated URLs. This can be useful if your S3 buckets are
-public.
-
-``AWS_QUERYSTRING_EXPIRE`` (optional; default is 3600 seconds)
-
-The number of seconds that a generated URL with `query parameter
-authentication`_ is valid for.
-
-
 To allow ``django-admin.py`` collectstatic to automatically put your static files in your bucket set the following in your settings.py::
 
     STATICFILES_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
 
+Available are numerous settings. It should be especially noted the following:
 
-.. _query parameter authentication: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
+``AWS_ACCESS_KEY_ID``
+    Your Amazon Web Services access key, as a string.
+
+``AWS_SECRET_ACCESS_KEY``
+    Your Amazon Web Services secret access key, as a string.
+
+``AWS_STORAGE_BUCKET_NAME``
+    Your Amazon Web Services storage bucket name, as a string.
+
+``AWS_DEFAULT_ACL`` (optional)
+    If set to ``private`` changes uploaded file's Access Control List from the default permission ``public-read`` to give owner full control and remove read access from everyone else. 
+
+``AWS_AUTO_CREATE_BUCKET`` (optional)
+    If set to ``True`` the bucket specified in ``AWS_STORAGE_BUCKET_NAME`` is automatically created.
+
+``AWS_HEADERS`` (optional)
+    If you'd like to set headers sent with each file of the storage::
+
+        # see http://developer.yahoo.com/performance/rules.html#expires
+        AWS_HEADERS = {
+            'Expires': 'Thu, 15 Apr 2010 20:00:00 GMT',
+            'Cache-Control': 'max-age=86400',
+        }
+
+``AWS_QUERYSTRING_AUTH`` (optional; default is ``True``)
+    Setting ``AWS_QUERYSTRING_AUTH`` to ``False`` removes `query parameter
+    authentication`_ from generated URLs. This can be useful if your S3 buckets are
+    public.
+
+``AWS_QUERYSTRING_EXPIRE`` (optional; default is 3600 seconds)
+    The number of seconds that a generated URL with `query parameter
+    authentication`_ is valid for.
 
 ``AWS_S3_ENCRYPTION`` (optional; default is ``False``)
-
-Enable server-side file encryption while at rest, by setting ``encrypt_key`` parameter to True. More info available here: http://boto.cloudhackers.com/en/latest/ref/s3.html
+    Enable server-side file encryption while at rest, by setting ``encrypt_key`` parameter to True. More info available here: http://boto.cloudhackers.com/en/latest/ref/s3.html
 
 ``AWS_S3_FILE_OVERWRITE`` (optional: default is ``True``)
+    By default files with the same name will overwrite each other. Set this to ``False`` to have extra characters appended.
 
-By default files with the same name will overwrite each other. Set this to ``False`` to have extra characters appended.
+.. _query parameter authentication: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html
 
 CloudFront
 ~~~~~~~~~~

--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -17,24 +17,23 @@ Add to your requirements file::
 Settings
 *******
 
-``DEFAULT_FILE_STORAGE``
-
-This setting sets the path to the Azure storage class::
+To use `AzureStorage` set::
 
     DEFAULT_FILE_STORAGE = 'storages.backends.azure_storage.AzureStorage'
 
+The following settings are available:
 
 ``AZURE_ACCOUNT_NAME``
 
-This setting is the Windows Azure Storage Account name, which in many cases is also the first part of the url for instance: http://azure_account_name.blob.core.windows.net/ would mean::
+    This setting is the Windows Azure Storage Account name, which in many cases is also the first part of the url for instance: http://azure_account_name.blob.core.windows.net/ would mean::
 
-   AZURE_ACCOUNT_NAME = "azure_account_name"
+       AZURE_ACCOUNT_NAME = "azure_account_name"
 
 ``AZURE_ACCOUNT_KEY``
 
-This is the private key that gives your Django app access to your Windows Azure Account.
+    This is the private key that gives your Django app access to your Windows Azure Account.
 
 ``AZURE_CONTAINER``
 
-This is where the files uploaded through your Django app will be uploaded.
-The container must be already created as the storage system will not attempt to create it.
+    This is where the files uploaded through your Django app will be uploaded.
+    The container must be already created as the storage system will not attempt to create it.

--- a/docs/backends/database.rst
+++ b/docs/backends/database.rst
@@ -56,4 +56,4 @@ Note: It returns special path, which should be mapped to special view, which ret
         response['Content-Disposition'] = 'inline; filename=%s'%filename
         return response
 
-Note: If filename exist, blob will be overwritten, to change this remove get_available_name(self, name), so Storage.get_available_name(self, name) will be used to generate new filename.
+.. note:: If filename exist, blob will be overwritten, to change this remove get_available_name(self, name), so Storage.get_available_name(self, name) will be used to generate new filename.

--- a/docs/backends/dropbox.rst
+++ b/docs/backends/dropbox.rst
@@ -4,14 +4,10 @@ DropBox
 Settings
 --------
 
-
 ``DROPBOX_OAUTH2_TOKEN``
-
-Your DropBox token, if you haven't follow this `guide step`_.
+    Your DropBox token, if you haven't follow this `guide step`_.
 
 ``DROPBOX_ROOT_PATH``
-
-Allow to jail your storage to a defined directory.
-
+    Allow to jail your storage to a defined directory.
 
 .. _`guide step`: https://www.dropbox.com/developers/documentation/python#tutorial

--- a/docs/backends/ftp.rst
+++ b/docs/backends/ftp.rst
@@ -9,11 +9,7 @@ Settings
 --------
 
 ``LOCATION``
-
-URL of the server that hold the files.
-Example ``'ftp://<user>:<pass>@<host>:<port>'``
+    URL of the server that hold the files. Example ``'ftp://<user>:<pass>@<host>:<port>'``
 
 ``BASE_URL``
-
-URL that serves the files stored at this location. Defaults to the value of
-your ``MEDIA_URL`` setting.
+    URL that serves the files stored at this location. Defaults to the value of your ``MEDIA_URL`` setting.

--- a/docs/backends/mogilefs.rst
+++ b/docs/backends/mogilefs.rst
@@ -5,11 +5,23 @@ This storage allows you to use MogileFS, it comes from this blog post.
 
 The MogileFS storage backend is fairly simple: it uses URLs (or, rather, parts of URLs) as keys into the mogile database. When the user requests a file stored by mogile (say, an avatar), the URL gets passed to a view which, using a client to the mogile tracker, retrieves the "correct" path (the path that points to the actual file data). The view will then either return the path(s) to perlbal to reproxy, or, if you're not using perlbal to reproxy (which you should), it serves the data of the file directly from django.
 
-* ``MOGILEFS_DOMAIN``: The mogile domain that files should read from/written to, e.g "production"
-* ``MOGILEFS_TRACKERS``: A list of trackers to connect to, e.g. ["foo.sample.com:7001", "bar.sample.com:7001"]
-* ``MOGILEFS_MEDIA_URL`` (optional): The prefix for URLs that point to mogile files. This is used in a similar way to ``MEDIA_URL``, e.g. "/mogilefs/"
-* ``SERVE_WITH_PERLBAL``: Boolean that, when True, will pass the paths back in the response in the ``X-REPROXY-URL`` header. If False, django will serve all mogile media files itself (bad idea for production, but useful if you're testing on a setup that doesn't have perlbal running)
-* ``DEFAULT_FILE_STORAGE``: This is the class that's used for the backend. You'll want to set this to ``project.app.storages.MogileFSStorage`` (or wherever you've installed the backend)
+To use `MogileFSStorage` set::
+
+    DEFAULT_FILE_STORAGE = 'storages.backends.mogile.MogileFSStorage'
+
+The following settings are available:
+
+``MOGILEFS_DOMAIN``
+    The mogile domain that files should read from/written to, e.g "production"
+
+``MOGILEFS_TRACKERS``
+    A list of trackers to connect to, e.g. ["foo.sample.com:7001", "bar.sample.com:7001"]
+
+``MOGILEFS_MEDIA_URL`` (optional)
+    The prefix for URLs that point to mogile files. This is used in a similar way to ``MEDIA_URL``, e.g. "/mogilefs/"
+
+``SERVE_WITH_PERLBAL``
+    Boolean that, when True, will pass the paths back in the response in the ``X-REPROXY-URL`` header. If False, django will serve all mogile media files itself (bad idea for production, but useful if you're testing on a setup that doesn't have perlbal running)
 
 Getting files into mogile
 *************************

--- a/docs/backends/sftp.rst
+++ b/docs/backends/sftp.rst
@@ -5,64 +5,55 @@ Settings
 --------
 
 ``SFTP_STORAGE_HOST``
-
-The hostname where you want the files to be saved.
+    The hostname where you want the files to be saved.
 
 ``SFTP_STORAGE_ROOT``
+    The root directory on the remote host into which files should be placed.
+    Should work the same way that ``STATIC_ROOT`` works for local files. Must
+    include a trailing slash.
 
-The root directory on the remote host into which files should be placed.
-Should work the same way that ``STATIC_ROOT`` works for local files. Must
-include a trailing slash.
+``SFTP_STORAGE_PARAMS`` (optional)
+    A dictionary containing connection parameters to be passed as keyword
+    arguments to ``paramiko.SSHClient().connect()`` (do not include hostname here).
+    See `paramiko SSHClient.connect() documentation`_ for details
 
-``SFTP_STORAGE_PARAMS`` (Optional)
+``SFTP_STORAGE_INTERACTIVE`` (optional)
+    A boolean indicating whether to prompt for a password if the connection cannot
+    be made using keys, and there is not already a password in
+    ``SFTP_STORAGE_PARAMS``. You can set this to ``True`` to enable interactive
+    login when running ``manage.py collectstatic``, for example.
 
-A dictionary containing connection parameters to be passed as keyword
-arguments to ``paramiko.SSHClient().connect()`` (do not include hostname here).
-See `paramiko SSHClient.connect() documentation`_ for details
+    .. warning::
+
+      DO NOT set SFTP_STORAGE_INTERACTIVE to True if you are using this storage
+      for files being uploaded to your site by users, because you'll have no way
+      to enter the password when they submit the form..
+
+``SFTP_STORAGE_FILE_MODE`` (optional)
+    A bitmask for setting permissions on newly-created files. See
+    `Python os.chmod documentation`_ for acceptable values.
+
+``SFTP_STORAGE_DIR_MODE`` (optional)
+    A bitmask for setting permissions on newly-created directories. See
+    `Python os.chmod documentation`_ for acceptable values.
+
+    .. note::
+
+      Hint: if you start the mode number with a 0 you can express it in octal
+      just like you would when doing "chmod 775 myfile" from bash.
+
+``SFTP_STORAGE_UID`` (optional)
+    UID of the account that should be set as owner of the files on the remote
+    host. You may have to be root to set this.
+
+``SFTP_STORAGE_GID`` (optional)
+    GID of the group that should be set on the files on the remote host. You have
+    to be a member of the group to set this.
+
+``SFTP_KNOWN_HOST_FILE`` (optional)
+    Absolute path of know host file, if it isn't set ``"~/.ssh/known_hosts"`` will be used.
+
 
 .. _`paramiko SSHClient.connect() documentation`: http://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.connect
 
-``SFTP_STORAGE_INTERACTIVE`` (Optional)
-
-A boolean indicating whether to prompt for a password if the connection cannot
-be made using keys, and there is not already a password in
-``SFTP_STORAGE_PARAMS``. You can set this to ``True`` to enable interactive
-login when running ``manage.py collectstatic``, for example.
-
-.. warning::
-
-  DO NOT set SFTP_STORAGE_INTERACTIVE to True if you are using this storage
-  for files being uploaded to your site by users, because you'll have no way
-  to enter the password when they submit the form..
-
-``SFTP_STORAGE_FILE_MODE`` (Optional)
-
-A bitmask for setting permissions on newly-created files. See
-`Python os.chmod documentation`_ for acceptable values.
-
-
-``SFTP_STORAGE_DIR_MODE`` (Optional)
-
-A bitmask for setting permissions on newly-created directories. See
-`Python os.chmod documentation`_ for acceptable values.
-
-.. note::
-
-  Hint: if you start the mode number with a 0 you can express it in octal
-  just like you would when doing "chmod 775 myfile" from bash.
-
 .. _`Python os.chmod documentation`: http://docs.python.org/library/os.html#os.chmod
-
-``SFTP_STORAGE_UID`` (Optional)
-
-UID of the account that should be set as owner of the files on the remote
-host. You may have to be root to set this.
-
-``SFTP_STORAGE_GID`` (Optional)
-
-GID of the group that should be set on the files on the remote host. You have
-to be a member of the group to set this.
-
-``SFTP_KNOWN_HOST_FILE`` (Optional)
-
-Absolute path of know host file, if it isn't set ``"~/.ssh/known_hosts"`` will be used.


### PR DESCRIPTION
Hello,

I made small improvements syntax of docs eg.t:
- use definition lists to settings list - it looks better,
- use ``.. note:: `` for notes,
- fix case of word "optional" in whole docs,

Using definitions lists require some changes in text or reorder paragraph, so I tried unify them.