### PR TITLE
Boto/Boto3 metadata customization

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,5 +38,7 @@ By order of apparition, thanks:
     * Jon Dufresne
     * Piotr Roksela, Dariusz Rzepka (Boto and Boto3 metadata customization)
 
+
+
 Extra thanks to Marty for adding this in Django,
 you can buy his very interesting book (Pro Django).

--- a/AUTHORS
+++ b/AUTHORS
@@ -36,8 +36,7 @@ By order of apparition, thanks:
     * Alex Watt (Google Cloud Storage patch)
     * Jumpei Yoshimura (S3 docs)
     * Jon Dufresne
-
-
+    * Piotr Roksela, Dariusz Rzepka (Boto and Boto3 metadata customization)
 
 Extra thanks to Marty for adding this in Django,
 you can buy his very interesting book (Pro Django).

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -430,6 +430,7 @@ class S3BotoStorage(Storage):
             key.last_modified = datetime.utcnow().strftime(ISO8601)
 
         key.set_metadata('Content-Type', content_type)
+        headers = self.update_headers(headers, name, content)
         self._save_content(key, content, headers=headers)
         return cleaned_name
 
@@ -523,3 +524,9 @@ class S3BotoStorage(Storage):
         if self.file_overwrite:
             return get_available_overwrite_name(name, max_length)
         return super(S3BotoStorage, self).get_available_name(name, max_length)
+
+    def update_headers(self, headers, name=None, content=None):
+        """
+        Method that can be used to adjust file parameters.
+        """
+        return headers

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -503,6 +503,7 @@ class S3Boto3Storage(Storage):
         if isinstance(content, File):
             content = content.file
 
+        parameters = self.update_parameters(parameters, obj, content)
         self._save_content(obj, content, parameters=parameters)
         # Note: In boto3, after a put, last_modified is automatically reloaded
         # the next time it is accessed; no need to specifically reload it.
@@ -631,3 +632,9 @@ class S3Boto3Storage(Storage):
         if self.file_overwrite:
             return get_available_overwrite_name(name, max_length)
         return super(S3Boto3Storage, self).get_available_name(name, max_length)
+
+    def update_parameters(self, parameters, obj=None, content=None):
+        """
+        Method that can be used to adjust file parameters.
+        """
+        return parameters

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -374,3 +374,21 @@ class S3BotoStorageTests(S3BotoTestCase):
         )
         with self.assertRaises(ImproperlyConfigured, msg=msg):
             s3boto.S3BotoStorage(location='/')
+
+    def test_update_headers(self):
+        result = self.storage.update_headers({})
+        self.assertEqual(result, {})
+
+        class ExampleStorage(s3boto.S3BotoStorage):
+            def update_headers(self, headers, name=None, content=None):
+                if '.csv' in name:
+                    headers['Cache-Control'] = 'max-age=86400'
+                return headers
+
+        storage = ExampleStorage()
+        storage._connection = mock.MagicMock()
+
+        updated_headers = storage.update_headers({}, 'some_image.jpg')
+        self.assertEqual(updated_headers, {})
+        updated_headers = storage.update_headers({}, 'some_data.csv')
+        self.assertIn('Cache-Control', updated_headers)

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -380,7 +380,8 @@ class S3BotoStorageTests(S3BotoTestCase):
         self.assertEqual(result, {})
 
         class ExampleStorage(s3boto.S3BotoStorage):
-            def update_headers(self, headers, name=None, content=None):
+            def get_headers(self, name, content, content_type, encoding=None):
+                headers = {}
                 if '.csv' in name:
                     headers['Cache-Control'] = 'max-age=86400'
                 return headers
@@ -388,7 +389,7 @@ class S3BotoStorageTests(S3BotoTestCase):
         storage = ExampleStorage()
         storage._connection = mock.MagicMock()
 
-        updated_headers = storage.update_headers({}, 'some_image.jpg')
+        updated_headers = storage.get_headers('some_image.jpg', None, None)
         self.assertEqual(updated_headers, {})
-        updated_headers = storage.update_headers({}, 'some_data.csv')
+        updated_headers = storage.get_headers('some_data.csv', None, None)
         self.assertIn('Cache-Control', updated_headers)

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -375,9 +375,12 @@ class S3BotoStorageTests(S3BotoTestCase):
         with self.assertRaises(ImproperlyConfigured, msg=msg):
             s3boto.S3BotoStorage(location='/')
 
