### PR TITLE
Ensure that we're reading the file from the start

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -387,6 +387,7 @@ class S3Boto3Storage(Storage):
 
     def _compress_content(self, content):
         """Gzip a given string content."""
+        content.seek(0)
         zbuf = BytesIO()
         zfile = GzipFile(mode='wb', compresslevel=6, fileobj=zbuf)
         try:


### PR DESCRIPTION
This is needed for Django 1.11 as we can no longer assume that the file we're looking is starting from the beginning, this can cause issues with empty files being saved instead of GZ variants.