### PR TITLE
Correct example in documentation of S3 parameters

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -56,10 +56,10 @@ Available are numerous settings. It should be especially noted the following:
         }
 
 ``AWS_S3_OBJECT_PARAMETERS`` (optional - boto3 only)
-  Use this to set arbitrary parameters on your object (such as Cache-Control)::
+  Use this to set object parameters on your object (such as CacheControl)::
 
         AWS_S3_OBJECT_PARAMETERS = {
-            'Cache-Control': 'max-age=86400',
+            'CacheControl': 'max-age=86400',
         }
 
 ``AWS_QUERYSTRING_AUTH`` (optional; default is ``True``)


### PR DESCRIPTION
When using the key "Cache-Control" in AWS_S3_OBJECT_PARAMETERS, I got this error:

> ValueError: Invalid extra_args key 'Cache-Control', must be one of: ACL, CacheControl, ContentDisposition, ContentEncoding, ContentLanguage, ContentType, Expires, GrantFullControl, GrantRead, GrantReadACP, GrantWriteACP, Metadata, RequestPayer, ServerSideEncryption, StorageClass, SSECustomerAlgorithm, SSECustomerKey, SSECustomerKeyMD5, SSEKMSKeyId, WebsiteRedirectLocation

I fixed it by replacing "Cache-Control" with "CacheControl".

I fixed the documentation to use the correct key, and to remove the word arbitrary, since it doesn't seem arbitrary to me.

I was using these package versions:

    boto3 1.4.4
    botocore 1.5.19
    django-storages 1.5.2    
    s3transfer 0.1.10
    