### PR TITLE
Calculate settings when storage is instantiated; not imported

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -9,11 +9,11 @@ from azure.storage.blob import BlobPermissions, ContentSettings
 from azure.storage.blob.blockblobservice import BlockBlobService
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.base import File
-from django.core.files.storage import Storage
 from django.utils import timezone
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import filepath_to_uri, force_bytes
 
+from storages.base import BaseStorage
 from storages.utils import (
     clean_name, get_available_overwrite_name, safe_join, setting,
 )
@@ -121,32 +121,37 @@ _AZURE_NAME_MAX_LEN = 1024
 
 
 @deconstructible
-class AzureStorage(Storage):
-
-    account_name = setting("AZURE_ACCOUNT_NAME")
-    account_key = setting("AZURE_ACCOUNT_KEY")
-    azure_container = setting("AZURE_CONTAINER")
-    azure_ssl = setting("AZURE_SSL", True)
-    upload_max_conn = setting("AZURE_UPLOAD_MAX_CONN", 2)
-    timeout = setting('AZURE_CONNECTION_TIMEOUT_SECS', 20)
-    max_memory_size = setting('AZURE_BLOB_MAX_MEMORY_SIZE', 2*1024*1024)
-    expiration_secs = setting('AZURE_URL_EXPIRATION_SECS')
-    overwrite_files = setting('AZURE_OVERWRITE_FILES', False)
-    location = setting('AZURE_LOCATION', '')
-    default_content_type = 'application/octet-stream'
-    cache_control = setting("AZURE_CACHE_CONTROL")
-    is_emulated = setting('AZURE_EMULATED_MODE', False)
-    endpoint_suffix = setting('AZURE_ENDPOINT_SUFFIX')
-    sas_token = setting('AZURE_SAS_TOKEN')
-    custom_domain = setting('AZURE_CUSTOM_DOMAIN')
-    connection_string = setting('AZURE_CONNECTION_STRING')
-    custom_connection_string = setting(
-        'AZURE_CUSTOM_CONNECTION_STRING', setting('AZURE_CONNECTION_STRING'))
-    token_credential = setting('AZURE_TOKEN_CREDENTIAL')
-
-    def __init__(self):
+class AzureStorage(BaseStorage):
+    def __init__(self, **settings):
+        super(AzureStorage, self).__init__(**settings)
         self._service = None
         self._custom_service = None
+
+    def get_default_settings(self):
+        return {
+            "account_name": setting("AZURE_ACCOUNT_NAME"),
+            "account_key": setting("AZURE_ACCOUNT_KEY"),
+            "azure_container": setting("AZURE_CONTAINER"),
+            "azure_ssl": setting("AZURE_SSL", True),
+            "upload_max_conn": setting("AZURE_UPLOAD_MAX_CONN", 2),
+            "timeout": setting('AZURE_CONNECTION_TIMEOUT_SECS', 20),
+            "max_memory_size": setting('AZURE_BLOB_MAX_MEMORY_SIZE', 2*1024*1024),
+            "expiration_secs": setting('AZURE_URL_EXPIRATION_SECS'),
+            "overwrite_files": setting('AZURE_OVERWRITE_FILES', False),
+            "location": setting('AZURE_LOCATION', ''),
+            "default_content_type": 'application/octet-stream',
+            "cache_control": setting("AZURE_CACHE_CONTROL"),
+            "is_emulated": setting('AZURE_EMULATED_MODE', False),
+            "endpoint_suffix": setting('AZURE_ENDPOINT_SUFFIX'),
+            "sas_token": setting('AZURE_SAS_TOKEN'),
+            "custom_domain": setting('AZURE_CUSTOM_DOMAIN'),
+            "connection_string": setting('AZURE_CONNECTION_STRING'),
+            "custom_connection_string": setting(
+                'AZURE_CUSTOM_CONNECTION_STRING',
+                setting('AZURE_CONNECTION_STRING'),
+            ),
+            "token_credential": setting('AZURE_TOKEN_CREDENTIAL'),
+        }
 
     def _blob_service(self, custom_domain=None, connection_string=None):
         # This won't open a connection or anything,

--- a/storages/base.py
+++ b/storages/base.py
@@ -1,0 +1,21 @@
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.storage import Storage
+
+
+class BaseStorage(Storage):
+    def __init__(self, **settings):
+        default_settings = self.get_default_settings()
+
+        for name, value in default_settings.items():
+            if not hasattr(self, name):
+                setattr(self, name, value)
+
+        for name, value in settings.items():
+            if name not in default_settings:
+                raise ImproperlyConfigured(
+                    "Invalid setting '%s' for %s" % (
+                        name,
+                        self.__class__.__name__,
+                    )
+                )
+            setattr(self, name, value)

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 import pytz
 from azure.storage.blob import Blob, BlobPermissions, BlobProperties
 from django.core.files.base import ContentFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from storages.backends import azure_storage
 
