### PR TITLE
Avoid silently changing settings; raise ImproperlyConfigured instead

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_bytes, smart_str
 
-from storages.utils import clean_name, safe_join, setting
+from storages.utils import check_location, clean_name, safe_join, setting
 
 try:
     from google.cloud.storage.client import Client
@@ -101,7 +101,8 @@ class GoogleCloudStorage(Storage):
             if hasattr(self, name):
                 setattr(self, name, value)
 
-        self.location = (self.location or '').lstrip('/')
+        check_location(self)
+
         self._bucket = None
         self._client = None
 

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -14,7 +14,7 @@ from django.utils.encoding import (
 )
 from django.utils.six import BytesIO
 
-from storages.utils import clean_name, safe_join, setting
+from storages.utils import check_location, clean_name, safe_join, setting
 
 try:
     from boto import __version__ as boto_version
@@ -235,7 +235,8 @@ class S3BotoStorage(Storage):
         if bucket is not None:
             self.bucket_name = bucket
 
-        self.location = (self.location or '').lstrip('/')
+        check_location(self)
+
         # Backward-compatibility: given the anteriority of the SECURE_URL setting
         # we fall back to https if specified in order to avoid the construction
         # of unsecure urls.

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -16,7 +16,7 @@ from django.utils.six import BytesIO
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.timezone import is_naive, localtime
 
-from storages.utils import safe_join, setting
+from storages.utils import check_location, safe_join, setting
 
 try:
     import boto3.session
@@ -237,7 +237,8 @@ class S3Boto3Storage(Storage):
         if bucket is not None:
             self.bucket_name = bucket
 
-        self.location = (self.location or '').lstrip('/')
+        check_location(self)
+
         # Backward-compatibility: given the anteriority of the SECURE_URL setting
         # we fall back to https if specified in order to avoid the construction
         # of unsecure urls.

--- a/storages/utils.py
+++ b/storages/utils.py
@@ -80,3 +80,15 @@ def safe_join(base, *paths):
                          ' component')
 
     return final_path.lstrip('/')
+
+
+def check_location(storage):
+    if storage.location.startswith('/'):
+        correct = storage.location.lstrip('/')
+        raise ImproperlyConfigured(
+            "%s.location cannot begin with a leading slash. Found '%s'. Use '%s' instead." % (
+                storage.__class__.__name__,
+                storage.location,
+                correct,
+            )
+        )

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -8,6 +8,7 @@ except ImportError:  # Python 3.2 and below
 import datetime
 import mimetypes
 
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils import timezone
@@ -359,3 +360,11 @@ class GCloudStorageTests(GCloudTestCase):
         bucket = self.storage.client.get_bucket(self.bucket_name)
         blob = bucket.get_blob(filename)
         self.assertEqual(blob.cache_control, cache_control)
+
+    def test_location_leading_slash(self):
+        msg = (
+            "GoogleCloudStorage.location cannot begin with a leading slash. "
+            "Found '/'. Use '' instead."
+        )
+        with self.assertRaises(ImproperlyConfigured, msg=msg):
+            gcloud.GoogleCloudStorage(location='/')

--- a/tests/test_gs.py
+++ b/tests/test_gs.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.test import TestCase
 
@@ -30,3 +31,11 @@ class GSStorageTestCase(GSBotoTestCase):
             policy=self.storage.default_acl,
             rewind=True,
         )
+
+    def test_location_leading_slash(self):
+        msg = (
+            "GSBotoStorage.location cannot begin with a leading slash. "
+            "Found '/'. Use '' instead."
+        )
+        with self.assertRaises(ImproperlyConfigured, msg=msg):
+            gs.GSBotoStorage(location='/')

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -9,6 +9,7 @@ import os
 from boto.exception import S3ResponseError
 from boto.s3.key import Key
 from boto.utils import ISO8601, parse_ts
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils import timezone as tz
@@ -343,3 +344,11 @@ class S3BotoStorageTests(S3BotoTestCase):
         f.close()
 
         assert content.size == sum(file_part_size)
+
+    def test_location_leading_slash(self):
+        msg = (
+            "S3BotoStorage.location cannot begin with a leading slash. "
+            "Found '/'. Use '' instead."
+        )
+        with self.assertRaises(ImproperlyConfigured, msg=msg):
+            s3boto.S3BotoStorage(location='/')

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -8,6 +8,7 @@ from unittest import skipIf
 
 from botocore.exceptions import ClientError
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils.six.moves.urllib import parse as urlparse
@@ -509,3 +510,11 @@ class S3Boto3StorageTests(S3Boto3TestCase):
                     'PartNumber': 2
                 }
             ]})
+
+    def test_location_leading_slash(self):
+        msg = (
+            "S3Boto3Storage.location cannot begin with a leading slash. "
+            "Found '/'. Use '' instead."
+        )
+        with self.assertRaises(ImproperlyConfigured, msg=msg):
+            s3boto3.S3Boto3Storage(location='/')


### PR DESCRIPTION
If a setting is considered invalid, raise an exception instead of silently changing it to some other value. Avoids confusion and forces the library user to be explicit.

For example, setting S3 location to a value with a leading slash previously stripped it. Instead, now instruct the user to use a valid value without the leading slash.