### PR TITLE
Simplify S3Boto3Storage.exists() by using boto3's head_object()

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -455,18 +455,11 @@ class S3Boto3Storage(Storage):
         self.bucket.Object(self._encode_name(name)).delete()
 
     def exists(self, name):
-        if not name:
-            try:
-                self.bucket
-                return True
-            except ImproperlyConfigured:
-                return False
         name = self._normalize_name(self._clean_name(name))
         if self.entries:
             return name in self.entries
-        obj = self.bucket.Object(self._encode_name(name))
         try:
-            obj.load()
+            self.connection.meta.client.head_object(Bucket=self.bucket_name, Key=name)
             return True
         except self.connection_response_error:
             return False


### PR DESCRIPTION
Avoids unnecessary API requests to fetch and create the bucket when simply checking if a key exists.

https://boto3.readthedocs.io/en/latest/reference/services/s3.html#S3.Client.head_object