### PR TITLE
Update to Amazon S3 Documentation

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -107,6 +107,9 @@ If you're using S3 as a CDN (via CloudFront), you'll probably want this storage
 to serve those files using that::
 
     AWS_S3_CUSTOM_DOMAIN = 'cdn.mydomain.com'
+**NOTE:** Django's `STATIC_URL` `must end in a slash`_ and the `AWS_S3_CUSTOM_DOMAIN` *must not*. It is best to set this variable indepedently of `STATIC_URL`.
+
+.. _must end in a slash: https://docs.djangoproject.com/en/dev/ref/settings/#static-url
 
 Keep in mind you'll have to configure CloudFront to use the proper bucket as an
 origin manually for this to work.


### PR DESCRIPTION
Included note indicating that AWS_S3_CUSTOM_DOMAIN must *not* end in a slash. It is required that `STATIC_URL` must end in a trailing slash, and if users are using CloudFront, their `STATIC_URL` and `AWS_S3_CUSTOM_DOMAIN` values will be the same. It is very easy for users to miss the trailing `/` and instead set `AWS_S3_CUSTOM_DOMAIN = STATIC_URL` which results in a double-slash in the static URL's (e.g. `https://mydomain.com//staticasset.jpg`).