### PR TITLE
add apache-libcloud installation note

### DIFF
--- a/docs/backends/apache_libcloud.rst
+++ b/docs/backends/apache_libcloud.rst
@@ -6,6 +6,10 @@ It aims to provide a consistent API for dealing with cloud storage (and, more
 broadly, the many other services provided by cloud providers, such as device
 provisioning, load balancer configuration, and DNS configuration).
 
+Use pip to install apache-libcloud from PyPI::
+
+    pip install apache-libcloud
+
 As of v0.10.1, Libcloud supports the following cloud storage providers:
     * `Amazon S3`_
     * `Google Cloud Storage`_


### PR DESCRIPTION
I try to configure django-storages to use google cloud storage refer to this file,
but I think it would be better to add apache-libcloud installation on this guideline,
so noob people like me won't need to have the exception first because know that must install apache-libcloud first.