### PR TITLE
Fix issue with gzipped files for Google Cloud Storage (gs)

### DIFF
--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -43,6 +43,11 @@ class GSBotoStorageFile(S3BotoStorageFile):
                 self._file.seek(0)
         return self._file
 
+    def _set_file(self, value):
+        self._file = value
+
+    file = property(_get_file, _set_file)
+
     def write(self, content):
         if 'w' not in self._mode:
             raise AttributeError("File was not opened in write mode.")

--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -1,4 +1,5 @@
 import warnings
+from tempfile import SpooledTemporaryFile
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.deconstruct import deconstructible
@@ -28,6 +29,19 @@ warnings.warn("DEPRECATION NOTICE: This backend is deprecated in favour of the "
 
 
 class GSBotoStorageFile(S3BotoStorageFile):
+
+    def _get_file(self):
+        if self._file is None:
+            self._file = SpooledTemporaryFile(
+                max_size=self._storage.max_memory_size,
+                suffix='.GSBotoStorageFile',
+                dir=setting('FILE_UPLOAD_TEMP_DIR', None)
+            )
+            if 'r' in self._mode:
+                self._is_dirty = False
+                self.key.get_contents_to_file(self._file)
+                self._file.seek(0)
+        return self._file
 
     def write(self, content):
         if 'w' not in self._mode:


### PR DESCRIPTION
I initially reported the issue [here](https://github.com/boto/boto/issues/3745) but I think it is better to address this in django-storages.

When you open a file from Google Cloud Storage using the 'gs' backend, if the file is gzipped it gets decompressed on the fly (not sure if this happens client side or server side). 

Without the PR, here is the issue I was getting when accessing a gzipped file:

```
> from django.contrib.staticfiles.storage import staticfiles_storage
> file = staticfiles_storage.open('css/assets.css')
> content = file.read()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/opt/build/local/lib/python2.7/site-packages/storages/backends/s3boto.py", line 105, in read
    return super(S3BotoStorageFile, self).read(*args, **kwargs)
  File "/usr/lib/python2.7/gzip.py", line 261, in read
    self._read(readsize)
  File "/usr/lib/python2.7/gzip.py", line 303, in _read
    self._read_gzip_header()
  File "/usr/lib/python2.7/gzip.py", line 197, in _read_gzip_header
    raise IOError, 'Not a gzipped file'
IOError: Not a gzipped file
```
There is no need to decompress the file in django-storages for gs. With this PR I am able to run the command 'collectstatic' with django-pipeline compressing and minifying static files and correctly storing those in GCS (also using ManifestFilesMixin)

Tested with:
boto==2.48.0
django-pipeline==1.6.13
