### PR TITLE
Fix inconsistent capitalization of "Dropbox"

### DIFF
--- a/docs/backends/dropbox.rst
+++ b/docs/backends/dropbox.rst
@@ -1,4 +1,4 @@
-DropBox
+Dropbox
 =======
 
 A custom storage system for Django using Dropbox Storage backend.
@@ -13,12 +13,12 @@ Install the package::
 Settings
 --------
 
-To use DropBoxStorage set::
+To use DropboxStorage set::
 
-    DEFAULT_FILE_STORAGE = 'storages.backends.dropbox.DropBoxStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.dropbox.DropboxStorage'
 
 ``DROPBOX_OAUTH2_TOKEN``
-    Your DropBox token, if you haven't follow this `guide step`_.
+    Your Dropbox token, if you haven't follow this `guide step`_.
 
 ``DROPBOX_ROOT_PATH``
     Allow to jail your storage to a defined directory.

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -32,7 +32,7 @@ class DropboxStorageException(Exception):
     pass
 
 
-class DropBoxFile(File):
+class DropboxFile(File):
     def __init__(self, name, storage):
         self.name = name
         self._storage = storage
@@ -107,7 +107,7 @@ class DropboxStorage(Storage):
         return media.link
 
     def _open(self, name, mode='rb'):
-        remote_file = DropBoxFile(self._full_path(name), self)
+        remote_file = DropboxFile(self._full_path(name), self)
         return remote_file
 
     def _save(self, name, content):

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -28,7 +28,7 @@ from storages.utils import setting
 DATE_FORMAT = '%a, %d %b %Y %X +0000'
 
 
-class DropBoxStorageException(Exception):
+class DropboxStorageException(Exception):
     pass
 
 
@@ -48,8 +48,8 @@ class DropBoxFile(File):
 
 
 @deconstructible
-class DropBoxStorage(Storage):
-    """DropBox Storage class for Django pluggable storage system."""
+class DropboxStorage(Storage):
+    """Dropbox Storage class for Django pluggable storage system."""
 
     CHUNK_SIZE = 4 * 1024 * 1024
 

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -67,7 +67,7 @@ class DropboxTest(TestCase):
 
     def test_no_access_token(self, *args):
         with self.assertRaises(ImproperlyConfigured):
-            dropbox.DropBoxStorage(None)
+            dropbox.DropboxStorage(None)
 
     @mock.patch('dropbox.Dropbox.files_delete',
                 return_value=FILE_FIXTURE)
@@ -153,8 +153,8 @@ class DropboxTest(TestCase):
 
 class DropboxFileTest(TestCase):
     def setUp(self, *args):
-        self.storage = dropbox.DropBoxStorage('foo')
-        self.file = dropbox.DropBoxFile('/foo.txt', self.storage)
+        self.storage = dropbox.DropboxStorage('foo')
+        self.file = dropbox.DropboxFile('/foo.txt', self.storage)
 
     @mock.patch('dropbox.Dropbox.files_download',
                 return_value=ContentFile(b'bar'))

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -61,9 +61,9 @@ FILE_MEDIA_FIXTURE = F()
 FILE_MEDIA_FIXTURE.link = 'https://dl.dropboxusercontent.com/1/view/foo'
 
 
-class DropBoxTest(TestCase):
+class DropboxTest(TestCase):
     def setUp(self, *args):
-        self.storage = dropbox.DropBoxStorage('foo')
+        self.storage = dropbox.DropboxStorage('foo')
 
     def test_no_access_token(self, *args):
         with self.assertRaises(ImproperlyConfigured):
@@ -143,7 +143,7 @@ class DropBoxTest(TestCase):
         self.assertEqual(url, FILE_MEDIA_FIXTURE.link)
 
     def test_formats(self, *args):
-        self.storage = dropbox.DropBoxStorage('foo')
+        self.storage = dropbox.DropboxStorage('foo')
         files = self.storage._full_path('')
         self.assertEqual(files, self.storage._full_path('/'))
         self.assertEqual(files, self.storage._full_path('.'))
@@ -151,7 +151,7 @@ class DropBoxTest(TestCase):
         self.assertEqual(files, self.storage._full_path('../..'))
 
 
-class DropBoxFileTest(TestCase):
+class DropboxFileTest(TestCase):
     def setUp(self, *args):
         self.storage = dropbox.DropBoxStorage('foo')
         self.file = dropbox.DropBoxFile('/foo.txt', self.storage)
@@ -165,20 +165,20 @@ class DropBoxFileTest(TestCase):
 
 @mock.patch('dropbox.Dropbox.files_get_metadata',
             return_value={'contents': []})
-class DropBoxRootPathTest(TestCase):
+class DropboxRootPathTest(TestCase):
     def test_jailed(self, *args):
-        self.storage = dropbox.DropBoxStorage('foo', '/bar')
+        self.storage = dropbox.DropboxStorage('foo', '/bar')
         dirs, files = self.storage.listdir('/')
         self.assertFalse(dirs)
         self.assertFalse(files)
 
     def test_suspicious(self, *args):
-        self.storage = dropbox.DropBoxStorage('foo', '/bar')
+        self.storage = dropbox.DropboxStorage('foo', '/bar')
         with self.assertRaises((SuspiciousFileOperation, ValueError)):
             self.storage._full_path('..')
 
     def test_formats(self, *args):
-        self.storage = dropbox.DropBoxStorage('foo', '/bar')
+        self.storage = dropbox.DropboxStorage('foo', '/bar')
         files = self.storage._full_path('')
         self.assertEqual(files, self.storage._full_path('/'))
         self.assertEqual(files, self.storage._full_path('.'))


### PR DESCRIPTION
The "b" is capitalized in some but not all places. "Dropbox" is one word, not two.
 https://www.dropbox.com/branding#in-writing

Might not be worth merging if you're worried about backwards compatibility (or I can add some class aliases).