### PR TITLE
Use tox environment variable TOXENV as supported by tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,29 +4,29 @@ cache: pip
 
 matrix:
   include:
-    - env: TOX_ENV=lint
+    - env: TOXENV=lint
     - python: 2.7
-      env: TOX_ENV=py27-django18
+      env: TOXENV=py27-django18
     - python: 3.3
-      env: TOX_ENV=py33-django18
+      env: TOXENV=py33-django18
     - python: 3.4
-      env: TOX_ENV=py34-django18
+      env: TOXENV=py34-django18
     - python: 3.5
-      env: TOX_ENV=py35-django18
+      env: TOXENV=py35-django18
     - python: 2.7
-      env: TOX_ENV=py27-django110
+      env: TOXENV=py27-django110
     - python: 3.4
-      env: TOX_ENV=py34-django110
+      env: TOXENV=py34-django110
     - python: 3.5
-      env: TOX_ENV=py35-django110
+      env: TOXENV=py35-django110
     - python: 2.7
-      env: TOX_ENV=py27-django111
+      env: TOXENV=py27-django111
     - python: 3.4
-      env: TOX_ENV=py34-django111
+      env: TOXENV=py34-django111
     - python: 3.5
-      env: TOX_ENV=py35-django111
+      env: TOXENV=py35-django111
     - python: 3.6
-      env: TOX_ENV=py36-django111
+      env: TOXENV=py36-django111
 
 before_install:
   - pip install codecov
@@ -38,4 +38,4 @@ after_success:
   - codecov
 
 script:
-  - tox -e $TOX_ENV
+  - tox


### PR DESCRIPTION
tox reads to environment variable `TOXENV` (not `TOX_ENV`) to decide what environment to test. Modify to fall in line with upstream. As a result, can use this feature instead of passing the environment through the `-e`
CLI argument.

More idiomatic with other project's use of tox and Travis.