### PR TITLE
Gcloud url fixes to handle public and private files 

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -138,7 +138,7 @@ Sets Cache-Control HTTP header for the file, more about HTTP caching can be foun
 Subdirectory in which the files will be stored.
 Defaults to the root of the bucket.
 
-``GS_EXPIRES_ON`` (optional: default is ``''``)
+``GS_EXPIRES_ON`` (optional: default is ``timedelta(seconds=86400)``)
 
 The time that a generated URL is valid before expiration. The default is 1 day.
 Public files will return a url that does not expire.

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -143,7 +143,7 @@ Sets Cache-Control HTTP header for the file, more about HTTP caching can be foun
 Subdirectory in which the files will be stored.
 Defaults to the root of the bucket.
 
-``GS_EXPIRES_ON`` (optional: default is ``timedelta(seconds=86400)``)
+``GS_EXPIRES_IN`` (optional: default is ``timedelta(seconds=86400)``)
 
 The time that a generated URL is valid before expiration. The default is 1 day.
 Public files will return a url that does not expire. Files will be signed by
@@ -152,7 +152,7 @@ the credentials provided to django-storages (See GS_CREDENTIALS).
 Note: Default Google Compute Engine (GCE) Service accounts are
 `unable to sign urls <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
 
-The ``GS_EXPIRES_ON`` value is handled by the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
+The ``GS_EXPIRES_IN`` value is handled by the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
 It supports `timedelta`, `datetime`, or `integer` seconds since epoch time.
 
 

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -143,7 +143,7 @@ Sets Cache-Control HTTP header for the file, more about HTTP caching can be foun
 Subdirectory in which the files will be stored.
 Defaults to the root of the bucket.
 
-``GS_EXPIRES_IN`` (optional: default is ``timedelta(seconds=86400)``)
+``GS_EXPIRATION`` (optional: default is ``timedelta(seconds=86400)``)
 
 The time that a generated URL is valid before expiration. The default is 1 day.
 Public files will return a url that does not expire. Files will be signed by
@@ -152,7 +152,7 @@ the credentials provided to django-storages (See GS_CREDENTIALS).
 Note: Default Google Compute Engine (GCE) Service accounts are
 `unable to sign urls <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
 
-The ``GS_EXPIRES_IN`` value is handled by the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
+The ``GS_EXPIRATION`` value is handled by the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
 It supports `timedelta`, `datetime`, or `integer` seconds since epoch time.
 
 

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -113,6 +113,8 @@ translated.)
 For most cases, the blob will need to be set to the ``publicRead`` ACL in order for the file to viewed.
 If GS_DEFAULT_ACL is not set, the blob will have the default permissions set by the bucket.
 
+``publicRead`` files will return a public - non-expiring url.
+
 
 ``GS_FILE_CHARSET`` (optional)
 
@@ -135,6 +137,12 @@ Sets Cache-Control HTTP header for the file, more about HTTP caching can be foun
 
 Subdirectory in which the files will be stored.
 Defaults to the root of the bucket.
+
+``GS_EXPIRES_ON`` (optional: default is ``''``)
+
+The time that a generated URL is valid before expiration. The default is 1 day.
+Public files will return a url that does not expire.
+
 
 Usage
 -----

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -147,13 +147,13 @@ Defaults to the root of the bucket.
 
 The time that a generated URL is valid before expiration. The default is 1 day.
 Public files will return a url that does not expire. Files will be signed by
-the default credentials provided to the client.
+the credentials provided to django-storages (See GS_CREDENTIALS).
 
 Note: Default Google Compute Engine (GCE) Service accounts are
 `unable to sign urls <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
 
-The value is handled to the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
-It supports `timedelta`, `datetime`, or `integer` number of seconds.
+The ``GS_EXPIRES_ON`` value is handled by the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
+It supports `timedelta`, `datetime`, or `integer` seconds since epoch time.
 
 
 Usage

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -141,7 +141,8 @@ Defaults to the root of the bucket.
 ``GS_EXPIRES_ON`` (optional: default is ``timedelta(seconds=86400)``)
 
 The time that a generated URL is valid before expiration. The default is 1 day.
-Public files will return a url that does not expire.
+Public files will return a url that does not expire. Files will be signed by
+the default credentials provided to the client.
 
 
 Usage

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -1,8 +1,8 @@
 Google Cloud Storage
 ====================
 
-This backend provides Django File API for `Google Cloud Storage <https://cloud.google.com/storage/>`
-using the python library provided by Google.
+This backend provides Django File API for `Google Cloud Storage <https://cloud.google.com/storage/>`_
+using the Python library provided by Google.
 
 
 Installation
