### PR TITLE
Fix safe_join to handle trailing slash with intermediate paths

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 django-storages change log
 ==========================
 
+1.6.2 (UNRELEASED)
+******************
+
+* Fix regression in ``safe_join()`` to handle a trailing slash in an
+  intermediate path.
+
 1.6.1 (2017-06-22)
 ******************
 

--- a/storages/utils.py
+++ b/storages/utils.py
@@ -60,11 +60,16 @@ def safe_join(base, *paths):
     """
     base_path = force_text(base)
     base_path = base_path.rstrip('/')
-    paths = [base_path + '/'] + [force_text(p) for p in paths if p]
+    paths = [force_text(p) for p in paths]
 
-    final_path = posixpath.normpath(posixpath.join(*paths))
-    # posixpath.normpath() strips the trailing /. Add it back.
-    if paths[-1].endswith('/'):
+    final_path = base_path + '/'
+    for path in paths:
+        _final_path = posixpath.normpath(posixpath.join(final_path, path))
+        # posixpath.normpath() strips the trailing /. Add it back.
+        if path.endswith('/') or _final_path + '/' == final_path:
+            _final_path += '/'
+        final_path = _final_path
+    if final_path == base_path:
         final_path += '/'
 
     # Ensure final_path starts with base_path and that the next character after

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,6 +59,10 @@ class SafeJoinTest(TestCase):
                                ".", "to/./somewhere")
         self.assertEqual(path, "path/to/somewhere")
 
+    def test_with_only_dot(self):
+        path = utils.safe_join("", ".")
+        self.assertEqual(path, "")
+
     def test_base_url(self):
         path = utils.safe_join("base_url", "path/to/somewhere")
         self.assertEqual(path, "base_url/path/to/somewhere")
@@ -94,4 +98,20 @@ class SafeJoinTest(TestCase):
 
     def test_join_empty_string(self):
         path = utils.safe_join('base_url', '')
+        self.assertEqual(path, 'base_url/')
+
+    def test_with_base_url_and_dot(self):
+        path = utils.safe_join('base_url', '.')
+        self.assertEqual(path, 'base_url/')
+
+    def test_with_base_url_and_dot_and_path_and_slash(self):
+        path = utils.safe_join('base_url', '.', 'path/to/', '.')
+        self.assertEqual(path, 'base_url/path/to/')
+
+    def test_join_nothing(self):
+        path = utils.safe_join('')
+        self.assertEqual(path, '')
+
+    def test_with_base_url_join_nothing(self):
+        path = utils.safe_join('base_url')
         self.assertEqual(path, 'base_url/')


### PR DESCRIPTION
Regression introduced in 895a068fcf3f23a6b71294c5b4b67a822df6e642

Partially reverts 39a2a7a8c08eadd2952cab485ea76434ae86b12f

---

@jschneier Apologies for the 2nd round of regression fixes. I believe I've covered all edge cases with this fix. I have added _many_ more unit tests and more thoroughly tested against my own projects. All feedback welcome. If the diff looks good, I'd appreciate if a new release could get cut as my previous changes to `safe_join()` is broken. Thanks!