### PR TITLE
Azure: Use BlockBlobService for automatic handling of files bigger th…

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -11,18 +11,13 @@ from django.utils.deconstruct import deconstructible
 
 try:
     import azure  # noqa
+    from azure.storage.blob import BlockBlobService
+    from azure.storage.blob import ContentSettings
+    from azure.common import AzureMissingResourceHttpError
 except ImportError:
     raise ImproperlyConfigured(
         "Could not load Azure bindings. "
         "See https://github.com/WindowsAzure/azure-sdk-for-python")
-
-try:
-    # azure-storage 0.20.0
-    from azure.storage.blob.blobservice import BlobService
-    from azure.common import AzureMissingResourceHttpError
-except ImportError:
-    from azure.storage import BlobService
-    from azure import WindowsAzureMissingResourceError as AzureMissingResourceHttpError
 
 from storages.utils import setting
 
@@ -45,7 +40,7 @@ class AzureStorage(Storage):
     @property
     def connection(self):
         if self._connection is None:
-            self._connection = BlobService(
+            self._connection = BlockBlobService(
                 self.account_name, self.account_key)
         return self._connection
 
@@ -65,7 +60,7 @@ class AzureStorage(Storage):
             return None
 
     def _open(self, name, mode="rb"):
-        contents = self.connection.get_blob(self.azure_container, name)
+        contents = self.connection.get_blob_to_bytes(self.azure_container, name)
         return ContentFile(contents)
 
     def exists(self, name):
@@ -93,9 +88,9 @@ class AzureStorage(Storage):
         else:
             content_data = content.read()
 
-        self.connection.put_blob(self.azure_container, name,
-                                 content_data, "BlockBlob",
-                                 x_ms_blob_content_type=content_type)
+        self.connection.create_blob_from_bytes(self.azure_container, name,
+                                 content_data,
+                                 content_settings=ContentSettings(content_type=content_type))
         return name
 
     def url(self, name):


### PR DESCRIPTION
…an 64MB

This will ensure that we don't have to worry about blob fragmentation and lib will do it for us automagically.

Tested with azure-storage-0.34.0

```
appdirs==1.4.3
azure==1.0.3
azure-common==1.1.4
azure-mgmt==0.20.2
azure-mgmt-common==0.20.0
azure-mgmt-compute==0.20.1
azure-mgmt-network==0.20.1
azure-mgmt-nspkg==1.0.0
azure-mgmt-resource==0.20.1
azure-mgmt-storage==0.20.0
azure-nspkg==1.0.0
azure-servicebus==0.20.1
azure-servicemanagement-legacy==0.20.2
azure-storage==0.34.0
cffi==1.9.1
cryptography==1.7.2
Django==1.10.6
django-storages==1.5.2
idna==2.5
packaging==16.8
pyasn1==0.2.3
pycparser==2.17
pyparsing==2.2.0
python-dateutil==2.6.0
requests==2.13.0
six==1.10.0
```

Will not work with azure-storage-0.20.3.