### PR TITLE
Add tox directory to isort skip list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ known_first_party = storages
 line_length = 79
 multi_line_output = 5
 not_skip = __init__.py
+skip =
+    .tox
+    docs
 
 [metadata]
 license_file = LICENSE

--- a/tox.ini
+++ b/tox.ini
@@ -57,4 +57,4 @@ deps =
 	isort
 commands =
 	flake8
-	isort --recursive --check-only --diff storages/ tests/
+	isort --recursive --check-only --diff


### PR DESCRIPTION
Like flake8, when running `isort --apply`, shouldn't affect the `.tox` directory.