### PR TITLE
Generate Signed URL

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -83,6 +83,7 @@ class GoogleCloudStorage(Storage):
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
+    expiry_time = setting('GS_QUERYSTRING_EXPIRE', None)
     # The max amount of memory a returned file can take up before being
     # rolled over into a temporary file on disk. Default is 0: Do not roll over.
     max_memory_size = setting('GS_MAX_MEMORY_SIZE', 0)
@@ -223,6 +224,8 @@ class GoogleCloudStorage(Storage):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(clean_name(name))
         blob = self._get_blob(self._encode_name(name))
+        if self.expiry_time:
+            return blob.generate_signed_url(self.expiry_time)
         return blob.public_url
 
     def get_available_name(self, name, max_length=None):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -1,3 +1,4 @@
+import mimetypes
 from tempfile import SpooledTemporaryFile
 
 from django.core.exceptions import ImproperlyConfigured
@@ -22,6 +23,7 @@ class GoogleCloudFile(File):
         self.name = name
         self._mode = mode
         self._storage = storage
+        self.mime_type = mimetypes.guess_type(name)[0]
         self.blob = storage.bucket.get_blob(name)
         if not self.blob and 'w' in mode:
             self.blob = Blob(self.name, storage.bucket)
@@ -69,7 +71,7 @@ class GoogleCloudFile(File):
         if self._file is not None:
             if self._is_dirty:
                 self.file.seek(0)
-                self.blob.upload_from_file(self.file)
+                self.blob.upload_from_file(self.file, content_type=self.mime_type)
             self._file.close()
             self._file = None
 
@@ -154,7 +156,7 @@ class GoogleCloudStorage(Storage):
         content.name = cleaned_name
         encoded_name = self._encode_name(name)
         file = GoogleCloudFile(encoded_name, 'rw', self)
-        file.blob.upload_from_file(content, size=content.size)
+        file.blob.upload_from_file(content, size=content.size. content_type=file.mime_type)
         return cleaned_name
 
     def delete(self, name):


### PR DESCRIPTION
The deprecated gs backend had the ability to generate a signed URL, which is useful for sensitive data and required for non-public buckets.

This simple addition of setting an expiry time in the settings tells the system to generate a signed URL instead of the normal public URL.