### PR TITLE
Fixing path encoding on gcloud #306

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -1,6 +1,11 @@
 import mimetypes
 from tempfile import SpooledTemporaryFile
 
+try:
+    from urllib.parse import unquote_plus
+except ImportError:
+    from urllib import unquote_plus
+
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
@@ -227,7 +232,7 @@ class GoogleCloudStorage(Storage):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(clean_name(name))
         blob = self._get_blob(self._encode_name(name))
-        return blob.public_url
+        return unquote_plus(blob.public_url)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -1,11 +1,6 @@
 import mimetypes
 from tempfile import SpooledTemporaryFile
 
-try:
-    from urllib.parse import unquote_plus
-except ImportError:
-    from urllib import unquote_plus
-
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
@@ -14,6 +9,13 @@ from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, smart_str
 
 from storages.utils import clean_name, safe_join, setting
+
+try:
+    from urllib.parse import unquote_plus
+except ImportError:
+    from urllib import unquote_plus
+
+
 
 try:
     from google.cloud.storage.client import Client

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -15,8 +15,6 @@ try:
 except ImportError:
     from urllib import unquote_plus
 
-
-
 try:
     from google.cloud.storage.client import Client
     from google.cloud.storage.blob import Blob


### PR DESCRIPTION
Simply running the url through `unquote_plus()` so that it no longer contains the `%2F`. 