@@ -403,3 +403,30 @@ class AzureStorageTest(TestCase):
         self.storage._service.get_blob_properties.return_value = Blob(props=props)
         time = self.storage.modified_time("name")
         self.assertEqual(accepted_time, time)
+
+    def test_override_settings(self):
+        with override_settings(AZURE_CONTAINER='foo1'):
+            storage = azure_storage.AzureStorage()
+            self.assertEqual(storage.azure_container, 'foo1')
+        with override_settings(AZURE_CONTAINER='foo2'):
+            storage = azure_storage.AzureStorage()
+            self.assertEqual(storage.azure_container, 'foo2')
+
+    def test_override_class_variable(self):
+        class MyStorage1(azure_storage.AzureStorage):
+            azure_container = 'foo1'
+
+        storage = MyStorage1()
+        self.assertEqual(storage.azure_container, 'foo1')
+
+        class MyStorage2(azure_storage.AzureStorage):
+            azure_container = 'foo2'
+
+        storage = MyStorage2()
+        self.assertEqual(storage.azure_container, 'foo2')
+
+    def test_override_init_argument(self):
+        storage = azure_storage.AzureStorage(azure_container='foo1')
+        self.assertEqual(storage.azure_container, 'foo1')
+        storage = azure_storage.AzureStorage(azure_container='foo2')
+        self.assertEqual(storage.azure_container, 'foo2')

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from google.cloud.exceptions import Conflict, NotFound
 from google.cloud.storage.blob import Blob
@@ -438,3 +438,30 @@ class GCloudStorageTests(GCloudTestCase):
             "Unset GS_AUTO_CREATE_BUCKET (it defaults to False) to silence this warning."
         )
         assert str(w[-1].message) == message
+
+    def test_override_settings(self):
+        with override_settings(GS_LOCATION='foo1'):
+            storage = gcloud.GoogleCloudStorage()
+            self.assertEqual(storage.location, 'foo1')
+        with override_settings(GS_LOCATION='foo2'):
+            storage = gcloud.GoogleCloudStorage()
+            self.assertEqual(storage.location, 'foo2')
+
+    def test_override_class_variable(self):
+        class MyStorage1(gcloud.GoogleCloudStorage):
+            location = 'foo1'
+
+        storage = MyStorage1()
+        self.assertEqual(storage.location, 'foo1')
+
+        class MyStorage2(gcloud.GoogleCloudStorage):
+            location = 'foo2'
+
+        storage = MyStorage2()
+        self.assertEqual(storage.location, 'foo2')
+
+    def test_override_init_argument(self):
+        storage = gcloud.GoogleCloudStorage(location='foo1')
+        self.assertEqual(storage.location, 'foo1')
+        storage = gcloud.GoogleCloudStorage(location='foo2')
+        self.assertEqual(storage.location, 'foo2')

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -690,3 +690,30 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         with warnings.catch_warnings(record=True) as w:
             MyStorage()
         assert len(w) == 0
+
+    def test_override_settings(self):
+        with override_settings(AWS_LOCATION='foo1'):
+            storage = s3boto3.S3Boto3Storage()
+            self.assertEqual(storage.location, 'foo1')
+        with override_settings(AWS_LOCATION='foo2'):
+            storage = s3boto3.S3Boto3Storage()
+            self.assertEqual(storage.location, 'foo2')
+
+    def test_override_class_variable(self):
+        class MyStorage1(s3boto3.S3Boto3Storage):
+            location = 'foo1'
+
+        storage = MyStorage1()
+        self.assertEqual(storage.location, 'foo1')
+
+        class MyStorage2(s3boto3.S3Boto3Storage):
+            location = 'foo2'
+
+        storage = MyStorage2()
+        self.assertEqual(storage.location, 'foo2')
+
+    def test_override_init_argument(self):
+        storage = s3boto3.S3Boto3Storage(location='foo1')
+        self.assertEqual(storage.location, 'foo1')
+        storage = s3boto3.S3Boto3Storage(location='foo2')
+        self.assertEqual(storage.location, 'foo2')


### PR DESCRIPTION
Makes the storage classes usable with Django's `override_settings`. For example, projects can now change the S3 location & bucket when running their tests. Affects the following backends:

- azure_storage
- gcloud
- gs
- s3boto
- s3boto3

The remaining storage backends do not need to be altered as they do no calculate settings at import time.

The class `BaseStorage` was created to use a common pattern to initialize settings for various backends. Users of these backends can expect them to work consistently. This class is fully backwards compatible. Settings can now be set:

- In settings.py
- Using override_settings
- As a class variable
- As an argument to __init__

Closes #498

Completes all necessary backends and adds tests.