### PR TITLE
Fix pickles

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -580,3 +580,16 @@ class S3Boto3Storage(Storage):
             name = self._clean_name(name)
             return name
         return super(S3Boto3Storage, self).get_available_name(name, max_length)
+
+    def __getstate__(self):
+        state = {}
+        # remove bucket and threading.local
+        state.update({
+            k: None if k in ('_bucket', '_connections') else v
+            for k, v in self.__dict__.items()
+        })
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self._connections = threading.local()

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import gzip
+import pickle
 import threading
 from datetime import datetime
 from unittest import skipIf
@@ -56,6 +57,37 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         """
         path = self.storage._clean_name("path\\to\\somewhere")
         self.assertEqual(path, "path/to/somewhere")
+
+    def test_pickle_with_bucket(self):
+        """
+        Test that the storage can be pickled with a bucket attached
+        """
+        # Ensure the bucket has been used
+        self.storage.bucket
+        self.assertIsNotNone(self.storage._bucket)
+
+        # Can't pickle MagicMock, but you can't pickle a real Bucket object either
+        p = pickle.dumps(self.storage)
+        new_storage = pickle.loads(p)
+
+        self.assertIsInstance(new_storage._connections, threading.local)
+        # Put the mock connection back in
+        new_storage._connections.connection = mock.MagicMock()
+
+        self.assertIsNone(new_storage._bucket)
+        new_storage.bucket
+        self.assertIsNotNone(new_storage._bucket)
+
+    def test_pickle_without_bucket(self):
+        """
+        Test that the storage can be pickled, without a bucket instance
+        """
+
+        # Can't pickle a threadlocal
+        p = pickle.dumps(self.storage)
+        new_storage = pickle.loads(p)
+
+        self.assertIsInstance(new_storage._connections, threading.local)
 
     def test_storage_url_slashes(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 
 [testenv]
-commands = py.test --cov=storages tests/
+commands = py.test --cov=storages tests/ {posargs}
 setenv =
     PYTHONDONTWRITEBYTECODE=1
     DJANGO_SETTINGS_MODULE=tests.settings


### PR DESCRIPTION
With this small change, storages instances are pickleable for the s3boto3 backend.