### PR TITLE
Remove redundant argument None to setting()

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -40,7 +40,7 @@ class GoogleCloudFile(File):
             self._file = SpooledTemporaryFile(
                 max_size=self._storage.max_memory_size,
                 suffix=".GSStorageFile",
-                dir=setting("FILE_UPLOAD_TEMP_DIR", None)
+                dir=setting("FILE_UPLOAD_TEMP_DIR")
             )
             if 'r' in self._mode:
                 self._is_dirty = False
@@ -79,17 +79,17 @@ class GoogleCloudFile(File):
 
 @deconstructible
 class GoogleCloudStorage(Storage):
-    project_id = setting('GS_PROJECT_ID', None)
-    credentials = setting('GS_CREDENTIALS', None)
-    bucket_name = setting('GS_BUCKET_NAME', None)
+    project_id = setting('GS_PROJECT_ID')
+    credentials = setting('GS_CREDENTIALS')
+    bucket_name = setting('GS_BUCKET_NAME')
     location = setting('GS_LOCATION', '')
     auto_create_bucket = setting('GS_AUTO_CREATE_BUCKET', False)
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
-    default_acl = setting('GS_DEFAULT_ACL', None)
+    default_acl = setting('GS_DEFAULT_ACL')
 
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
-    cache_control = setting('GS_CACHE_CONTROL', None)
+    cache_control = setting('GS_CACHE_CONTROL')
     # The max amount of memory a returned file can take up before being
     # rolled over into a temporary file on disk. Default is 0: Do not roll over.
     max_memory_size = setting('GS_MAX_MEMORY_SIZE', 0)

--- a/storages/backends/gs.py
+++ b/storages/backends/gs.py
@@ -58,7 +58,7 @@ class GSBotoStorage(S3BotoStorage):
     secret_key = setting('GS_SECRET_ACCESS_KEY')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
     headers = setting('GS_HEADERS', {})
-    bucket_name = setting('GS_BUCKET_NAME', None)
+    bucket_name = setting('GS_BUCKET_NAME')
     auto_create_bucket = setting('GS_AUTO_CREATE_BUCKET', False)
     default_acl = setting('GS_DEFAULT_ACL', 'public-read')
     bucket_acl = setting('GS_BUCKET_ACL', default_acl)

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -86,7 +86,7 @@ class S3BotoStorageFile(File):
             self._file = SpooledTemporaryFile(
                 max_size=self._storage.max_memory_size,
                 suffix='.S3BotoStorageFile',
-                dir=setting('FILE_UPLOAD_TEMP_DIR', None)
+                dir=setting('FILE_UPLOAD_TEMP_DIR')
             )
             if 'r' in self._mode:
                 self._is_dirty = False
@@ -214,9 +214,9 @@ class S3BotoStorage(Storage):
     url_protocol = setting('AWS_S3_URL_PROTOCOL', 'http:')
     host = setting('AWS_S3_HOST', S3Connection.DefaultHost)
     use_ssl = setting('AWS_S3_USE_SSL', True)
-    port = setting('AWS_S3_PORT', None)
-    proxy = setting('AWS_S3_PROXY_HOST', None)
-    proxy_port = setting('AWS_S3_PROXY_PORT', None)
+    port = setting('AWS_S3_PORT')
+    proxy = setting('AWS_S3_PROXY_HOST')
+    proxy_port = setting('AWS_S3_PROXY_PORT')
 
     # The max amount of memory a returned file can take up before being
     # rolled over into a temporary file on disk. Default is 0: Do not roll over.

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -89,7 +89,7 @@ class S3Boto3StorageFile(File):
             self._file = SpooledTemporaryFile(
                 max_size=self._storage.max_memory_size,
                 suffix=".S3Boto3StorageFile",
-                dir=setting("FILE_UPLOAD_TEMP_DIR", None)
+                dir=setting("FILE_UPLOAD_TEMP_DIR")
             )
             if 'r' in self._mode:
                 self._is_dirty = False
@@ -216,8 +216,8 @@ class S3Boto3Storage(Storage):
         'image/svg+xml',
     ))
     url_protocol = setting('AWS_S3_URL_PROTOCOL', 'http:')
-    endpoint_url = setting('AWS_S3_ENDPOINT_URL', None)
-    region_name = setting('AWS_S3_REGION_NAME', None)
+    endpoint_url = setting('AWS_S3_ENDPOINT_URL')
+    region_name = setting('AWS_S3_REGION_NAME')
     use_ssl = setting('AWS_S3_USE_SSL', True)
 
     # The max amount of memory a returned file can take up before being


### PR DESCRIPTION
The function is defined with `default=None`, no need pass a value.