### PR TITLE
gcloud: Set predefined_acl when saving file

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -245,7 +245,7 @@ class GoogleCloudStorage(Storage):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(clean_name(name))
         name = name.lstrip("/")
-        return "{}/{}".format(setting('MEDIA_URL'), name)
+        return "{}{}".format(setting('MEDIA_URL'), name)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -244,6 +244,7 @@ class GoogleCloudStorage(Storage):
     def url(self, name):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(clean_name(name))
+        name = name.lstrip("/")
         return "{}/{}".format(setting('MEDIA_URL'), name)
 
     def get_available_name(self, name, max_length=None):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -164,7 +164,8 @@ class GoogleCloudStorage(Storage):
         encoded_name = self._encode_name(name)
         file = GoogleCloudFile(encoded_name, 'rw', self)
         file.blob.upload_from_file(content, size=content.size,
-                                   content_type=file.mime_type)
+                                   content_type=file.mime_type,
+                                   predefined_acl=self.auto_create_acl)
         return cleaned_name
 
     def delete(self, name):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -244,8 +244,7 @@ class GoogleCloudStorage(Storage):
     def url(self, name):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(clean_name(name))
-        blob = self._get_blob(self._encode_name(name))
-        return blob.public_url
+        return "{}/{}/{}".format(setting('MEDIA_URL'), setting('GS_BUCKET_NAME'), name)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -244,7 +244,7 @@ class GoogleCloudStorage(Storage):
     def url(self, name):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(clean_name(name))
-        return "{}/{}/{}".format(setting('MEDIA_URL'), setting('GS_BUCKET_NAME'), name)
+        return "{}/{}/{}".format(setting('MEDIA_URL'), name)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -244,7 +244,7 @@ class GoogleCloudStorage(Storage):
     def url(self, name):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(clean_name(name))
-        return "{}/{}/{}".format(setting('MEDIA_URL'), name)
+        return "{}/{}".format(setting('MEDIA_URL'), name)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -102,7 +102,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, size=len(data), content_type=mimetypes.guess_type(self.filename)[0])
+            content, predefined_acl=self.storage.auto_create_acl, size=len(data), content_type=mimetypes.guess_type(self.filename)[0])
 
     def test_save2(self):
         data = 'This is some test ủⓝï℅ⅆℇ content.'
@@ -113,7 +113,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, size=len(data), content_type=mimetypes.guess_type(filename)[0])
+            content, predefined_acl=self.storage.auto_create_acl, size=len(data), content_type=mimetypes.guess_type(filename)[0])
 
     def test_delete(self):
         self.storage.delete(self.filename)

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -102,7 +102,11 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, predefined_acl=self.storage.auto_create_acl, size=len(data), content_type=mimetypes.guess_type(self.filename)[0])
+            content,
+            predefined_acl=self.storage.auto_create_acl,
+            size=len(data),
+            content_type=mimetypes.guess_type(self.filename)[0]
+        )
 
     def test_save2(self):
         data = 'This is some test ủⓝï℅ⅆℇ content.'
@@ -113,7 +117,11 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, predefined_acl=self.storage.auto_create_acl, size=len(data), content_type=mimetypes.guess_type(filename)[0])
+            content,
+            predefined_acl=self.storage.auto_create_acl,
+            size=len(data),
+            content_type=mimetypes.guess_type(filename)[0]
+        )
 
     def test_delete(self):
         self.storage.delete(self.filename)


### PR DESCRIPTION
The predefined_acl should be applied to files, not just the bucket when
its created (if auto create is on).

For example, if the acl is set to `publicRead` in the settings, this
should be applied to files even if the bucket already existed.