### PR TITLE
Dropbox: large file support and a regression fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,6 +31,7 @@ By order of apparition, thanks:
     * Jody McIntyre (Google Cloud Storage native support)
     * Stanislav Kaledin (Bug fixes in SFTPStorage)
     * Filip Vavera (Google Cloud MIME types support)
+    * Max Malysh (Dropbox large file support)
 
 Extra thanks to Marty for adding this in Django,
 you can buy his very interesting book (Pro Django).

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -108,5 +108,7 @@ class DropBoxStorage(Storage):
         return remote_file
 
     def _save(self, name, content):
-        self.client.files_upload(content, self._full_path(name))
+        content.open()
+        self.client.files_upload(content.read(), self._full_path(name))
+        content.close()
         return name

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -21,7 +21,7 @@ from django.utils._os import safe_join
 from django.utils.deconstruct import deconstructible
 from dropbox import Dropbox
 from dropbox.exceptions import ApiError
-from dropbox.files import UploadSessionCursor, CommitInfo
+from dropbox.files import CommitInfo, UploadSessionCursor
 
 from storages.utils import setting
 

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -21,6 +21,7 @@ from django.utils._os import safe_join
 from django.utils.deconstruct import deconstructible
 from dropbox import Dropbox
 from dropbox.exceptions import ApiError
+from dropbox.files import UploadSessionCursor, CommitInfo
 
 from storages.utils import setting
 
@@ -49,6 +50,8 @@ class DropBoxFile(File):
 @deconstructible
 class DropBoxStorage(Storage):
     """DropBox Storage class for Django pluggable storage system."""
+
+    CHUNK_SIZE = 4 * 1024 * 1024
 
     def __init__(self, oauth2_access_token=None, root_path=None):
         oauth2_access_token = oauth2_access_token or setting('DROPBOX_OAUTH2_TOKEN')
@@ -109,6 +112,30 @@ class DropBoxStorage(Storage):
 
     def _save(self, name, content):
         content.open()
-        self.client.files_upload(content.read(), self._full_path(name))
+        if content.size <= self.CHUNK_SIZE:
+            self.client.files_upload(content.read(), self._full_path(name))
+        else:
+            self._chunked_upload(content, self._full_path(name))
         content.close()
         return name
+
+    def _chunked_upload(self, content, dest_path):
+        upload_session = self.client.files_upload_session_start(
+            content.read(self.CHUNK_SIZE)
+        )
+        cursor = UploadSessionCursor(
+            session_id=upload_session.session_id,
+            offset=content.tell()
+        )
+        commit = CommitInfo(path=dest_path)
+
+        while content.tell() < content.size:
+            if (content.size - content.tell()) <= self.CHUNK_SIZE:
+                self.client.files_upload_session_finish(
+                    content.read(self.CHUNK_SIZE), cursor, commit
+                )
+            else:
+                self.client.files_upload_session_append_v2(
+                    content.read(self.CHUNK_SIZE), cursor
+                )
+                cursor.offset = content.tell()

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -123,6 +123,19 @@ class DropBoxTest(TestCase):
         self.storage._save('foo', File(BytesIO(b'bar'), 'foo'))
         self.assertTrue(files_upload.called)
 
+    @mock.patch('dropbox.Dropbox.files_upload')
+    @mock.patch('dropbox.Dropbox.files_upload_session_finish')
+    @mock.patch('dropbox.Dropbox.files_upload_session_append_v2')
+    @mock.patch('dropbox.Dropbox.files_upload_session_start',
+                return_value=mock.MagicMock(session_id='foo'))
+    def test_chunked_upload(self, start, append, finish, upload):
+        large_file = File(BytesIO(b'bar' * self.storage.CHUNK_SIZE), 'foo')
+        self.storage._save('foo', large_file)
+        self.assertTrue(start.called)
+        self.assertTrue(append.called)
+        self.assertTrue(finish.called)
+        self.assertFalse(upload.called)
+
     @mock.patch('dropbox.Dropbox.files_get_temporary_link',
                 return_value=FILE_MEDIA_FIXTURE)
     def test_url(self, *args):

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -5,6 +5,7 @@ from django.core.exceptions import (
 )
 from django.core.files.base import ContentFile, File
 from django.test import TestCase
+from django.utils.six import BytesIO
 
 from storages.backends import dropbox
 
@@ -118,8 +119,9 @@ class DropBoxTest(TestCase):
 
     @mock.patch('dropbox.Dropbox.files_upload',
                 return_value='foo')
-    def test_save(self, *args):
-        self.storage._save('foo', b'bar')
+    def test_save(self, files_upload, *args):
+        self.storage._save('foo', File(BytesIO(b'bar'), 'foo'))
+        self.assertTrue(files_upload.called)
 
     @mock.patch('dropbox.Dropbox.files_get_temporary_link',
                 return_value=FILE_MEDIA_FIXTURE)


### PR DESCRIPTION
This PR:

- fixes a regression in `DropBoxStorage._save` introduced with e46f306 (see https://github.com/jschneier/django-storages/issues/378);
- adds large file support for Dropbox (see https://github.com/jschneier/django-storages/issues/301).

I've tested uploading a 1.5 GB file and it works fine. 
