### PR TITLE
Consolidate flake8 & isort tox envs to a single lint env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ cache: pip
 
 matrix:
   include:
-    - env: TOX_ENV=flake8
-    - env: TOX_ENV=isort
+    - env: TOX_ENV=lint
     - python: 2.7
       env: TOX_ENV=py27-django18
     - python: 3.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
-    flake8
-    isort
-    {py27,py33,py34,py35}-django18,
+    lint
+    {py27,py33,py34,py35}-django18
     {py27,py34,py35}-django110
     {py27,py34,py35,py36}-django111
 
@@ -25,10 +24,10 @@ deps =
     pytest-cov>=2.2.1
 
 
-[testenv:flake8]
-deps = flake8
-commands = flake8
-
-[testenv:isort]
-deps = isort
-commands = isort --recursive --check-only --diff storages/ tests/
+[testenv:lint]
+deps =
+    flake8
+    isort
+commands =
+    flake8
+    isort --recursive --check-only --diff storages/ tests/


### PR DESCRIPTION
Fall under the general umbrella of linting the project. Run all linting tools as one stage of testing.

Added @jleclanche's suggestion from #338.