### PR TITLE
Don't re-compress files before upload to S3. #451

### DIFF
--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -413,12 +413,10 @@ class S3BotoStorage(Storage):
         # setting the content_type in the key object is not enough.
         headers.update({'Content-Type': content_type})
 
-        if self.gzip and content_type in self.gzip_content_types:
+        if (self.gzip and content_type in self.gzip_content_types and
+            encoding is None):
             content = self._compress_content(content)
             headers.update({'Content-Encoding': 'gzip'})
-        elif encoding:
-            # If the content already has a particular encoding, set it
-            headers.update({'Content-Encoding': encoding})
 
         content.name = cleaned_name
         encoded_name = self._encode_name(name)

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -414,7 +414,7 @@ class S3BotoStorage(Storage):
         headers.update({'Content-Type': content_type})
 
         if (self.gzip and content_type in self.gzip_content_types and
-            encoding is None):
+                encoding is None):
             content = self._compress_content(content)
             headers.update({'Content-Encoding': 'gzip'})
 

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -480,7 +480,7 @@ class S3Boto3Storage(Storage):
         parameters.update({'ContentType': content_type})
 
         if (self.gzip and content_type in self.gzip_content_types and
-            encoding is None):
+                encoding is None):
             content = self._compress_content(content)
             parameters.update({'ContentEncoding': 'gzip'})
 

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -479,12 +479,10 @@ class S3Boto3Storage(Storage):
         # setting the content_type in the key object is not enough.
         parameters.update({'ContentType': content_type})
 
-        if self.gzip and content_type in self.gzip_content_types:
+        if (self.gzip and content_type in self.gzip_content_types and
+            encoding is None):
             content = self._compress_content(content)
             parameters.update({'ContentEncoding': 'gzip'})
-        elif encoding:
-            # If the content already has a particular encoding, set it
-            parameters.update({'ContentEncoding': encoding})
 
         encoded_name = self._encode_name(name)
         obj = self.bucket.Object(encoded_name)

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -99,8 +99,7 @@ class S3BotoStorageTests(S3BotoTestCase):
                                             'application/octet-stream')
         key.set_contents_from_file.assert_called_with(
             content,
-            headers={'Content-Type': 'application/octet-stream',
-                     'Content-Encoding': 'gzip'},
+            headers={'Content-Type': 'application/octet-stream'},
             policy=self.storage.default_acl,
             reduced_redundancy=self.storage.reduced_redundancy,
             rewind=True,

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -173,7 +173,6 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             content.file,
             ExtraArgs={
                 'ContentType': 'application/octet-stream',
-                'ContentEncoding': 'gzip',
                 'ACL': self.storage.default_acl,
             }
         )


### PR DESCRIPTION
This proposed change does the following:

1.  Now django-storages will upload `.gz` and similar files without re-compressing them (as in, take a gzip file and gzip it again), before upload to S3.
2. It won't set a Content-Encoding header that causes `.gz` and similar files to be automatically decompressed on download , thus leaving it with the `.gz` extension when it is already decompressed.

These changes allow .gz files (and other compression types compatible with the Content-Encoding header) to be uploaded and downloaded without modification.

The original code in question is at
https://github.com/jschneier/django-storages/blob/master/storages/backends/s3boto3.py#L482

`_type, encoding = mimetypes.guess_type(name)`
...

        if self.gzip and content_type in self.gzip_content_types:
            content = self._compress_content(content)
            parameters.update({'ContentEncoding': 'gzip'})
        elif encoding:
            # If the content already has a particular encoding, set it
            parameters.update({'ContentEncoding': encoding})

Noting that `mimetypes.guess_type("myfile.csv.gz")` is `('text/csv', 'gzip')`.

So if the file is `file.csv.gz`, and `text/csv` is in `self.gzip_content_types`, then it will be compressed again in the first if clause. Downloading normally it seems transparent, because the content-encoding is reversed once by the browser, then you get your inner .gz file back, no surprises.

But if you are having the files scanned on S3, by, say, AWS Glue, then it will be totally blocked by the double compression.

Now look at the `elif encoding:` clause.
If the file is `file.csv.gz`, then the content encoding header will be added. On download, the file will be gunzipped by the browser. But the filename is wrong - the OS will see the `.gz`, and when you try to decompress it, the OS decompression utility is baffled. You have to manually remove the `.gz`.

So to meet expectations of how these files should actually be named, given their settings, the first branch of the `if` should add `.gz` extension to show the double compression exists on S3, and the `elif` branch should remove the `.gz` extension to show that the ContentEncoding is removed. Basically, this if block prevents .gz files from being moved back and forth from S3 without modification.

To be clear, I am not advocating that the extension .gz actually be added or removed. I'm just pointing out that would be the logical entailment of what is being attempted.

This revised code does the following:
If a file is NOT compressed (encoding is None), AND the settings indicate it is a ContentType the user wants to store compressed, and be automatically uncompressed, THEN compress it, set the ContentEncoding header, and upload it.

Otherwise, DO NOT set the content-encoding header, and upload the file as is.
