### PR TITLE
Fix ValueError crash in S3Boto3Storage

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -446,8 +446,7 @@ class S3Boto3Storage(Storage):
         # even if wrapped file-like object exists. To avoid Django-specific
         # logic, pass internal file-like object if `content` is `File`
         # class instance.
-        if isinstance(content, File):
-            content = content.file
+        content.name = name
 
         self._save_content(obj, content, parameters=parameters)
         # Note: In boto3, after a put, last_modified is automatically reloaded

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -82,12 +82,13 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         obj = self.storage.bucket.Object.return_value
         obj.upload_fileobj.assert_called_with(
-            content.file,
+            content,
             ExtraArgs={
                 'ContentType': 'text/plain',
                 'ACL': self.storage.default_acl,
             }
         )
+        self.assertEqual(content.name, name)
 
     def test_storage_save_gzipped(self):
         """
@@ -98,13 +99,14 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.storage.save(name, content)
         obj = self.storage.bucket.Object.return_value
         obj.upload_fileobj.assert_called_with(
-            content.file,
+            content,
             ExtraArgs={
                 'ContentType': 'application/octet-stream',
                 'ContentEncoding': 'gzip',
                 'ACL': self.storage.default_acl,
             }
         )
+        self.assertEqual(content.name, name)
 
     def test_storage_save_gzip(self):
         """


### PR DESCRIPTION
Using this storage with `ManifestFilesMixin`, and in some other
not-so-uncommon scenarios.

This tweak essentially retains the changes from c73680e, but fixes #382.