### PR TITLE
Fix _full_path function in dropbox.py

### DIFF
--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -18,12 +18,11 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils._os import safe_join
-
 from storages.utils import setting
 
 from dropbox.client import DropboxClient
 from dropbox.rest import ErrorResponse
+from os.path import join
 
 DATE_FORMAT = '%a, %d %b %Y %X +0000'
 
@@ -62,7 +61,7 @@ class DropBoxStorage(Storage):
     def _full_path(self, name):
         if name == '/':
             name = ''
-        return safe_join(self.root_path, name)
+        return join(self.root_path, name).replace('\\', '/')
 
     def delete(self, name):
         self.client.file_delete(self._full_path(name))


### PR DESCRIPTION
The function _full_path() was unnecessarily creating absolute paths from the system home, and this path was indeed getting reflected inside the dropbox folder. 

For eg. when DROPBOX_ROOT_PATH = '/django-cms/', the function created a full path of C:\django-cms\<upload file path> inside the root dropbox folder. 

Also the error of 'backslashes not allowed' was getting encountered on the Windows platform.
This commit fixes both the above issues.