### PR TITLE
Prefer io.BytesIO; available on all supported Pythons

### DIFF
--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -1,6 +1,7 @@
 # Django storage using libcloud providers
 # Aymeric Barantal (mric at chamal.fr) 2011
 #
+import io
 import os
 
 from django.conf import settings
@@ -8,7 +9,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.six import BytesIO, string_types
+from django.utils.six import string_types
 from django.utils.six.moves.urllib.parse import urljoin
 
 try:
@@ -170,7 +171,7 @@ class LibCloudFile(File):
     def _get_file(self):
         if self._file is None:
             data = self._storage._read(self.name)
-            self._file = BytesIO(data)
+            self._file = io.BytesIO(data)
         return self._file
 
     def _set_file(self, value):
@@ -190,7 +191,7 @@ class LibCloudFile(File):
     def write(self, content):
         if 'w' not in self._mode:
             raise AttributeError("File was opened for read-only access.")
-        self.file = BytesIO(content)
+        self.file = io.BytesIO(content)
         self._is_dirty = True
 
     def close(self):

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -15,6 +15,7 @@
 #     file = models.FileField(upload_to='a/b/c/', storage=fs)
 
 import ftplib
+import io
 import os
 from datetime import datetime
 
@@ -23,7 +24,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.six import BytesIO
 from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.utils import setting
@@ -138,7 +138,7 @@ class FTPStorage(Storage):
         return remote_file
 
     def _read(self, name):
-        memory_file = BytesIO()
+        memory_file = io.BytesIO()
         try:
             pwd = self._connection.pwd()
             self._connection.cwd(os.path.dirname(name))
@@ -251,7 +251,7 @@ class FTPStorageFile(File):
         self._storage = storage
         self._mode = mode
         self._is_dirty = False
-        self.file = BytesIO()
+        self.file = io.BytesIO()
         self._is_read = False
 
     @property
@@ -277,7 +277,7 @@ class FTPStorageFile(File):
     def write(self, content):
         if 'w' not in self._mode:
             raise AttributeError("File was opened for read-only access.")
-        self.file = BytesIO(content)
+        self.file = io.BytesIO(content)
         self._is_dirty = True
         self._is_read = True
 

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -1,3 +1,4 @@
+import io
 import mimetypes
 import os
 import warnings
@@ -14,7 +15,6 @@ from django.utils.deconstruct import deconstructible
 from django.utils.encoding import (
     filepath_to_uri, force_bytes, force_text, smart_str,
 )
-from django.utils.six import BytesIO
 
 from storages.utils import (
     check_location, clean_name, get_available_overwrite_name, lookup_env,
@@ -380,7 +380,7 @@ class S3BotoStorage(Storage):
 
     def _compress_content(self, content):
         """Gzip a given string content."""
-        zbuf = BytesIO()
+        zbuf = io.BytesIO()
         #  The GZIP header has a modification time attribute (see http://www.zlib.org/rfc-gzip.html)
         #  This means each time a file is compressed it changes even if the other contents don't change
         #  For S3 this defeats detection of changes using MD5 sums on gzipped files

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -1,3 +1,4 @@
+import io
 import mimetypes
 import os
 import posixpath
@@ -14,7 +15,6 @@ from django.utils.deconstruct import deconstructible
 from django.utils.encoding import (
     filepath_to_uri, force_bytes, force_text, smart_text,
 )
-from django.utils.six import BytesIO
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.timezone import is_naive, localtime
 
@@ -442,7 +442,7 @@ class S3Boto3Storage(Storage):
     def _compress_content(self, content):
         """Gzip a given string content."""
         content.seek(0)
-        zbuf = BytesIO()
+        zbuf = io.BytesIO()
         #  The GZIP header has a modification time attribute (see http://www.zlib.org/rfc-gzip.html)
         #  This means each time a file is compressed it changes even if the other contents don't change
         #  For S3 this defeats detection of changes using MD5 sums on gzipped files

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -6,6 +6,7 @@
 from __future__ import print_function
 
 import getpass
+import io
 import os
 import posixpath
 import stat
@@ -15,7 +16,6 @@ import paramiko
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.six import BytesIO
 from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.utils import setting
@@ -194,7 +194,7 @@ class SFTPStorageFile(File):
     def __init__(self, name, storage, mode):
         self.name = name
         self.mode = mode
-        self.file = BytesIO()
+        self.file = io.BytesIO()
         self._storage = storage
         self._is_read = False
         self._is_dirty = False
@@ -215,7 +215,7 @@ class SFTPStorageFile(File):
     def write(self, content):
         if 'w' not in self.mode:
             raise AttributeError("File was opened for read-only access.")
-        self.file = BytesIO(content)
+        self.file = io.BytesIO(content)
         self._is_dirty = True
         self._is_read = True
 

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -1,3 +1,4 @@
+import io
 from datetime import datetime
 
 from django.core.exceptions import (
@@ -5,7 +6,6 @@ from django.core.exceptions import (
 )
 from django.core.files.base import ContentFile, File
 from django.test import TestCase
-from django.utils.six import BytesIO
 
 from storages.backends import dropbox
 
@@ -120,7 +120,7 @@ class DropBoxTest(TestCase):
     @mock.patch('dropbox.Dropbox.files_upload',
                 return_value='foo')
     def test_save(self, files_upload, *args):
-        self.storage._save('foo', File(BytesIO(b'bar'), 'foo'))
+        self.storage._save('foo', File(io.BytesIO(b'bar'), 'foo'))
         self.assertTrue(files_upload.called)
 
     @mock.patch('dropbox.Dropbox.files_upload')
@@ -129,7 +129,7 @@ class DropBoxTest(TestCase):
     @mock.patch('dropbox.Dropbox.files_upload_session_start',
                 return_value=mock.MagicMock(session_id='foo'))
     def test_chunked_upload(self, start, append, finish, upload):
-        large_file = File(BytesIO(b'bar' * self.storage.CHUNK_SIZE), 'foo')
+        large_file = File(io.BytesIO(b'bar' * self.storage.CHUNK_SIZE), 'foo')
         self.storage._save('foo', large_file)
         self.assertTrue(start.called)
         self.assertTrue(append.called)

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -2,12 +2,12 @@ try:
     from unittest.mock import patch
 except ImportError:
     from mock import patch
+import io
 from datetime import datetime
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.test import TestCase
-from django.utils.six import BytesIO
 
 from storages.backends import ftp
 
@@ -109,7 +109,7 @@ class FTPTest(TestCase):
     })
     def test_put_file(self, mock_ftp):
         self.storage._start_connection()
