### PR TITLE
Remove unnecessary settings from tests/settings.py

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,13 +1,4 @@
-import os
-
-MEDIA_ROOT = os.path.normcase(os.path.dirname(os.path.abspath(__file__)))
 MEDIA_URL = '/media/'
-
-INSTALLED_APPS = (
-    'django.contrib.auth',
-    'django.contrib.sessions',
-    'django.contrib.contenttypes',
-)
 
 DATABASES = {
     'default': {
@@ -16,17 +7,6 @@ DATABASES = {
     }
 }
 
-MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-)
-
-DEFAULT_FILE_STORAGE = 'backends.s3boto.S3BotoStorage'
-AWS_IS_GZIPPED = True
-GS_IS_GZIPPED = True
 SECRET_KEY = 'hailthesunshine'
 
 USE_TZ = True
-TIME_ZONE = 'America/Chicago'


### PR DESCRIPTION
Backend settings should be set as necessary in tests; not globally.