### PR TITLE
bucket.exists should return False if file is not found on the Google Cloud Storage

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -171,9 +171,11 @@ class GoogleCloudStorage(Storage):
                 return True
             except ImproperlyConfigured:
                 return False
-
         name = self._normalize_name(clean_name(name))
-        return bool(self.bucket.get_blob(self._encode_name(name)))
+        try:
+            return bool(self.bucket.get_blob(self._encode_name(name)))
+        except NotFound:
+            return False
 
     def listdir(self, name):
         name = self._normalize_name(clean_name(name))

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -151,6 +151,16 @@ class GCloudStorageTests(GCloudTestCase):
         self.assertTrue(self.storage.exists(''))
         self.storage._client.create_bucket.assert_called_with(self.bucket_name)
 
+    def test_not_exists_should_return_false_and_not_throw_exception(self):
+
+        def _raise_not_found(*args, **kwargs):
+            raise NotFound('File does not exist: cache/x/x/xxx.png')
+
+        self.storage._bucket = mock.MagicMock()
+        self.storage._bucket.get_blob.side_effect = _raise_not_found
+        self.assertFalse(self.storage.exists(self.filename))
+        self.storage._bucket.get_blob.assert_called_with(self.filename)
+
     def test_listdir(self):
         file_names = ["some/path/1.txt", "2.txt", "other/path/3.txt", "4.txt"]
 


### PR DESCRIPTION
sorl-thumbnail for example validates whether the thumbnail for any given image exists on the server before regeneration occurs. `exists` should always return True or False and not throw any exceptions.