-    def test_update_headers(self):
-        result = self.storage.update_headers({})
-        self.assertEqual(result, {})
+    def test_get_headers(self):
+        result = self.storage.get_headers(name='file.pdf', content=None, content_type='application/pdf')
+        self.assertEqual(result, {'Content-Type': 'application/pdf'})
+        result = self.storage.get_headers(name='file.pdf', content=None, content_type='application/pdf',
+                                          encoding='gzip')
+        self.assertEqual(result, {'Content-Type': 'application/pdf', 'Content-Encoding': 'gzip'})
 
         class ExampleStorage(s3boto.S3BotoStorage):
             def get_headers(self, name, content, content_type, encoding=None):
@@ -388,7 +391,6 @@ class S3BotoStorageTests(S3BotoTestCase):
 
         storage = ExampleStorage()
         storage._connection = mock.MagicMock()
-
         updated_headers = storage.get_headers('some_image.jpg', None, None)
         self.assertEqual(updated_headers, {})
         updated_headers = storage.get_headers('some_data.csv', None, None)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -605,6 +605,9 @@ class S3Boto3StorageTests(S3Boto3TestCase):
     def test_get_parameters(self):
         result = self.storage.get_parameters('file.pdf', ContentFile(''), content_type='application/pdf')
         self.assertEqual(result, {'ContentType': 'application/pdf'})
+        result = self.storage.get_parameters(
+            'file.pdf', ContentFile(''), content_type='application/pdf', encoding='gzip')
+        self.assertEqual(result, {'ContentType': 'application/pdf', 'ContentEncoding': 'gzip'})
 
         class ExampleStorage(s3boto3.S3Boto3Storage):
             def get_parameters(self, obj, content, content_type, encoding=None):
@@ -615,7 +618,6 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         storage = ExampleStorage()
         storage._connection = mock.MagicMock()
-
         updated_parameters = storage.get_parameters(None, ContentFile(''), None)
         self.assertEqual(updated_parameters, {})
         updated_parameters = storage.get_parameters(None, ContentFile('some longer content'), None)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -601,3 +601,21 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         with warnings.catch_warnings(record=True) as w:
             MyStorage()
         assert len(w) == 0
+
+    def test_update_parameters(self):
+        result = self.storage.update_parameters({})
+        self.assertEqual(result, {})
+
+        class ExampleStorage(s3boto3.S3Boto3Storage):
+            def update_parameters(self, parameters, obj=None, content=None):
+                if content and content.size > 4:
+                    parameters['Cache-Control'] = 'max-age=86400'
+                return parameters
+
+        storage = ExampleStorage()
+        storage._connection = mock.MagicMock()
+
+        updated_parameters = storage.update_parameters({}, content='')
+        self.assertEqual(updated_parameters, {})
+        updated_parameters = storage.update_parameters({}, content=ContentFile('some longer content'))
+        self.assertIn('Cache-Control', updated_parameters)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -602,12 +602,13 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             MyStorage()
         assert len(w) == 0
 
-    def test_update_parameters(self):
-        result = self.storage.update_parameters({})
-        self.assertEqual(result, {})
+    def test_get_parameters(self):
+        result = self.storage.get_parameters('file.pdf', ContentFile(''), content_type='application/pdf')
+        self.assertEqual(result, {'ContentType': 'application/pdf'})
 
         class ExampleStorage(s3boto3.S3Boto3Storage):
-            def update_parameters(self, parameters, obj=None, content=None):
+            def get_parameters(self, obj, content, content_type, encoding=None):
+                parameters = {}
                 if content and content.size > 4:
                     parameters['Cache-Control'] = 'max-age=86400'
                 return parameters
@@ -615,7 +616,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         storage = ExampleStorage()
         storage._connection = mock.MagicMock()
 
-        updated_parameters = storage.update_parameters({}, content='')
+        updated_parameters = storage.get_parameters(None, ContentFile(''), None)
         self.assertEqual(updated_parameters, {})
-        updated_parameters = storage.update_parameters({}, content=ContentFile('some longer content'))
+        updated_parameters = storage.get_parameters(None, ContentFile('some longer content'), None)
         self.assertIn('Cache-Control', updated_parameters)


### PR DESCRIPTION
I added `update_headers` and `update_parameters` methods in Boto/Boto3 storages. These methods allow to implement metadata customization for specific files in inheriting classes without rewriting save method. The way this customization is performed can depend on project needs, but in a most basic scenario you can just use an if-else statement checking saved file name and contents.