### PR TITLE
SpooledTemporaryFile.write() is meant to be called with small chunks,…

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -91,7 +91,7 @@ class S3Boto3StorageFile(File):
             )
             if 'r' in self._mode:
                 self._is_dirty = False
-                self._file.write(self.obj.get()['Body'].read())
+                self.obj.download_fileobj(self._file)
                 self._file.seek(0)
             if self._storage.gzip and self.obj.content_encoding == 'gzip':
                 self._file = GzipFile(mode=self._mode, fileobj=self._file, mtime=0.0)


### PR DESCRIPTION
… not once with a large payload

This fixes #383.

It was sending the entire contents of the S3 file to SpooledTemporaryFile.write() in a single call which defeats the purpose of using SpooledTemporaryFile as it only checks if it needs to switch to disk after each write.