### PR TITLE
Update for dropbox api v2

### DIFF
--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -108,5 +108,5 @@ class DropBoxStorage(Storage):
         return remote_file
 
     def _save(self, name, content):
-        self.client.files_upload(content, self._full_path(name))
+        self.client.files_upload(content.file.read(), self._full_path(name))
         return name

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -83,7 +83,7 @@ class DropBoxTest(TestCase):
         exists = self.storage.exists('bar')
         self.assertFalse(exists)
 
-    @mock.patch('dropbox.Dropbox.files_get_metadata',
+    @mock.patch('dropbox.Dropbox.files_list_folder',
                 return_value=FILES_FIXTURE)
     def test_listdir(self, *args):
         dirs, files = self.storage.listdir('/')


### PR DESCRIPTION
I fix three problems I met,
1. From [dropbox-python-sdk](https://github.com/dropbox/dropbox-sdk-python/releases/tag/v7.1.0):"File upload endpoints no longer accept file-like objects. Only byte strings are allowed", so I modify the argument of `files_upload`
2. From the discussion [here](https://www.dropboxforum.com/t5/API-support/Python-API-V2-Metadata-of-root-folder/m-p/228433#M12382), `files_get_metadata` API v2 is not allowed to check root folder's metadata, so I replace it with `files_list_folder` to modify `listdir` function
3. According to official doc, `files_upload` isn't used to upload single file larger than 150MB, so I use `files_upload_session_start`,`files_upload_session_append` and `files_upload_session_finish` to implement large file upload, I tested files range from 600~800MB and works well, resolves issue #301 
