### PR TITLE
New settings GS_CACHE_CONTROL to define caching policy via the Cache-Control HTTP header

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -66,7 +66,7 @@ By default files with the same name will overwrite each other. Set this to ``Fal
 The maximum amount of memory a returned file can take up before being
 rolled over into a temporary file on disk. Default is 0: Do not roll over.
 
-``GS_CACHE_CONTROL`` (optional: default is ``public, max-age=3600``)
+``GS_CACHE_CONTROL`` (optional: default is ``None``)
 
 Sets Cache-Control HTTP header for the file, more about HTTP caching can be found `here <https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control>`_
 

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -66,6 +66,10 @@ By default files with the same name will overwrite each other. Set this to ``Fal
 The maximum amount of memory a returned file can take up before being
 rolled over into a temporary file on disk. Default is 0: Do not roll over.
 
+``GS_CACHE_CONTROL`` (optional: default is ``public, max-age=3600``)
+
+Sets Cache-Control HTTP header for the file, more about HTTP caching can be found `here <https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control>`_
+
 Fields
 ------
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -86,6 +86,7 @@ class GoogleCloudStorage(Storage):
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
+    cache_control = setting('GS_CACHE_CONTROL', 'public, max-age=3600')
     # The max amount of memory a returned file can take up before being
     # rolled over into a temporary file on disk. Default is 0: Do not roll over.
     max_memory_size = setting('GS_MAX_MEMORY_SIZE', 0)
@@ -156,6 +157,7 @@ class GoogleCloudStorage(Storage):
         content.name = cleaned_name
         encoded_name = self._encode_name(name)
         file = GoogleCloudFile(encoded_name, 'rw', self)
+        file.blob.cache_control = self.cache_control
         file.blob.upload_from_file(content, size=content.size,
                                    content_type=file.mime_type)
         return cleaned_name

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -86,7 +86,7 @@ class GoogleCloudStorage(Storage):
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
-    cache_control = setting('GS_CACHE_CONTROL', 'public, max-age=3600')
+    cache_control = setting('GS_CACHE_CONTROL', None)
     # The max amount of memory a returned file can take up before being
     # rolled over into a temporary file on disk. Default is 0: Do not roll over.
     max_memory_size = setting('GS_MAX_MEMORY_SIZE', 0)

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -285,3 +285,16 @@ class GCloudStorageTests(GCloudTestCase):
     def test_get_available_name_unicode(self):
         filename = 'ủⓝï℅ⅆℇ.txt'
         self.assertEqual(self.storage.get_available_name(filename), filename)
+
+    def test_cache_control(self):
+        data = 'This is some test content.'
+        filename = 'cache_control_file.txt'
+        content = ContentFile(data)
+        cache_control = 'public, max-age=604800'
+
+        self.storage.cache_control = cache_control
+        self.storage.save(filename, content)
+
+        bucket = self.storage.client.get_bucket(self.bucket_name)
+        blob = bucket.get_blob(filename)
+        self.assertEqual(blob.cache_control, cache_control)


### PR DESCRIPTION
If you use gcloud as a storage in your django project you usually want to leverage browser caching and this will allow you to do that.