### PR TITLE
Integrate isort and use it to consistently sort imports across files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache: pip
 matrix:
   include:
     - env: TOX_ENV=flake8
+    - env: TOX_ENV=isort
     - python: 2.7
       env: TOX_ENV=py27-django18
     - python: 3.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,12 @@ exclude =
     .tox,
     docs
 max-line-length = 119
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = storages
+line_length = 79
+multi_line_output = 5
+not_skip = __init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+
 import storages
 
 

--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -4,11 +4,11 @@
 import os
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
-from django.core.exceptions import ImproperlyConfigured
 from django.utils.deconstruct import deconstructible
-from django.utils.six import string_types, BytesIO
+from django.utils.six import BytesIO, string_types
 from django.utils.six.moves.urllib.parse import urljoin
 
 try:

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -1,13 +1,15 @@
-from datetime import datetime
-import os.path
 import mimetypes
+import os.path
 import time
+from datetime import datetime
 from time import mktime
 
-from django.core.files.base import ContentFile
 from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
+
+from storages.utils import setting
 
 try:
     import azure  # noqa
@@ -23,8 +25,6 @@ try:
 except ImportError:
     from azure.storage import BlobService
     from azure import WindowsAzureMissingResourceError as AzureMissingResourceHttpError
-
-from storages.utils import setting
 
 
 def clean_name(name):

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -11,19 +11,18 @@
 from __future__ import absolute_import
 
 from datetime import datetime
-from tempfile import SpooledTemporaryFile
 from shutil import copyfileobj
+from tempfile import SpooledTemporaryFile
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
-from django.utils.deconstruct import deconstructible
 from django.utils._os import safe_join
-
-from storages.utils import setting
-
+from django.utils.deconstruct import deconstructible
 from dropbox import Dropbox
 from dropbox.exceptions import ApiError
+
+from storages.utils import setting
 
 DATE_FORMAT = '%a, %d %b %Y %X +0000'
 

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -14,17 +14,17 @@
 # class FTPTest(models.Model):
 #     file = models.FileField(upload_to='a/b/c/', storage=fs)
 
+import ftplib
 import os
 from datetime import datetime
-import ftplib
 
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
-from django.core.exceptions import ImproperlyConfigured
 from django.utils.deconstruct import deconstructible
-from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.six import BytesIO
+from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.utils import setting
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -3,9 +3,10 @@ from tempfile import SpooledTemporaryFile
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
+from django.utils import timezone
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, smart_str
-from django.utils import timezone
+
 from storages.utils import clean_name, safe_join, setting
 
 try:

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -1,16 +1,20 @@
-import os
 import mimetypes
+import os
 from datetime import datetime
 from gzip import GzipFile
 from tempfile import SpooledTemporaryFile
 
+from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File
 from django.core.files.storage import Storage
-from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
-from django.utils.deconstruct import deconstructible
-from django.utils.encoding import force_text, smart_str, filepath_to_uri, force_bytes
-from django.utils.six import BytesIO
 from django.utils import timezone as tz
+from django.utils.deconstruct import deconstructible
+from django.utils.encoding import (
+    filepath_to_uri, force_bytes, force_text, smart_str,
+)
+from django.utils.six import BytesIO
+
+from storages.utils import clean_name, safe_join, setting
 
 try:
     from boto import __version__ as boto_version
@@ -22,7 +26,6 @@ except ImportError:
     raise ImproperlyConfigured("Could not load Boto's S3 bindings.\n"
                                "See https://github.com/boto/boto")
 
-from storages.utils import clean_name, safe_join, setting
 
 boto_version_info = tuple([int(i) for i in boto_version.split('-')[0].split('.')])
 

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -1,6 +1,6 @@
+import mimetypes
 import os
 import posixpath
-import mimetypes
 from gzip import GzipFile
 from tempfile import SpooledTemporaryFile
 
@@ -8,10 +8,14 @@ from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.encoding import force_text, smart_text, filepath_to_uri, force_bytes
-from django.utils.six.moves.urllib import parse as urlparse
+from django.utils.encoding import (
+    filepath_to_uri, force_bytes, force_text, smart_text,
+)
 from django.utils.six import BytesIO
-from django.utils.timezone import localtime, is_naive
+from django.utils.six.moves.urllib import parse as urlparse
+from django.utils.timezone import is_naive, localtime
+
+from storages.utils import safe_join, setting
 
 try:
     import boto3.session
@@ -22,7 +26,6 @@ except ImportError:
     raise ImproperlyConfigured("Could not load Boto3's S3 bindings.\n"
                                "See https://github.com/boto/boto3")
 
