### PR TITLE
Fix bug in generating presigned url in s3boto3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ By order of apparition, thanks:
     * Alex Watt (Google Cloud Storage patch)
     * Jumpei Yoshimura (S3 docs)
     * Jon Dufresne
+    * Charles Verdad (patches)
 
 
 

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -618,7 +618,8 @@ class S3Boto3Storage(Storage):
 
         params = parameters.copy() if parameters else {}
         params['Bucket'] = self.bucket.name
-        params['Key'] = self._encode_name(name)
+        params['Key'] = "%s/%s" % (self.location, self._encode_name(name))
+        params['Key'] = params['Key'].lstrip('/')  # in case self.location == ''
         url = self.bucket.meta.client.generate_presigned_url('get_object', Params=params,
                                                              ExpiresIn=expire)
         if self.querystring_auth:

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -513,8 +513,8 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.storage.url(name)
         self.storage.bucket.meta.client.generate_presigned_url.assert_called_with(
             'get_object',
-             Params={'Bucket': self.storage.bucket.name, 'Key': expected_key},
-             ExpiresIn=self.storage.querystring_expire
+            Params={'Bucket': self.storage.bucket.name, 'Key': expected_key},
+            ExpiresIn=self.storage.querystring_expire
         )
 
     def test_generated_url_is_encoded(self):


### PR DESCRIPTION
Add file location in addition to file name when requesting pre-signed urls in boto client.

https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html

This resolves https://github.com/jschneier/django-storages/issues/622