### PR TITLE
Fix Dropbox tests to work with version 8.0.0

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 boto3>=1.2.3
 boto>=2.32.0
-dropbox>=7.2.1
+dropbox>=8.0.0
 Django>=1.8
 flake8
 google-cloud-storage>=0.22.0

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 
 from django.core.exceptions import (
@@ -60,9 +59,6 @@ FILE_MEDIA_FIXTURE = {
 
 
 class DropBoxTest(TestCase):
-    @mock.patch('dropbox.client._OAUTH2_ACCESS_TOKEN_PATTERN',
-                re.compile(r'.*'))
-    @mock.patch('dropbox.client.DropboxOAuth2Session')
     def setUp(self, *args):
         self.storage = dropbox.DropBoxStorage('foo')
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     py27: mock
     boto3>=1.2.3
     boto>=2.32.0
-    dropbox>=7.2.1
+    dropbox>=8.0.0
     google-cloud-storage>=0.22.0
     paramiko
     pytest-cov>=2.2.1


### PR DESCRIPTION
The client module was removed from the library.