### PR TITLE
allowing uploading of files bigger than the put_blob limit of 64mb

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -93,9 +93,9 @@ class AzureStorage(Storage):
         else:
             content_data = content.read()
 
-        self.connection.put_blob(self.azure_container, name,
-                                 content_data, "BlockBlob",
-                                 x_ms_blob_content_type=content_type)
+            self.connection.put_block_blob_from_bytes(self.azure_container, name,
+                                                      content_data,
+                                                      x_ms_blob_content_type=content_type)
         return name
 
     def url(self, name):


### PR DESCRIPTION
This fixes a small bug when trying to use the azure backend to upload files bigger than 64MB. 

it doesn't change any dependancies and sadly doesn't add tests as i am not sure how to create mockup tests for azure.