### PR TITLE
Send copy of ContentFile.file to upload_fileobj.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ By order of apparition, thanks:
     * Jody McIntyre (Google Cloud Storage native support)
     * Stanislav Kaledin (Bug fixes in SFTPStorage)
     * Filip Vavera (Google Cloud MIME types support)
+    * João Sampaio (S3 with Boto3)
 
 Extra thanks to Marty for adding this in Django,
 you can buy his very interesting book (Pro Django).

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -1,3 +1,4 @@
+import io
 import mimetypes
 import os
 import posixpath
@@ -444,10 +445,10 @@ class S3Boto3Storage(Storage):
         # provided. `File.__bool__`  method is Django-specific and depends on
         # file name, for this reason`botocore.handlers.calculate_md5` can fail
         # even if wrapped file-like object exists. To avoid Django-specific
-        # logic, pass internal file-like object if `content` is `File`
-        # class instance.
+        # logic, pass a copy of internal file-like object if `content` is
+        # `File` class instance.
         if isinstance(content, File):
-            content = content.file
+            content = io.BytesIO(force_bytes(content.file.read()))
 
         self._save_content(obj, content, parameters=parameters)
         # Note: In boto3, after a put, last_modified is automatically reloaded

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -447,6 +447,7 @@ class S3Boto3Storage(Storage):
         # logic, pass a copy of internal file-like object if `content` is
         # `File` class instance.
         if isinstance(content, File):
+            content.file.seek(0)
             content = BytesIO(force_bytes(content.file.read()))
 
         self._save_content(obj, content, parameters=parameters)

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -1,4 +1,3 @@
-import io
 import mimetypes
 import os
 import posixpath
@@ -448,7 +447,7 @@ class S3Boto3Storage(Storage):
         # logic, pass a copy of internal file-like object if `content` is
         # `File` class instance.
         if isinstance(content, File):
-            content = io.BytesIO(force_bytes(content.file.read()))
+            content = BytesIO(force_bytes(content.file.read()))
 
         self._save_content(obj, content, parameters=parameters)
         # Note: In boto3, after a put, last_modified is automatically reloaded

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -71,13 +71,13 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.assertEqual(self.storage.url('path/1'), 'https://example.com/path/1')
         self.assertEqual(self.storage.url('path/1/'), 'https://example.com/path/1/')
 
-    @mock.patch('storages.backends.s3boto3.io')
-    def test_storage_save(self, mocked_io):
+    @mock.patch('storages.backends.s3boto3.BytesIO')
+    def test_storage_save(self, mocked_BytesIO):
         """
         Test saving a file
         """
         content_file = mock.Mock()
-        mocked_io.BytesIO.return_value = content_file
+        mocked_BytesIO.return_value = content_file
 
         name = 'test_storage_save.txt'
         content = ContentFile('new content')
@@ -93,13 +93,13 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             }
         )
 
-    @mock.patch('storages.backends.s3boto3.io')
-    def test_storage_save_gzipped(self, mocked_io):
+    @mock.patch('storages.backends.s3boto3.BytesIO')
+    def test_storage_save_gzipped(self, mocked_BytesIO):
         """
         Test saving a gzipped file
         """
         content_file = mock.Mock()
-        mocked_io.BytesIO.return_value = content_file
+        mocked_BytesIO.return_value = content_file
 
         name = 'test_storage_save.gz'
         content = ContentFile("I am gzip'd")


### PR DESCRIPTION
This will stop upload_fileobj from modifying the internal file. This is important because the default storage mixin for hashed static files that comes in Django expects files to be open after they are saved, and
upload_fileobj closes them.