### PR TITLE
PRE / POST hooks

### DIFF
--- a/storages/backends/base.py
+++ b/storages/backends/base.py
@@ -1,0 +1,9 @@
+from django.core.files.base import File
+from django.core.files.storage import Storage
+
+class BaseFile(File):
+    pass
+
+class BaseStorage(Storage):
+    def pre_save(name, content):
+        return name, content

--- a/storages/backends/base.py
+++ b/storages/backends/base.py
@@ -5,5 +5,5 @@ class BaseFile(File):
     pass
 
 class BaseStorage(Storage):
-    def pre_save(name, content):
+    def pre_save(self, name, content):
         return name, content

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -10,7 +10,6 @@ from tempfile import SpooledTemporaryFile
 from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File
-from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import (
     filepath_to_uri, force_bytes, force_text, smart_text,
@@ -18,6 +17,7 @@ from django.utils.encoding import (
 from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.timezone import is_naive, localtime
 
+from storages.backends.base import BaseStorage, BaseFile
 from storages.utils import (
     check_location, get_available_overwrite_name, lookup_env, safe_join,
     setting,
@@ -37,7 +37,7 @@ boto3_version_info = tuple([int(i) for i in boto3_version.split('.')])
 
 
 @deconstructible
-class S3Boto3StorageFile(File):
+class S3Boto3StorageFile(BaseFile):
 
     """
     The default file object used by the S3Boto3Storage backend.
@@ -168,7 +168,7 @@ class S3Boto3StorageFile(File):
 
 
 @deconstructible
-class S3Boto3Storage(Storage):
+class S3Boto3Storage(BaseStorage):
     """
     Amazon Simple Storage Service using Boto3
 
@@ -469,6 +469,7 @@ class S3Boto3Storage(Storage):
         return f
 
     def _save(self, name, content):
+        name, content = self.pre_save(name, content)
         cleaned_name = self._clean_name(name)
         name = self._normalize_name(cleaned_name)
         parameters = self.object_parameters.copy()


### PR DESCRIPTION
The idea of this proposal is to allow developers to hook their own actions into some of the methods (`read` and `write` for example).

The way I think this could be achieved without making huge changes to the code is by using `django-storages` `s current OOP design. Currently all backend storages implement Django's `Storage` class. 

    django.core.files.storage.Storage
        |
        |-- storages.backends.s3boto3.S3Bot3Storage

This proposal creates a dummy proxy class that implements the hooks that could be used by developers.

    django.core.files.storage.Storage
        |
        |-- storages.backends.base.BaseStorage
            |
            |-- storages.backends.s3boto3.S3Bot3Storage

The code as-it-is now implements only `pre_save`, which receives `name, content` and returns `name, content` without modifying them in any way. This allows the code to work as expected by default if `pre_save` isn't overwritten. 

If a developer chooses to override the behaviour of a particular hook, it would be as simple as overriding only that particular method. As an example, I'll show how to override the `pre_save` method and convert all uploaded files to `base64`:

First, create a new class, anywhere in your app/project:

    import base64
    from storages.backends.s3boto3 import S3Boto3Storage

    class S3Mod(S3Boto3Storage):
        def pre_save(self, name, content):
            content.seek(0)
            _content = base64.b64encode(content.read())
            content.seek(0)
            content.truncate(0)
            content.write(_content)
            content.seek(0)
            return name, content

Then set the default storage to that class:

    DEFAULT_FILE_STORAGE = 'playground.s3mod.S3Mod'

