### PR TITLE
Add support for AWS_SESSION_TOKEN and AWS_SECURITY_TOKEN

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -209,6 +209,7 @@ class S3Boto3Storage(Storage):
     # used for looking up the access and secret key from env vars
     access_key_names = ['AWS_S3_ACCESS_KEY_ID', 'AWS_ACCESS_KEY_ID']
     secret_key_names = ['AWS_S3_SECRET_ACCESS_KEY', 'AWS_SECRET_ACCESS_KEY']
+    security_token_names = ['AWS_SESSION_TOKEN', 'AWS_SECURITY_TOKEN']
 
     access_key = setting('AWS_S3_ACCESS_KEY_ID', setting('AWS_ACCESS_KEY_ID'))
     secret_key = setting('AWS_S3_SECRET_ACCESS_KEY', setting('AWS_SECRET_ACCESS_KEY'))
@@ -272,6 +273,7 @@ class S3Boto3Storage(Storage):
 
         if not self.access_key and not self.secret_key:
             self.access_key, self.secret_key = self._get_access_keys()
+            self.security_token = self._get_security_token()
 
         if not self.config:
             self.config = Config(s3={'addressing_style': self.addressing_style},
@@ -289,6 +291,7 @@ class S3Boto3Storage(Storage):
                 self.connection_service_name,
                 aws_access_key_id=self.access_key,
                 aws_secret_access_key=self.secret_key,
+                aws_session_token=self.security_token,
                 region_name=self.region_name,
                 use_ssl=self.use_ssl,
                 endpoint_url=self.endpoint_url,
@@ -316,20 +319,25 @@ class S3Boto3Storage(Storage):
                                  for entry in self.bucket.objects.filter(Prefix=self.location))
         return self._entries
 
+    def _lookup_env(self, names):
+        for name in names:
+            value = os.environ.get(name)
+            if value:
+                return value
+
     def _get_access_keys(self):
         """
         Gets the access keys to use when accessing S3. If none
         are provided to the class in the constructor or in the
         settings then get them from the environment variables.
         """
-        def lookup_env(names):
-            for name in names:
-                value = os.environ.get(name)
-                if value:
-                    return value
-        access_key = self.access_key or lookup_env(self.access_key_names)
-        secret_key = self.secret_key or lookup_env(self.secret_key_names)
+        access_key = self.access_key or self._lookup_env(self.access_key_names)
+        secret_key = self.secret_key or self._lookup_env(self.secret_key_names)
         return access_key, secret_key
+
+    def _get_security_token(self):
+        security_token = self._lookup_env(self.security_token_names)
+        return security_token
 
     def _get_or_create_bucket(self, name):
         """


### PR DESCRIPTION
Add support for reading the AWS_SESSION_TOKEN and AWS_SECURITY_TOKEN from the environment.

Verified this works as expected in AWS Lambda. 