### PR TITLE
Fix data-corruption issue with s3boto and s3boto3 multipart uploads

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -74,6 +74,8 @@ class S3BotoStorageFile(File):
         if buffer_size is not None:
             self.buffer_size = buffer_size
         self._write_counter = 0
+        # file position of the latest part file uploaded
+        self._last_part_pos = 0
 
     @property
     def size(self):
@@ -123,9 +125,13 @@ class S3BotoStorageFile(File):
                 reduced_redundancy=self._storage.reduced_redundancy,
                 encrypt_key=self._storage.encryption,
             )
-        if self.buffer_size <= self._buffer_file_size:
+        if self.buffer_size <= self._file_part_size:
             self._flush_write_buffer()
         return super(S3BotoStorageFile, self).write(force_bytes(content), *args, **kwargs)
+
+    @property
+    def _file_part_size(self):
+        return self._buffer_file_size - self._last_part_pos
 
     @property
     def _buffer_file_size(self):
@@ -136,12 +142,15 @@ class S3BotoStorageFile(File):
         return length
 
     def _flush_write_buffer(self):
-        if self._buffer_file_size:
+        if self._file_part_size:
             self._write_counter += 1
-            self.file.seek(0)
+            pos = self.file.tell()
+            self.file.seek(self._last_part_pos)
             headers = self._storage.headers.copy()
             self._multipart.upload_part_from_file(
                 self.file, self._write_counter, headers=headers)
+            self.file.seek(pos)
+            self._last_part_pos = self._buffer_file_size
 
     def close(self):
         if self._is_dirty:

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -1,11 +1,10 @@
-import os
-
 try:
     from unittest import mock
 except ImportError:  # Python 3.2 and below
     import mock
 
 import datetime
+import os
 
 from boto.exception import S3ResponseError
 from boto.s3.key import Key

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -1,3 +1,5 @@
+import os
+
 try:
     from unittest import mock
 except ImportError:  # Python 3.2 and below
@@ -306,3 +308,39 @@ class S3BotoStorageTests(S3BotoTestCase):
             self.assertEqual(modtime,
                              tz.make_naive(tz.make_aware(
                                 datetime.datetime.strptime(utcnow, ISO8601), tz.utc)))
+
+    def test_file_greater_than_5MB(self):
+        name = 'test_storage_save.txt'
+        content = ContentFile('0' * 10 * 1024 * 1024)
+
+        # Set the encryption flag used for multipart uploads
+        self.storage.encryption = True
+        # Set the ACL header used when creating/writing data.
+        self.storage.bucket.connection.provider.acl_header = 'x-amz-acl'
+        # Set the mocked key's bucket
+        self.storage.bucket.get_key.return_value.bucket = self.storage.bucket
+        # Set the name of the mock object
+        self.storage.bucket.get_key.return_value.name = name
+
+        def get_upload_file_size(fp):
+            pos = fp.tell()
+            fp.seek(0, os.SEEK_END)
+            length = fp.tell() - pos
+            fp.seek(pos)
+            return length
+
+        def upload_part_from_file(fp, part_num, *args, **kwargs):
+            if len(file_part_size) != part_num:
+                file_part_size.append(get_upload_file_size(fp))
+
+        file_part_size = []
+        f = self.storage.open(name, 'w')
+
+        # initiate the multipart upload
+        f.write('')
+        f._multipart.upload_part_from_file = upload_part_from_file
+        for chunk in content.chunks():
+            f.write(chunk)
+        f.close()
+
+        assert content.size == sum(file_part_size)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import gzip, os
+import gzip
 import threading
 from datetime import datetime
 from unittest import skipIf
@@ -420,7 +420,6 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.storage.reduced_redundancy = True
         self.storage.default_acl = 'public-read'
 
-
         f = self.storage.open(name, 'w')
         self.storage.bucket.Object.assert_called_with(name)
         obj = self.storage.bucket.Object.return_value
@@ -432,7 +431,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         with mock.patch.object(f, '_flush_write_buffer') as method:
             f.write(content)
