### PR TITLE
Fix flake8 error in storages/backends/ftp.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - env: TOX_ENV=lint
     - python: 2.7
       env: TOX_ENV=py27-django18
-    - python: 3.3
-      env: TOX_ENV=py33-django18
     - python: 3.4
       env: TOX_ENV=py34-django18
     - python: 3.5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 django-storages change log
 ==========================
 
+UNRELEASED
+**********
+
+* Dropped support for Python 3.3.
+
 1.6.5 (2017-08-01)
 ******************
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -109,7 +109,7 @@ class FTPStorage(Storage):
         for path_part in path_splitted:
             try:
                 self._connection.cwd(path_part)
-            except:
+            except Exception:
                 try:
                     self._connection.mkd(path_part)
                     self._connection.cwd(path_part)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    {py27,py33,py34,py35}-django18
+    {py27,py34,py35}-django18
     {py27,py34,py35}-django110
     {py27,py34,py35,py36}-django111
 


### PR DESCRIPTION
Fixes error:

```
  ./storages/backends/ftp.py:112:13: E722 do not use bare except'
```