### PR TITLE
New option GS_USE_STATIC_URL_AS_BASE_URL to use Django settings' STATIC_URL as the base URL

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -66,6 +66,13 @@ By default files with the same name will overwrite each other. Set this to ``Fal
 The maximum amount of memory a returned file can take up before being
 rolled over into a temporary file on disk. Default is 0: Do not roll over.
 
+``GS_USE_STATIC_URL_AS_BASE_URL`` (optional: default is ``False``)
+
+If you would like to use Django settings' ``STATIC_URL`` as the base URL, then
+set this option to ``True``, e.g.
+https://storage.googleapis.com/bucket_name/favicon.ico
+becomes https://static_url.set.in.django.settings/favicon.ico.
+
 Fields
 ------
 

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -69,9 +69,7 @@ rolled over into a temporary file on disk. Default is 0: Do not roll over.
 ``GS_USE_STATIC_URL_AS_BASE_URL`` (optional: default is ``False``)
 
 If you would like to use Django settings' ``STATIC_URL`` as the base URL, then
-set this option to ``True``, e.g.
-https://storage.googleapis.com/bucket_name/favicon.ico
-becomes https://static_url.set.in.django.settings/favicon.ico.
+set this option to ``True``.
 
 Fields
 ------

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -1,6 +1,10 @@
 import mimetypes
 from tempfile import SpooledTemporaryFile
-import urlparse
+
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
@@ -236,7 +240,7 @@ class GoogleCloudStorage(Storage):
         name = self._normalize_name(clean_name(name))
         if self.use_static_url_as_base_url and self.static_url is not None:
             # Django expects name to contain relative path.
-            url = urlparse.urljoin(self.static_url, './{}'.format(name))
+            url = urljoin(self.static_url, './{}'.format(name))
         else:
             blob = self._get_blob(self._encode_name(name))
             url = blob.public_url

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -7,7 +7,6 @@ except ImportError:  # Python 3.2 and below
 
 import datetime
 import mimetypes
-import urlparse
 
 from django.core.files.base import ContentFile
 from django.test import TestCase


### PR DESCRIPTION
Fix #385.