### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ django-storages
 
 
 .. image:: https://img.shields.io/pypi/v/django-storages.svg
-    :target: https://pypi.python.org/pypi/django-storages
+    :target: https://pypi.org/project/django-storages/
     :alt: PyPI Version
 
 .. image:: https://travis-ci.org/jschneier/django-storages.svg?branch=master


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html