### PR TITLE
Test using Django 2.1 final release

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ commands = py.test --cov=storages tests/ {posargs}
 deps =
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
-	django21: Django>=2.1b1,<2.2
+	django21: Django>=2.1,<2.2
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
 	py27: mock
 	pytest


### PR DESCRIPTION
Django 2.1 was released on August 1, 2018.

https://docs.djangoproject.com/en/2.1/releases/2.1/