-            method.assert_not_called() # buffer not flushed on write
+            method.assert_not_called()  # buffer not flushed on write
 
         assert f._file_part_size == len(content)
         obj.initiate_multipart_upload.assert_called_with(
@@ -444,7 +443,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         with mock.patch.object(f, '_flush_write_buffer', wraps=f._flush_write_buffer) as method:
             f.close()
-            method.assert_called_with() # buffer flushed on close
+            method.assert_called_with()  # buffer flushed on close
         multipart.Part.assert_called_with(1)
         part.upload.assert_called_with(Body=content.encode('utf-8'))
         multipart.complete.assert_called_once_with(
@@ -478,16 +477,16 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         with mock.patch.object(f, '_flush_write_buffer', wraps=f._flush_write_buffer) as method:
             f.write(content1)
-            method.assert_not_called() # buffer doesn't get flushed on the first write
-            assert f._file_part_size == len(content1) # file part size is the size of what's written
-            assert f._last_part_pos == 0 # no parts added, so last part stays at 0
+            method.assert_not_called()  # buffer doesn't get flushed on the first write
+            assert f._file_part_size == len(content1)  # file part size is the size of what's written
+            assert f._last_part_pos == 0  # no parts added, so last part stays at 0
             f.write(content2)
-            method.assert_called_with() # second write flushes buffer
-            multipart.Part.assert_called_with(1) # first part created
-            part.upload.assert_called_with(Body=content1.encode('utf-8')) # first part is uploaded
-            assert f._last_part_pos == len(content1) # buffer spools to end of content1
-            assert f._buffer_file_size == len(content1) + len(content2) # _buffer_file_size is total written
-            assert f._file_part_size == len(content2) # new part is size of content2
+            method.assert_called_with()  # second write flushes buffer
+            multipart.Part.assert_called_with(1)  # first part created
+            part.upload.assert_called_with(Body=content1.encode('utf-8'))  # first part is uploaded
+            assert f._last_part_pos == len(content1)  # buffer spools to end of content1
+            assert f._buffer_file_size == len(content1) + len(content2)  # _buffer_file_size is total written
+            assert f._file_part_size == len(content2)  # new part is size of content2
 
         obj.initiate_multipart_upload.assert_called_with(
                 ACL='public-read',
@@ -510,4 +509,3 @@ class S3Boto3StorageTests(S3Boto3TestCase):
                     'PartNumber': 2
                 }
             ]})
-

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import gzip
+import gzip, os
 import threading
 from datetime import datetime
 from unittest import skipIf
@@ -406,3 +406,108 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         # Connection for each thread needs to be unique
         self.assertIsNot(connections[0], connections[1])
