### PR TITLE
 Libcloud backend flexible `extra_kwargs` during driver init

### DIFF
--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -89,7 +89,7 @@ class LibCloudStorage(Storage):
         directories, the second item being files.
         """
         container = self._get_bucket()
-        objects = self.driver.list_container_objects(container)
+        objects = self.driver.iterate_container_objects(container)
         path = self._clean_name(path)
         if not path.endswith('/'):
             path = "%s/" % path

--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -18,6 +18,9 @@ except ImportError:
     raise ImproperlyConfigured("Could not load libcloud")
 
 
+_KNOWN_OPTIONS = frozenset({'type', 'user', 'key', 'bucket'})
+
+
 @deconstructible
 class LibCloudStorage(Storage):
     """Django storage derived class using apache libcloud to operate
@@ -30,12 +33,8 @@ class LibCloudStorage(Storage):
         if not self.provider:
             raise ImproperlyConfigured(
                 'LIBCLOUD_PROVIDERS %s not defined or invalid' % provider_name)
-        extra_kwargs = {}
-        if 'region' in self.provider:
-            extra_kwargs['region'] = self.provider['region']
-        # Used by the GoogleStorageDriver
-        if 'project' in self.provider:
-            extra_kwargs['project'] = self.provider['project']
+        extra_kwargs = {k: self.provider[k]
+                        for k in self.provider.keys() - _KNOWN_OPTIONS}
         try:
             provider_type = self.provider['type']
             if isinstance(provider_type, string_types):


### PR DESCRIPTION
Pick up `extra_kwargs` from the settings by building a dictionary with all (key,value) pairs that are not "well-known" by the backend, allowing for more Libcloud driver flexibility with extra arguments that this backend is not aware of.

Use-case - I'm working on adding Tencent COS to Libcloud, and it requires `region` and `app_id` arguments.