### PR TITLE
#257: S3Boto3Storage bucket_params

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ By order of apparition, thanks:
     * EunPyo (Andrew) Hong (Azure)
     * Michael Barrientos (S3 with Boto3)
     * piglei (patches)
+    * Matt Braymer-Hayes (S3 with Boto3)
 
 Extra thanks to Marty for adding this in Django,
 you can buy his very interesting book (Pro Django).

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -365,7 +365,7 @@ class S3Boto3Storage(Storage):
                     if region_name != 'us-east-1':
                         bucket_params['CreateBucketConfiguration'] = {
                             'LocationConstraint': region_name}
-                    bucket.create(ACL=self.bucket_acl)
+                    bucket.create(**bucket_params)
                 else:
                     raise ImproperlyConfigured("Bucket %s does not exist. Buckets "
                                                "can be automatically created by "


### PR DESCRIPTION
Hey folks, the only change this makes is to use `bucket_params` when calling `bucket.create()`.

I'm not sure the best way to test this and would love some advice. Thanks!

Resolves #257.