### PR TITLE
Simplify install instructions by removing INSTALLED_APPS step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@ hasn't been released yet) then the magic incantation you are looking for is:
 
   pip install -e 'git+https://github.com/jschneier/django-storages.git#egg=django-storages'
 
-Once that is done add ``storages`` to your ``INSTALLED_APPS`` and set ``DEFAULT_FILE_STORAGE`` to the
-backend of your choice. If, for example, you want to use the boto3 backend you would set:
+Once that is done set ``DEFAULT_FILE_STORAGE`` to the backend of your choice.
+If, for example, you want to use the boto3 backend you would set:
 
 .. code-block:: python
 

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -12,14 +12,6 @@ Use pip to install from PyPI::
 
     pip install django-storages[google]
 
-Add ``storages`` to your settings.py file::
-
-    INSTALLED_APPS = (
-        ...
-        'storages',
-        ...
-    )
-
 Authentication
 --------------
 By default this library will try to use the credentials associated with the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,14 +16,6 @@ Use pip to install from PyPI::
 
     pip install django-storages
 
-Add ``storages`` to your settings.py file::
-
-    INSTALLED_APPS = (
-        ...
-        'storages',
-        ...
-    )
-
 Each storage backend has its own unique settings you will need to add to your settings.py file. Read the documentation for your storage engine(s) of choice to determine what you need to add.
 
 Contributing

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -7,7 +7,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.sessions',
     'django.contrib.contenttypes',
-    'storages'
 )
 
 DATABASES = {


### PR DESCRIPTION
django-storages is not required to be in `INSTALLED_APPS`. It provides no models, templates, templatetags, or other Django features that use a registered app. Can simplify the installation instructions and avoid unnecessary configuration.

The Django configuration used, `DEFAULT_FILE_STORAGE`, can be any valid Python path even if it isn't a configured app.

I have been successfully using django-storages without `INSTALLED_APPS` on projects for quite some time.