### PR TITLE
Add option to detect content encoding to fix gzip uploads.  Resolves #451

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -102,6 +102,9 @@ Available are numerous settings. It should be especially noted the following:
 ``AWS_IS_GZIPPED`` (optional: default is ``False``)
     Whether or not to enable gzipping of content types specified by ``GZIP_CONTENT_TYPES``
 
+``AWS_DETECT_CONTENT_ENCODING`` (optional: default is ``False``)
+    Detect content encoding on files and set ContentEncoding headers accordingly when sending to S3.  Files gzipped before being sent to S3 will be stored uncompressed.
+
 ``GZIP_CONTENT_TYPES`` (optional: default is ``text/css``, ``text/javascript``, ``application/javascript``, ``application/x-javascript``, ``image/svg+xml``)
     When ``AWS_IS_GZIPPED`` is set to ``True`` the content types which will be gzipped
 

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -199,6 +199,7 @@ class S3BotoStorage(Storage):
     secure_urls = setting('AWS_S3_SECURE_URLS', True)
     file_name_charset = setting('AWS_S3_FILE_NAME_CHARSET', 'utf-8')
     gzip = setting('AWS_IS_GZIPPED', False)
+    detect_content_encoding = setting('AWS_DETECT_CONTENT_ENCODING', False)
     preload_metadata = setting('AWS_PRELOAD_METADATA', False)
     gzip_content_types = setting('GZIP_CONTENT_TYPES', (
         'text/css',
@@ -386,7 +387,7 @@ class S3BotoStorage(Storage):
         if self.gzip and content_type in self.gzip_content_types:
             content = self._compress_content(content)
             headers.update({'Content-Encoding': 'gzip'})
-        elif encoding:
+        elif self.detect_content_encoding and encoding:
             # If the content already has a particular encoding, set it
             headers.update({'Content-Encoding': encoding})
 

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -206,6 +206,7 @@ class S3Boto3Storage(Storage):
     secure_urls = setting('AWS_S3_SECURE_URLS', True)
     file_name_charset = setting('AWS_S3_FILE_NAME_CHARSET', 'utf-8')
     gzip = setting('AWS_IS_GZIPPED', False)
+    detect_content_encoding = setting('AWS_DETECT_CONTENT_ENCODING', False)
     preload_metadata = setting('AWS_PRELOAD_METADATA', False)
     gzip_content_types = setting('GZIP_CONTENT_TYPES', (
         'text/css',
@@ -474,7 +475,7 @@ class S3Boto3Storage(Storage):
         if self.gzip and content_type in self.gzip_content_types:
             content = self._compress_content(content)
             parameters.update({'ContentEncoding': 'gzip'})
-        elif encoding:
+        elif self.detect_content_encoding and encoding:
             # If the content already has a particular encoding, set it
             parameters.update({'ContentEncoding': encoding})
 

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -4,8 +4,7 @@ except ImportError:  # Python 3.2 and below
     import mock
 
 import datetime
-import gzip
-import os
+import zlib
 
 from boto.exception import S3ResponseError
 from boto.s3.key import Key
@@ -94,7 +93,7 @@ class S3BotoStorageTests(S3BotoTestCase):
         Test saving a gzipped file
         """
         name = 'test_storage_save.gz'
-        compressed_data = gzip.compress("I am gzip'd".encode('utf8'))
+        compressed_data = zlib.compress("I am gzip'd".encode('utf8'))
         content = ContentFile(compressed_data)
         self.storage.detect_content_encoding = False
         self.storage.save(name, content)
@@ -114,7 +113,7 @@ class S3BotoStorageTests(S3BotoTestCase):
         Test saving a gzipped file
         """
         name = 'test_storage_save.gz'
-        compressed_data = gzip.compress("I am gzip'd".encode('utf8'))
+        compressed_data = zlib.compress("I am gzip'd".encode('utf8'))
         content = ContentFile(compressed_data)
         self.storage.detect_content_encoding = True
         self.storage.save(name, content)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -166,7 +166,27 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         Test saving a gzipped file
         """
         name = 'test_storage_save.gz'
-        content = ContentFile("I am gzip'd")
+        compressed_data = gzip.compress("I am gzip'd".encode('utf8'))
+        content = ContentFile(compressed_data)
+        self.storage.detect_content_encoding = False
+        self.storage.save(name, content)
+        obj = self.storage.bucket.Object.return_value
+        obj.upload_fileobj.assert_called_with(
+            content.file,
+            ExtraArgs={
+                'ContentType': 'application/octet-stream',
+                'ACL': self.storage.default_acl,
+            }
+        )
+
+    def test_storage_save_gzip_encoded(self):
+        """
+        Test saving a gzipped file
+        """
+        name = 'test_storage_save.gz'
+        compressed_data = gzip.compress("I am gzip'd".encode('utf8'))
+        content = ContentFile(compressed_data)
+        self.storage.detect_content_encoding = True
         self.storage.save(name, content)
         obj = self.storage.bucket.Object.return_value
         obj.upload_fileobj.assert_called_with(

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 
 import gzip
 import pickle
-import zlib
 import threading
 import warnings
+import zlib
 from datetime import datetime
 from unittest import skipIf
 

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 import gzip
 import pickle
+import zlib
 import threading
 import warnings
 from datetime import datetime
@@ -166,7 +167,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         Test saving a gzipped file
         """
         name = 'test_storage_save.gz'
-        compressed_data = gzip.compress("I am gzip'd".encode('utf8'))
+        compressed_data = zlib.compress("I am gzip'd".encode('utf8'))
         content = ContentFile(compressed_data)
         self.storage.detect_content_encoding = False
         self.storage.save(name, content)
@@ -184,7 +185,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         Test saving a gzipped file
         """
         name = 'test_storage_save.gz'
-        compressed_data = gzip.compress("I am gzip'd".encode('utf8'))
+        compressed_data = zlib.compress("I am gzip'd".encode('utf8'))
         content = ContentFile(compressed_data)
         self.storage.detect_content_encoding = True
         self.storage.save(name, content)


### PR DESCRIPTION
The behavior selected in the resolution of #263 has broken django storages when trying to upload normal gzip files without double compressing them or when `AWS_IS_GZIPPED=False`.

`AWS_DETECT_CONTENT_ENCODING` has been added to allow the behavior that was introduced last year to be used when desired.  If `AWS_DETECT_CONTENT_ENCODING=True` and `AWS_IS_GZIPPED=False` gzip encoded files will be stored in their uncompressed form on S3.  The detect content encoding default in the storage classes is `False` which reverses the behavior introduced in pull request #264.  This default of `False` would appear to be the least confusing to someone in a new project trying to use django-storages to upload a .gz file.

This pull request modifies the existing unit test and adds one new unit test to verify the behavior of both AWS_DETECT_CONTENT_ENCODING states in both the boto and boto3 based storage classes.  The new configuration option has also been added to the documentation.