-        self.storage._put_file('foo', File(BytesIO(b'foo'), 'foo'))
+        self.storage._put_file('foo', File(io.BytesIO(b'foo'), 'foo'))
 
     @patch('ftplib.FTP', **{
         'return_value.pwd.return_value': 'foo',
@@ -118,7 +118,7 @@ class FTPTest(TestCase):
     def test_put_file_error(self, mock_ftp):
         self.storage._start_connection()
         with self.assertRaises(ftp.FTPStorageException):
-            self.storage._put_file('foo', File(BytesIO(b'foo'), 'foo'))
+            self.storage._put_file('foo', File(io.BytesIO(b'foo'), 'foo'))
 
     def test_open(self):
         remote_file = self.storage._open('foo')
@@ -140,7 +140,7 @@ class FTPTest(TestCase):
         'return_value.storbinary.return_value': None
     })
     def test_save(self, mock_ftp):
-        self.storage._save('foo', File(BytesIO(b'foo'), 'foo'))
+        self.storage._save('foo', File(io.BytesIO(b'foo'), 'foo'))
 
     @patch('ftplib.FTP', **{'return_value.sendcmd.return_value': '213 20160727094506'})
     def test_modified_time(self, mock_ftp):
@@ -213,13 +213,13 @@ class FTPStorageFileTest(TestCase):
         self.assertEqual(file_.size, 1024)
 
     @patch('ftplib.FTP', **{'return_value.pwd.return_value': 'foo'})
-    @patch('storages.backends.ftp.FTPStorage._read', return_value=BytesIO(b'foo'))
+    @patch('storages.backends.ftp.FTPStorage._read', return_value=io.BytesIO(b'foo'))
     def test_readlines(self, mock_ftp, mock_storage):
         file_ = ftp.FTPStorageFile('fi', self.storage, 'wb')
         self.assertEqual([b'foo'], file_.readlines())
 
     @patch('ftplib.FTP', **{'return_value.pwd.return_value': 'foo'})
-    @patch('storages.backends.ftp.FTPStorage._read', return_value=BytesIO(b'foo'))
+    @patch('storages.backends.ftp.FTPStorage._read', return_value=io.BytesIO(b'foo'))
     def test_read(self, mock_ftp, mock_storage):
         file_ = ftp.FTPStorageFile('fi', self.storage, 'wb')
         self.assertEqual(b'foo', file_.read())
@@ -231,7 +231,7 @@ class FTPStorageFileTest(TestCase):
         self.assertEqual(file_.file.read(), b'foo')
 
     @patch('ftplib.FTP', **{'return_value.pwd.return_value': 'foo'})
-    @patch('storages.backends.ftp.FTPStorage._read', return_value=BytesIO(b'foo'))
+    @patch('storages.backends.ftp.FTPStorage._read', return_value=io.BytesIO(b'foo'))
     def test_close(self, mock_ftp, mock_storage):
         file_ = ftp.FTPStorageFile('fi', self.storage, 'wb')
         file_.is_dirty = True

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -1,3 +1,4 @@
+import io
 import os
 import stat
 from datetime import datetime
@@ -5,7 +6,6 @@ from datetime import datetime
 import paramiko
 from django.core.files.base import File
 from django.test import TestCase
-from django.utils.six import BytesIO
 
 from storages.backends import sftpstorage
 
@@ -69,14 +69,14 @@ class SFTPStorageTest(TestCase):
 
     @patch('storages.backends.sftpstorage.SFTPStorage.sftp')
     def test_save(self, mock_sftp):
-        self.storage._save('foo', File(BytesIO(b'foo'), 'foo'))
+        self.storage._save('foo', File(io.BytesIO(b'foo'), 'foo'))
         self.assertTrue(mock_sftp.open.return_value.write.called)
 
     @patch('storages.backends.sftpstorage.SFTPStorage.sftp', **{
         'stat.side_effect': (IOError(), True)
     })
     def test_save_in_subdir(self, mock_sftp):
-        self.storage._save('bar/foo', File(BytesIO(b'foo'), 'foo'))
+        self.storage._save('bar/foo', File(io.BytesIO(b'foo'), 'foo'))
         self.assertEqual(mock_sftp.mkdir.call_args_list[0][0], ('bar',))
         self.assertTrue(mock_sftp.open.return_value.write.called)
 


### PR DESCRIPTION
`io.BytesIO` is available on all supported Pythons. No need to use six shim. Use future compatible interface.