@@ -15,19 +15,20 @@ Use pip to install from PyPI::
 Authentication
 --------------
 By default this library will try to use the credentials associated with the
-current Google Compute Engine (GCE) instance for authentication.
+current Google Compute Engine (GCE) or Google Kubernetes Engine (GKE) instance
+for authentication. In most cases, the default service accounts are not sufficient
+to read/write and sign files in GCS.
 
-#. Create a service account.
-(`Google Getting Started Guide <https://cloud.google.com/docs/authentication/getting-started>`)
-#. Create the key and download `your-project-XXXXX.json` file.
-#. Set an environment variable of GOOGLE_APPLICATION_CREDENTIALS to path of the json file.
-#. Make sure your service account has access to the bucket.
-(`Using IAM Permissions <https://cloud.google.com/storage/docs/access-control/using-iam-permissions>`)
+1. Create a service account.
+(`Google Getting Started Guide <https://cloud.google.com/docs/authentication/getting-started>`__)
+2. Create the key and download `your-project-XXXXX.json` file.
+3. Make sure your service account has access to the bucket and appropriate permissions.
+(`Using IAM Permissions <https://cloud.google.com/storage/docs/access-control/using-iam-permissions>`__)
+4. The key must be mounted/available to your running Django app.
+Note: a json keyfile will work for developer machines (or other instances outside Google infrastructure).
+5. Set an environment variable of GOOGLE_APPLICATION_CREDENTIALS to path of the json file.
 
-
-Alternatively, if you do not want to use the env variable GOOGLE_APPLICATION_CREDENTIALS
-use the setting `GS_CREDENTIALS` as described below.
-
+Alternatively, you can use the setting `GS_CREDENTIALS` as described below.
 
 
 Getting Started
@@ -113,7 +114,11 @@ translated.)
 For most cases, the blob will need to be set to the ``publicRead`` ACL in order for the file to viewed.
 If GS_DEFAULT_ACL is not set, the blob will have the default permissions set by the bucket.
 
-``publicRead`` files will return a public - non-expiring url.
+``publicRead`` files will return a public - non-expiring url. All other files return
+a signed (expiring) url.
+
+**GS_DEFAULT_ACL must be set to ``publicRead`` to return a public url.** Even if you set
+the bucket to public or set the file permissions directly in GCS to public.
 
 
 ``GS_FILE_CHARSET`` (optional)
@@ -143,6 +148,12 @@ Defaults to the root of the bucket.
 The time that a generated URL is valid before expiration. The default is 1 day.
 Public files will return a url that does not expire. Files will be signed by
 the default credentials provided to the client.
