### PR TITLE
Drop Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ matrix:
     - env: TOX_ENV=lint
     - python: 2.7
       env: TOX_ENV=py27-django18
-    - python: 3.3
-      env: TOX_ENV=py33-django18
     - python: 3.4
       env: TOX_ENV=py34-django18
     - python: 3.5

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -109,7 +109,7 @@ class FTPStorage(Storage):
         for path_part in path_splitted:
             try:
                 self._connection.cwd(path_part)
-            except:
+            except Exception:
                 try:
                     self._connection.mkd(path_part)
                     self._connection.cwd(path_part)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     lint
-    {py27,py33,py34,py35}-django18
+    {py27,py34,py35}-django18
     {py27,py34,py35}-django110
     {py27,py34,py35,py36}-django111
 


### PR DESCRIPTION
Python 3.3 has reached its end of life, and it's past time we drop
support for it.

Also, latest pytest no longer supports Python 3.3, so CI is currently
failing.