### PR TITLE
Sync dependency versions between requirements-tests.txt and tox.ini

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,9 +1,9 @@
 boto3>=1.2.3
 boto>=2.32.0
-dropbox>=7.21
+dropbox>=7.2.1
 Django>=1.8
 flake8
-google-cloud>=0.25.0
+google-cloud-storage>=0.22.0
 mock
 paramiko
 pytest-cov>=2.2.1

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,12 @@ deps =
     django110: Django>=1.10, <1.11
     django111: Django>=1.11, <2.0
     py27: mock
-    boto>=2.32.0
-    pytest-cov>=2.2.1
     boto3>=1.2.3
-    dropbox>=3.24
-    paramiko
+    boto>=2.32.0
+    dropbox>=7.2.1
     google-cloud-storage>=0.22.0
+    paramiko
+    pytest-cov>=2.2.1
 
 
 [testenv:flake8]


### PR DESCRIPTION
* Fixed typo dropbox>=7.21 -> dropbox>=7.2.1
* Alphabetized tox dependencies
* In requirements-tests.txt, change google-cloud>=0.25.0 ->
  google-cloud-storage>=0.22.0 to match tox.ini