### PR TITLE
Remove unused argument strict from utils.setting()

### DIFF
--- a/storages/utils.py
+++ b/storages/utils.py
@@ -1,27 +1,19 @@
 import posixpath
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.utils.encoding import force_text
 
 
-def setting(name, default=None, strict=False):
+def setting(name, default=None):
     """
     Helper function to get a Django setting by name. If setting doesn't exists
-    it can return a default or raise an error if in strict mode.
+    it will return a default.
 
     :param name: Name of setting
     :type name: str
     :param default: Value if setting is unfound
-    :param strict: Define if return default value or raise an error
-    :type strict: bool
     :returns: Setting's value
-    :raises: django.core.exceptions.ImproperlyConfigured if setting is unfound
-             and strict mode
     """
-    if strict and not hasattr(settings, name):
-        msg = "You must provide settings.%s" % name
-        raise ImproperlyConfigured(msg)
     return getattr(settings, name, default)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 import datetime
 
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
 
 from storages import utils
@@ -11,12 +10,6 @@ class SettingTest(TestCase):
     def test_get_setting(self):
         value = utils.setting('SECRET_KEY')
         self.assertEqual(settings.SECRET_KEY, value)
-
-    def test_setting_unfound(self):
-        self.assertIsNone(utils.setting('FOO'))
-        self.assertEqual(utils.setting('FOO', 'bar'), 'bar')
-        with self.assertRaises(ImproperlyConfigured):
-            utils.setting('FOO', strict=True)
 
 
 class CleanNameTests(TestCase):


### PR DESCRIPTION
Unused since its introduction in c8e902b4c9e95ada0aa12488e6fd26cfad47fe85. Never passed as `True`, always `False`.