### PR TITLE
Prefer readthedocs.io instead of readthedocs.org for doc links

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -425,7 +425,7 @@ since March 2013.
 * Fixed S3BotoStorage performance problem calling modified_time()
 * Added deprecation warning for s3 backend, refs `#40`_
 * Fixed CLOUDFILES_CONNECTION_KWARGS import error, fixes `#78`_
-* Switched to sphinx documentation, set official docs up on http://django-storages.rtfd.org/
+* Switched to sphinx documentation, set official docs up on https://django-storages.readthedocs.io/
 * HashPathStorage uses self.exists now, fixes `#83`_
 
 .. _#13: https://bitbucket.org/david/django-storages/pull-request/13/a-version-of-sftp-storage-that-allows-you

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Issues are tracked via GitHub issues at the `project issue page
 
 Documentation
 =============
-Documentation for django-storages is located at https://django-storages.readthedocs.org/.
+Documentation for django-storages is located at https://django-storages.readthedocs.io/.
 
 Contributing
 ============


### PR DESCRIPTION
Read the Docs moved to hosting at readthedocs.io instead of readthedocs.org. Fix all links in the project.

For additional details, see:

https://blog.readthedocs.com/securing-subdomains/