+
+    def test_file_greater_than_5mb(self):
+        """
+        test writing a large file in a single part so that the buffer is flushed
+        only on close
+        """
+        name = 'test_storage_save.txt'
+        content = '0' * 10 * 1024 * 1024
+
+        # set the encryption flag used for multipart uploads
+        self.storage.encryption = True
+        self.storage.reduced_redundancy = True
+        self.storage.default_acl = 'public-read'
+
+
+        f = self.storage.open(name, 'w')
+        self.storage.bucket.Object.assert_called_with(name)
+        obj = self.storage.bucket.Object.return_value
+        # set the name of the mock object
+        obj.key = name
+        multipart = obj.initiate_multipart_upload.return_value
+        part = multipart.Part.return_value
+        multipart.parts.all.return_value = [mock.MagicMock(e_tag='123', part_number=1)]
+
+        with mock.patch.object(f, '_flush_write_buffer') as method:
+            f.write(content)
+            method.assert_not_called() # buffer not flushed on write
+
+        assert f._file_part_size == len(content)
+        obj.initiate_multipart_upload.assert_called_with(
+                ACL='public-read',
+                ContentType='text/plain',
+                ServerSideEncryption='AES256',
+                StorageClass='REDUCED_REDUNDANCY'
+        )
+
+        with mock.patch.object(f, '_flush_write_buffer', wraps=f._flush_write_buffer) as method:
+            f.close()
+            method.assert_called_with() # buffer flushed on close
+        multipart.Part.assert_called_with(1)
+        part.upload.assert_called_with(Body=content.encode('utf-8'))
+        multipart.complete.assert_called_once_with(
+            MultipartUpload={'Parts': [{'ETag': '123', 'PartNumber': 1}]})
+
+    def test_file_write_after_exceeding_5mb(self):
+        """
+        test writing a large file in two parts so that the buffer is flushed
+        on write and on close
+        """
+        name = 'test_storage_save.txt'
+        content1 = '0' * 5 * 1024 * 1024
+        content2 = '0'
+
+        # set the encryption flag used for multipart uploads
+        self.storage.encryption = True
+        self.storage.reduced_redundancy = True
+        self.storage.default_acl = 'public-read'
+
+        f = self.storage.open(name, 'w')
+        self.storage.bucket.Object.assert_called_with(name)
+        obj = self.storage.bucket.Object.return_value
+        # set the name of the mock object
+        obj.key = name
+        multipart = obj.initiate_multipart_upload.return_value
+        part = multipart.Part.return_value
+        multipart.parts.all.return_value = [
+            mock.MagicMock(e_tag='123', part_number=1),
+            mock.MagicMock(e_tag='456', part_number=2)
+        ]
+
+        with mock.patch.object(f, '_flush_write_buffer', wraps=f._flush_write_buffer) as method:
+            f.write(content1)
+            method.assert_not_called() # buffer doesn't get flushed on the first write
+            assert f._file_part_size == len(content1) # file part size is the size of what's written
+            assert f._last_part_pos == 0 # no parts added, so last part stays at 0
+            f.write(content2)
+            method.assert_called_with() # second write flushes buffer
+            multipart.Part.assert_called_with(1) # first part created
+            part.upload.assert_called_with(Body=content1.encode('utf-8')) # first part is uploaded
+            assert f._last_part_pos == len(content1) # buffer spools to end of content1
+            assert f._buffer_file_size == len(content1) + len(content2) # _buffer_file_size is total written
+            assert f._file_part_size == len(content2) # new part is size of content2
+
+        obj.initiate_multipart_upload.assert_called_with(
+                ACL='public-read',
+                ContentType='text/plain',
+                ServerSideEncryption='AES256',
+                StorageClass='REDUCED_REDUNDANCY'
+        )
+        # save the internal file before closing
+        f.close()
+        multipart.Part.assert_called_with(2)
+        part.upload.assert_called_with(Body=content2.encode('utf-8'))
+        multipart.complete.assert_called_once_with(
+            MultipartUpload={'Parts': [
+                {
+                    'ETag': '123',
+                    'PartNumber': 1
+                },
+                {
+                    'ETag': '456',
+                    'PartNumber': 2
+                }
+            ]})
+

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -258,7 +258,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
     def test_storage_exists_doesnt_create_bucket(self):
         with mock.patch.object(self.storage, '_get_or_create_bucket') as method:
             self.storage.exists('file.txt')
-            method.assert_not_called()
+            self.assertFalse(method.called)
 
     def test_storage_delete(self):
         self.storage.delete("path/to/file.txt")
@@ -431,7 +431,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         with mock.patch.object(f, '_flush_write_buffer') as method:
             f.write(content)
-            method.assert_not_called()  # buffer not flushed on write
+            self.assertFalse(method.called)  # buffer not flushed on write
 
         assert f._file_part_size == len(content)
         obj.initiate_multipart_upload.assert_called_with(
@@ -477,7 +477,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         with mock.patch.object(f, '_flush_write_buffer', wraps=f._flush_write_buffer) as method:
             f.write(content1)
-            method.assert_not_called()  # buffer doesn't get flushed on the first write
+            self.assertFalse(method.called)  # buffer doesn't get flushed on the first write
             assert f._file_part_size == len(content1)  # file part size is the size of what's written
             assert f._last_part_pos == 0  # no parts added, so last part stays at 0
             f.write(content2)


### PR DESCRIPTION
This is a consolidation of #197 and #365 with merge conflicts resolved and `flake8` niggles addressed. All credit for the fixes belongs to @vinayinvicible and @tommwatson. 

Since the data-corruption problem is long-standing and severe, please consider merging these fixes and their included unit tests. If there are any issues with the proposed changes that make you hesitate to merge, please bring them up candidly—I'll work to address them ASAP!

I believe that this PR should:

* Close #169
* Fix #160
* Fix #364
* Fix #449

Additionally, #450 is related but cannot be closed by this PR because it also addresses #383, which is a separate issue about file _reading_.