### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ All rights reserved.
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, 
+    1. Redistributions of source code must retain the above copyright notice,
        this list of conditions and the following disclaimer.
 
     2. Redistributions in binary form must reproduce the above copyright

--- a/docs/backends/apache_libcloud.rst
+++ b/docs/backends/apache_libcloud.rst
@@ -175,4 +175,3 @@ into your settings.py::
     libcloud.security.CA_CERTS_PATH.append("/path/to/your/cacerts.pem")
 
 .. _Download a certificate authority file: http://curl.haxx.se/ca/cacert.pem
-

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -61,7 +61,7 @@ ACL used when creating a new blob, from the
 translated.)
 
 For most cases, the blob will need to be set to the ``publicRead`` ACL in order for the file to viewed.
-If GS_DEFAULT_ACL is not set, the blob will have the default permissions set by the bucket. 
+If GS_DEFAULT_ACL is not set, the blob will have the default permissions set by the bucket.
 
 
 ``GS_FILE_CHARSET`` (optional)
@@ -83,7 +83,7 @@ Sets Cache-Control HTTP header for the file, more about HTTP caching can be foun
 
 ``GS_LOCATION`` (optional: default is ``''``)
 
-Subdirectory in which the files will be stored. 
+Subdirectory in which the files will be stored.
 Defaults to the root of the bucket.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,4 +46,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner by avoiding spurious white space changes on unrelated lines.