### PR TITLE
Remove unnecessary install step from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ before_install:
   - if [[ $TRAVIS_DIST == trusty ]]; then sudo rm /etc/boto.cfg; fi
 
 install:
-  - pip install --upgrade pip setuptools wheel
   - pip install tox
 
 script:


### PR DESCRIPTION
Upgrading pip, setuptools, and wheel is unnecessary. It only adds time and network traffic to the CI build.