+
+Note: Default Google Compute Engine (GCE) Service accounts are
+`unable to sign urls <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
+
+The value is handled to the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
+It supports `timedelta`, `datetime`, or `integer` number of seconds.
 
 
 Usage

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -88,7 +88,7 @@ class GoogleCloudStorage(Storage):
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     default_acl = setting('GS_DEFAULT_ACL')
 
-    expires_in = setting('GS_EXPIRES_IN', timedelta(seconds=86400))
+    expiration = setting('GS_EXPIRATION', timedelta(seconds=86400))
 
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
@@ -262,7 +262,7 @@ class GoogleCloudStorage(Storage):
 
         if self.default_acl == 'publicRead':
             return blob.public_url
-        return blob.generate_signed_url(self.expires_in)
+        return blob.generate_signed_url(self.expiration)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -1,6 +1,6 @@
 import mimetypes
-from tempfile import SpooledTemporaryFile
 from datetime import timedelta
+from tempfile import SpooledTemporaryFile
 
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -88,7 +88,7 @@ class GoogleCloudStorage(Storage):
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     default_acl = setting('GS_DEFAULT_ACL')
 
-    expires_on = setting('GS_EXPIRES_ON', timedelta(seconds=86400))
+    expires_in = setting('GS_EXPIRES_IN', timedelta(seconds=86400))
 
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
@@ -259,10 +259,10 @@ class GoogleCloudStorage(Storage):
         """
         name = self._normalize_name(clean_name(name))
         blob = self.bucket.blob(self._encode_name(name))
-        if (self.default_acl == 'publicRead'):
+        if self.default_acl == 'publicRead':
             return blob.public_url
 
-        return blob.generate_signed_url(expiration=self.expires_on)
+        return blob.generate_signed_url(self.expires_in)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -259,9 +259,9 @@ class GoogleCloudStorage(Storage):
         """
         name = self._normalize_name(clean_name(name))
         blob = self.bucket.blob(self._encode_name(name))
+
         if self.default_acl == 'publicRead':
             return blob.public_url
-
         return blob.generate_signed_url(self.expires_in)
 
     def get_available_name(self, name, max_length=None):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -88,7 +88,7 @@ class GoogleCloudStorage(Storage):
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     default_acl = setting('GS_DEFAULT_ACL')
 
-    expires_on = setting('GS_EXPIRES_ON',timedelta(seconds=86400))
+    expires_on = setting('GS_EXPIRES_ON', timedelta(seconds=86400))
 
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -1,5 +1,6 @@
 import mimetypes
 from tempfile import SpooledTemporaryFile
+from datetime import timedelta
 
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File
@@ -86,6 +87,8 @@ class GoogleCloudStorage(Storage):
     auto_create_bucket = setting('GS_AUTO_CREATE_BUCKET', False)
     auto_create_acl = setting('GS_AUTO_CREATE_ACL', 'projectPrivate')
     default_acl = setting('GS_DEFAULT_ACL')
+
+    expires_on = setting('GS_EXPIRES_ON',timedelta(seconds=86400))
 
     file_name_charset = setting('GS_FILE_NAME_CHARSET', 'utf-8')
     file_overwrite = setting('GS_FILE_OVERWRITE', True)
@@ -249,10 +252,17 @@ class GoogleCloudStorage(Storage):
         return created if setting('USE_TZ') else timezone.make_naive(created)
 
     def url(self, name):
-        # Preserve the trailing slash after normalizing the path.
+        """
+        Return public url or a signed url for the Blob.
+        This DOES NOT check for existance of Blob - that makes codes too slow
+        for many use cases.
+        """
         name = self._normalize_name(clean_name(name))
-        blob = self._get_blob(self._encode_name(name))
-        return blob.public_url
+        blob = self.bucket.blob(self._encode_name(name))
+        if (self.default_acl == 'publicRead'):
+            return blob.public_url
+
+        return blob.generate_signed_url(expiration=self.expires_on)
 
     def get_available_name(self, name, max_length=None):
         if self.file_overwrite:

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -5,9 +5,8 @@ try:
 except ImportError:  # Python 3.2 and below
     import mock
 
-import datetime
-from datetime import timedelta
 import mimetypes
+from datetime import datetime, timedelta
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
@@ -252,7 +251,7 @@ class GCloudStorageTests(GCloudTestCase):
         self.assertRaises(NotFound, self.storage.size, self.filename)
 
     def test_modified_time(self):
-        naive_date = datetime.datetime(2017, 1, 2, 3, 4, 5, 678)
+        naive_date = datetime(2017, 1, 2, 3, 4, 5, 678)
         aware_date = timezone.make_aware(naive_date, timezone.utc)
 
         self.storage._bucket = mock.MagicMock()
@@ -267,7 +266,7 @@ class GCloudStorageTests(GCloudTestCase):
             self.storage._bucket.get_blob.assert_called_with(self.filename)
 
     def test_get_modified_time(self):
-        naive_date = datetime.datetime(2017, 1, 2, 3, 4, 5, 678)
+        naive_date = datetime(2017, 1, 2, 3, 4, 5, 678)
         aware_date = timezone.make_aware(naive_date, timezone.utc)
 
         self.storage._bucket = mock.MagicMock()
@@ -289,7 +288,7 @@ class GCloudStorageTests(GCloudTestCase):
             self.storage._bucket.get_blob.assert_called_with(self.filename)
 
     def test_get_created_time(self):
-        naive_date = datetime.datetime(2017, 1, 2, 3, 4, 5, 678)
+        naive_date = datetime(2017, 1, 2, 3, 4, 5, 678)
         aware_date = timezone.make_aware(naive_date, timezone.utc)
 
         self.storage._bucket = mock.MagicMock()

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -6,6 +6,7 @@ except ImportError:  # Python 3.2 and below
     import mock
 
 import datetime
+from datetime import timedelta
 import mimetypes
 
 from django.core.exceptions import ImproperlyConfigured
@@ -315,22 +316,47 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.assertRaises(NotFound, self.storage.modified_time, self.filename)
 
-    def test_url(self):
+    def test_url_public_object(self):
         url = 'https://example.com/mah-bukkit/{}'.format(self.filename)
+        self.storage.default_acl = 'publicRead'
 
         self.storage._bucket = mock.MagicMock()
         blob = mock.MagicMock()
         blob.public_url = url
-        self.storage._bucket.get_blob.return_value = blob
+        blob.generate_signed_url = 'not called'
+        self.storage._bucket.blob.return_value = blob
 
         self.assertEqual(self.storage.url(self.filename), url)
-        self.storage._bucket.get_blob.assert_called_with(self.filename)
+        self.storage._bucket.blob.assert_called_with(self.filename)
 
-    def test_url_no_file(self):
+    def test_url_not_public_file(self):
+        secret_filename = 'secret_file.txt'
         self.storage._bucket = mock.MagicMock()
-        self.storage._bucket.get_blob.return_value = None
+        blob = mock.MagicMock()
+        generate_signed_url = mock.MagicMock(return_value='http://signed_url')
+        blob.public_url = 'http://this_is_public_url'
+        blob.generate_signed_url = generate_signed_url
+        self.storage._bucket.blob.return_value = blob
 
-        self.assertRaises(NotFound, self.storage.url, self.filename)
+        url = self.storage.url(secret_filename)
+        self.storage._bucket.blob.assert_called_with(secret_filename)
+        self.assertEqual(url,'http://signed_url')
+        blob.generate_signed_url.assert_called_with(expiration=timedelta(seconds=86400))
+
+    def test_url_not_public_file_with_custom_expires(self):
+        secret_filename = 'secret_file.txt'
+        self.storage._bucket = mock.MagicMock()
+        blob = mock.MagicMock()
+        generate_signed_url = mock.MagicMock(return_value='http://signed_url')
+        blob.generate_signed_url = generate_signed_url
+        self.storage._bucket.blob.return_value = blob
+
+        self.storage.expires_on = timedelta(seconds=3600)
+
+        url = self.storage.url(secret_filename)
+        self.storage._bucket.blob.assert_called_with(secret_filename)
+        self.assertEqual(url,'http://signed_url')
+        blob.generate_signed_url.assert_called_with(expiration=timedelta(seconds=3600))
 
     def test_get_available_name(self):
         self.storage.file_overwrite = True

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -340,7 +340,7 @@ class GCloudStorageTests(GCloudTestCase):
         url = self.storage.url(secret_filename)
         self.storage._bucket.blob.assert_called_with(secret_filename)
         self.assertEqual(url, 'http://signed_url')
-        blob.generate_signed_url.assert_called_with(expiration=timedelta(seconds=86400))
+        blob.generate_signed_url.assert_called_with(timedelta(seconds=86400))
 
     def test_url_not_public_file_with_custom_expires(self):
         secret_filename = 'secret_file.txt'
@@ -350,12 +350,12 @@ class GCloudStorageTests(GCloudTestCase):
         blob.generate_signed_url = generate_signed_url
         self.storage._bucket.blob.return_value = blob
 
-        self.storage.expires_on = timedelta(seconds=3600)
+        self.storage.expires_in = timedelta(seconds=3600)
 
         url = self.storage.url(secret_filename)
         self.storage._bucket.blob.assert_called_with(secret_filename)
         self.assertEqual(url, 'http://signed_url')
-        blob.generate_signed_url.assert_called_with(expiration=timedelta(seconds=3600))
+        blob.generate_signed_url.assert_called_with(timedelta(seconds=3600))
 
     def test_get_available_name(self):
         self.storage.file_overwrite = True

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -340,7 +340,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         url = self.storage.url(secret_filename)
         self.storage._bucket.blob.assert_called_with(secret_filename)
-        self.assertEqual(url,'http://signed_url')
+        self.assertEqual(url, 'http://signed_url')
         blob.generate_signed_url.assert_called_with(expiration=timedelta(seconds=86400))
 
     def test_url_not_public_file_with_custom_expires(self):
@@ -355,7 +355,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         url = self.storage.url(secret_filename)
         self.storage._bucket.blob.assert_called_with(secret_filename)
-        self.assertEqual(url,'http://signed_url')
+        self.assertEqual(url, 'http://signed_url')
         blob.generate_signed_url.assert_called_with(expiration=timedelta(seconds=3600))
 
     def test_get_available_name(self):

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -350,7 +350,7 @@ class GCloudStorageTests(GCloudTestCase):
         blob.generate_signed_url = generate_signed_url
         self.storage._bucket.blob.return_value = blob
 
-        self.storage.expires_in = timedelta(seconds=3600)
+        self.storage.expiration = timedelta(seconds=3600)
 
         url = self.storage.url(secret_filename)
         self.storage._bucket.blob.assert_called_with(secret_filename)


### PR DESCRIPTION
For public files use blob.public_url. This does not require a network trip to Google, so much faster. 
For non-public files, it will return a signed url. The default authentication is set to 1 day but is configurable with GS_EXPIRES_IN. 

It relies on the GS_DEFAULT_ACL to tell if the files will be public. Actually, checking the ACL with Google would be slow. It does not use the GS_CREATE_BUCKET_ACL on purpose because public buckets are a bad idea and lead to a lot of security leaks. 

Docs + tests are updated.

Does not currently support a custom url (did not before either), can be added as an additional feature.

Fixes #491 and #425 