-from storages.utils import setting, safe_join
 
 boto3_version_info = tuple([int(i) for i in boto3_version.split('.')])
 

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -1,17 +1,17 @@
-from __future__ import print_function
 # SFTP storage backend for Django.
 # Author: Brent Tubbs <brent.tubbs@gmail.com>
 # License: MIT
 #
 # Modeled on the FTP storage by Rafal Jonca <jonca.rafal@gmail.com>
+from __future__ import print_function
 
 import getpass
 import os
-import paramiko
 import posixpath
 import stat
 from datetime import datetime
 
+import paramiko
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -1,16 +1,19 @@
 import re
 from datetime import datetime
+
+from django.core.exceptions import (
+    ImproperlyConfigured, SuspiciousFileOperation,
+)
+from django.core.files.base import ContentFile, File
+from django.test import TestCase
+
+from storages.backends import dropbox
+
 try:
     from unittest import mock
 except ImportError:  # Python 3.2 and below
     import mock
 
-from django.test import TestCase
-from django.core.files.base import File, ContentFile
-from django.core.exceptions import ImproperlyConfigured, \
-    SuspiciousFileOperation
-
-from storages.backends import dropbox
 
 FILE_DATE = datetime(2015, 8, 24, 15, 6, 41)
 FILE_FIXTURE = {

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -4,9 +4,9 @@ except ImportError:
     from mock import patch
 from datetime import datetime
 
-from django.test import TestCase
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
+from django.test import TestCase
 from django.utils.six import BytesIO
 
 from storages.backends import ftp

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -8,9 +8,8 @@ except ImportError:  # Python 3.2 and below
 import datetime
 
 from django.core.files.base import ContentFile
-from django.utils import timezone
 from django.test import TestCase
-
+from django.utils import timezone
 from google.cloud.exceptions import NotFound
 from google.cloud.storage.blob import Blob
 

--- a/tests/test_gs.py
+++ b/tests/test_gs.py
@@ -1,5 +1,5 @@
-from django.test import TestCase
 from django.core.files.base import ContentFile
+from django.test import TestCase
 
 from storages.backends import gs, s3boto
 

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -5,14 +5,13 @@ except ImportError:  # Python 3.2 and below
 
 import datetime
 
-from django.test import TestCase
-from django.core.files.base import ContentFile
-from django.utils.six.moves.urllib import parse as urlparse
-from django.utils import timezone as tz
-
 from boto.exception import S3ResponseError
 from boto.s3.key import Key
-from boto.utils import parse_ts, ISO8601
+from boto.utils import ISO8601, parse_ts
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from django.utils import timezone as tz
+from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.backends import s3boto
 

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from datetime import datetime
 import gzip
+from datetime import datetime
+
+from botocore.exceptions import ClientError
+from django.conf import settings
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from django.utils.six.moves.urllib import parse as urlparse
+from django.utils.timezone import is_aware, utc
+
+from storages.backends import s3boto3
+
 try:
     from unittest import mock
 except ImportError:  # Python 3.2 and below
     import mock
-
-from django.test import TestCase
-from django.conf import settings
-from django.core.files.base import ContentFile
-from django.utils.six.moves.urllib import parse as urlparse
-from django.utils.timezone import is_aware, utc
-
-from botocore.exceptions import ClientError
-
-from storages.backends import s3boto3
 
 
 class S3Boto3TestCase(TestCase):

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -2,15 +2,16 @@ import os
 import stat
 from datetime import datetime
 
+from django.core.files.base import File
+from django.test import TestCase
+from django.utils.six import BytesIO
+
+from storages.backends import sftpstorage
+
 try:
     from unittest.mock import patch, MagicMock
 except ImportError:  # Python 3.2 and below
     from mock import patch, MagicMock
-
-from django.test import TestCase
-from django.core.files.base import File
-from django.utils.six import BytesIO
-from storages.backends import sftpstorage
 
 
 class SFTPStorageTest(TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,9 @@
 import datetime
 
-from django.test import TestCase
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+
 from storages import utils
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     flake8
+    isort
     {py27,py33,py34,py35}-django18,
     {py27,py34,py35}-django110
     {py27,py34,py35,py36}-django111
@@ -27,3 +28,7 @@ deps =
 [testenv:flake8]
 deps = flake8
 commands = flake8
+
+[testenv:isort]
+deps = isort
+commands = isort --recursive --check-only --diff storages/ tests/


### PR DESCRIPTION
Reduces need to think and order imports, simply let the tool do it. Provides more consistent code style across Python modules by always ordering imports a single way.

Use same configuration as Django project.