### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,8 +54,7 @@ Issues are tracked via GitHub issues at the `project issue page
 
 Documentation
 =============
-The original documentation for django-storages is located at https://django-storages.readthedocs.org/.
-Stay tuned for forthcoming documentation updates.
+Documentation for django-storages is located at https://django-storages.readthedocs.org/.
 
 Contributing
 ============


### PR DESCRIPTION
Small tweak in README.  The portion changing hasn't been updated in 3 years (save adding https to the link).  Saying things like "The original documentation" and "stay tuned for forthcoming..." is inaccurate, given the docs are up-to-date on the site.