### PR TITLE
Ensure content_type is str in S3Boto3Storage

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -431,6 +431,8 @@ class S3Boto3Storage(Storage):
         _type, encoding = mimetypes.guess_type(name)
         content_type = getattr(content, 'content_type', None)
         content_type = content_type or _type or self.default_content_type
+        if type(content_type) == bytes:
+            content_type = content_type.decode('utf8')
 
         # setting the content_type in the key object is not enough.
         parameters.update({'ContentType': content_type})

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -109,6 +109,25 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             }
         )
 
+    def test_bytes_content_type(self):
+        """
+        Test saving a file with a Bytes content type.
+        """
+        name = 'test_data.json'
+        content = ContentFile('data')
+        content.content_type = b'application/json'
+        self.storage.save(name, content)
+        self.storage.bucket.Object.assert_called_once_with(name)
+
+        obj = self.storage.bucket.Object.return_value
+        obj.upload_fileobj.assert_called_with(
+            content.file,
+            ExtraArgs={
+                'ContentType': u'application/json',
+                'ACL': self.storage.default_acl,
+            }
+        )
+
     def test_storage_save_gzipped(self):
         """
         Test saving a gzipped file


### PR DESCRIPTION
If `content_type` in `S3Boto3Storage._save()` is expressed as `bytes` instead of `str`, this will cause `botocore` to throw a validation error e.g: `Invalid type for parameter ContentType, value: b'text/javascript', type: <class 'bytes'>, valid types: <class 'str'>: ParamValidationError`.

This patch fixes this issue by ensuring `content_type` is a `str` before handing the value off to `boto3`.