### PR TITLE
Make sure that we read the file from the beginning in Google Cloud Storage backend

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -169,7 +169,7 @@ class GoogleCloudStorage(Storage):
         file = GoogleCloudFile(encoded_name, 'rw', self)
         file.blob.cache_control = self.cache_control
         content.seek(0)
-        file.blob.upload_from_file(content, size=content.size,
+        file.blob.upload_from_file(content, rewind=True, size=content.size,
                                    content_type=file.mime_type)
         if self.default_acl:
             file.blob.acl.save_predefined(self.default_acl)

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -103,7 +103,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, size=len(data), content_type=mimetypes.guess_type(self.filename)[0])
+            content, rewind=True, size=len(data), content_type=mimetypes.guess_type(self.filename)[0])
 
     def test_save2(self):
         data = 'This is some test ủⓝï℅ⅆℇ content.'
@@ -114,7 +114,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, size=len(data), content_type=mimetypes.guess_type(filename)[0])
+            content, rewind=True, size=len(data), content_type=mimetypes.guess_type(filename)[0])
 
     def test_save_with_default_acl(self):
         data = 'This is some test ủⓝï℅ⅆℇ content.'
@@ -130,7 +130,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, size=len(data), content_type=mimetypes.guess_type(filename)[0])
+            content, rewind=True, size=len(data), content_type=mimetypes.guess_type(filename)[0])
         self.storage._bucket.get_blob().acl.save_predefined.assert_called_with('publicRead')
 
     def test_delete(self):


### PR DESCRIPTION
Makes the same effect as with s3 storage:

https://github.com/jschneier/django-storages/blob/7757ff0ee62e52d2c67fcfe90858a3c646ad0de1/storages/backends/s3boto3.py#L512

Without rewinding the file to the beginning, it's possible that we will try to upload 0 bytes in case if some code reads the file before Django calls the save method on backend.