### PR TITLE
Dropbox 8.x support

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,3 +7,4 @@ google-cloud-storage>=0.22.0
 mock
 paramiko
 pytest-cov>=2.2.1
+pathlib2

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,6 +1,6 @@
 boto3>=1.2.3
 boto>=2.32.0
-dropbox>=8.0.0
+dropbox>=8.2.0
 Django>=1.8
 flake8
 google-cloud-storage>=0.22.0

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -109,8 +109,11 @@ class DropBoxStorage(Storage):
         return metadata.client_modified
 
     def url(self, name):
-        media = self.client.files_get_temporary_link(self._full_path(name))
-        return media.link
+        try:
+            media = self.client.files_get_temporary_link(self._full_path(name))
+            return media.link
+        except ApiError:
+            raise ValueError("This file is not accessible via a URL.")
 
     def _open(self, name, mode='rb'):
         return DropBoxFile(self._full_path(name), self)

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -18,7 +18,7 @@ from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 from dropbox import Dropbox
 from dropbox.exceptions import ApiError
-from dropbox.files import CommitInfo, UploadSessionCursor, FolderMetadata
+from dropbox.files import CommitInfo, FolderMetadata, UploadSessionCursor
 
 from storages.utils import setting
 

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -1,17 +1,13 @@
 from datetime import datetime
 
-from django.core.exceptions import (
-    ImproperlyConfigured, SuspiciousFileOperation,
-)
-from django.core.files.base import ContentFile, File
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import File
 from django.test import TestCase
 from django.utils.six import BytesIO
+from dropbox.exceptions import ApiError
+from dropbox.files import FileMetadata, FolderMetadata, ListFolderResult
 
 from storages.backends import dropbox
-
-from requests import Response
-from dropbox.files import ListFolderResult, FolderMetadata, FileMetadata
-from dropbox.exceptions import ApiError
 
 try:
     from unittest import mock

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.utils.six import BytesIO
 
 from storages.backends import dropbox
+from dropbox.files import ListFolderResult, FolderMetadata, FileMetadata
 
 try:
     from unittest import mock
@@ -17,6 +18,12 @@ except ImportError:  # Python 3.2 and below
 
 class F(object):
     pass
+
+
+LIST_FOLDER_RESULT = ListFolderResult(entries=[
+    FolderMetadata(name='bar'),
+    FileMetadata(name='foo.txt'),
+], has_more=False)
 
 
 FILE_DATE = datetime(2015, 8, 24, 15, 6, 41)
@@ -86,8 +93,8 @@ class DropBoxTest(TestCase):
         exists = self.storage.exists('bar')
         self.assertFalse(exists)
 
-    @mock.patch('dropbox.Dropbox.files_get_metadata',
-                return_value=FILES_FIXTURE)
+    @mock.patch('dropbox.Dropbox.files_list_folder',
+                return_value=LIST_FOLDER_RESULT)
     def test_listdir(self, *args):
         dirs, files = self.storage.listdir('/')
         self.assertGreater(len(dirs), 0)
@@ -163,8 +170,8 @@ class DropBoxFileTest(TestCase):
         self.assertEqual(file.read(), b'bar')
 
 
-@mock.patch('dropbox.Dropbox.files_get_metadata',
-            return_value={'contents': []})
+@mock.patch('dropbox.Dropbox.files_list_folder',
+            return_value=ListFolderResult(entries=[], has_more=False))
 class DropBoxRootPathTest(TestCase):
     def test_jailed(self, *args):
         self.storage = dropbox.DropBoxStorage('foo', '/bar')

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     django110: Django>=1.10, <1.11
     django111: Django>=1.11, <2.0
     py27: mock
+    py27: pathlib2
+    py33: pathlib2
     boto3>=1.2.3
     boto>=2.32.0
     dropbox>=8.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     py27: mock
     boto3>=1.2.3
     boto>=2.32.0
-    dropbox>=8.0.0
+    dropbox>=8.2.0
     google-cloud-storage>=0.22.0
     paramiko
     pytest-cov>=2.2.1


### PR DESCRIPTION
Fixes support for recent versions of the Dropbox SDK.

The API was radically different to the previous SDK, but the mocks used in the unit tests made it so the unit tests appeared to continue passing. This updates the backend to use the return types in the new SDK.

Fixes #396 and #397.