### PR TITLE
Avoid incorrect behaviour of S3BotoStorage.exists

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -233,6 +233,7 @@ class S3BotoStorage(Storage):
         self._entries = {}
         self._bucket = None
         self._connection = None
+        self._loaded_meta = False
 
         self.security_token = None
         if not self.access_key and not self.secret_key:
@@ -270,9 +271,14 @@ class S3BotoStorage(Storage):
         """
         Get the locally cached files for the bucket.
         """
-        if self.preload_metadata and not self._entries:
-            self._entries = dict((self._decode_name(entry.key), entry)
-                                 for entry in self.bucket.list(prefix=self.location))
+        if self.preload_metadata and not self._loaded_meta:
+            self._entries.update(
+                dict(
+                    (self._decode_name(entry.key), entry)
+                    for entry in self.bucket.list(prefix=self.location)
+                )
+            )
+            self._loaded_meta = True
         return self._entries
 
     def _lookup_env(self, names):


### PR DESCRIPTION
Calling `S3BotoStorage._save` writes to `_entries` if `preload_metadata`
is True. Future access to `_entries` is limited as the property `entries` only
loads metadata for the bucket if `_entries` is empty, which due to `_save`
it may not be. This in turn causes `exists` to incorrectly return False for
existent files.