### PR TITLE
Remove confusing sentence about legacy storage s3.S3Storage

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -11,9 +11,6 @@ library has now been officially deprecated and is due to be removed shortly.
 All current users of the legacy ``S3BotoStorage`` backend are encouraged to migrate
 to the ``S3Boto3Storage`` backend by following the :ref:`migration instructions <migrating-boto-to-boto3>`.
 
-For historical completeness an extreme legacy backend was removed
-in version 1.2
-
 Settings
 --------
 


### PR DESCRIPTION
While reviewing the docs, I found the reference to "extreme legacy
backend" confusing and ambiguous. It provides no details and doesn't
name what was removed. Diving into the git logs, I discovered this was
referencing a previous S3 backend, "storages.backends.s3.S3Storage". As
this was removed in 2014 and was part of the quite old 1.2 release, I
think enough time has passed such that this reference can be completely
removed.