### PR TITLE
Deprecate the S3BotoStorage backend in favor of S3Boto3Storage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 django-storages change log
 ==========================
 
+UNRELEASED
+**********
+
+* The `S3BotoStorage` backend is now deprecated in favor of `S3Boto3Storage`.
+  `S3BotoStorage` will be removed in a future version.
+
 1.6.6 (2018-03-26)
 ******************
 

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -1,5 +1,6 @@
 import mimetypes
 import os
+import warnings
 from datetime import datetime
 from gzip import GzipFile
 from tempfile import SpooledTemporaryFile
@@ -32,6 +33,16 @@ boto_version_info = tuple([int(i) for i in boto_version.split('-')[0].split('.')
 if boto_version_info[:2] < (2, 32):
     raise ImproperlyConfigured("The installed Boto library must be 2.32 or "
                                "higher.\nSee https://github.com/boto/boto")
+
+warnings.warn(
+    "DEPRECATION NOTICE: The S3BotoStorage backend is deprecated in favor of "
+    "the S3Boto3Storage backend. This backend uses the Boto library instead of "
+    "the next version of the library, Boto3. Going forward, API updates and all "
+    "new feature work will be focused on the Boto3 library and the "
+    "S3Boto3Storage backend. The S3BotoStorage backend will be removed in a "
+    "future version.",
+    DeprecationWarning,
+)
 
 
 @deconstructible


### PR DESCRIPTION
Add a deprecation warning when using `S3BotoStorage` that suggests upgrading to `S3Boto3Storage`. Give the user something visible to see to inform them to change their code and warn them the backend will be removed in a future version.