### PR TITLE
Detect Content-Type when content_type property is null

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -378,8 +378,8 @@ class S3BotoStorage(Storage):
         name = self._normalize_name(cleaned_name)
         headers = self.headers.copy()
         _type, encoding = mimetypes.guess_type(name)
-        content_type = getattr(content, 'content_type',
-                               _type or self.key_class.DefaultContentType)
+        content_type = getattr(content, 'content_type', None)
+        content_type = content_type or _type or self.key_class.DefaultContentType
 
         # setting the content_type in the key object is not enough.
         headers.update({'Content-Type': content_type})

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -419,8 +419,8 @@ class S3Boto3Storage(Storage):
         name = self._normalize_name(cleaned_name)
         parameters = self.object_parameters.copy()
         _type, encoding = mimetypes.guess_type(name)
-        content_type = getattr(content, 'content_type',
-                               _type or self.default_content_type)
+        content_type = getattr(content, 'content_type', None)
+        content_type = content_type or _type or self.default_content_type
 
         # setting the content_type in the key object is not enough.
         parameters.update({'ContentType': content_type})

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -66,6 +66,26 @@ class S3BotoStorageTests(S3BotoTestCase):
             rewind=True
         )
 
+    def test_content_type(self):
+        """
+        Test saving a file with a None content type.
+        """
+        name = 'test_image.jpg'
+        content = ContentFile('data')
+        content.content_type = None
+        self.storage.save(name, content)
+        self.storage.bucket.get_key.assert_called_once_with(name)
+
+        key = self.storage.bucket.get_key.return_value
+        key.set_metadata.assert_called_with('Content-Type', 'image/jpeg')
+        key.set_contents_from_file.assert_called_with(
+            content,
+            headers={'Content-Type': 'image/jpeg'},
+            policy=self.storage.default_acl,
+            reduced_redundancy=self.storage.reduced_redundancy,
+            rewind=True
+        )
+
     def test_storage_save_gzipped(self):
         """
         Test saving a gzipped file

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -89,6 +89,25 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             }
         )
 
+    def test_content_type(self):
+        """
+        Test saving a file with a None content type.
+        """
+        name = 'test_image.jpg'
+        content = ContentFile('data')
+        content.content_type = None
+        self.storage.save(name, content)
+        self.storage.bucket.Object.assert_called_once_with(name)
+
+        obj = self.storage.bucket.Object.return_value
+        obj.upload_fileobj.assert_called_with(
+            content.file,
+            ExtraArgs={
+                'ContentType': 'image/jpeg',
+                'ACL': self.storage.default_acl,
+            }
+        )
+
     def test_storage_save_gzipped(self):
         """
         Test saving a gzipped file

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ deps =
     django110: Django>=1.10, <1.11
     django111: Django>=1.11, <2.0
     py27: mock
+    # enum is needed by paramiko, but wasn't added to py3 until py34
+    py33: enum34
     boto3>=1.2.3
     boto>=2.32.0
     dropbox>=8.0.0


### PR DESCRIPTION
Fallback on other content-type detection methods when the content_type property is None
Fixes #406 