### PR TITLE
Use tox configuration option "extras"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 2.4
 envlist =
 	py27-django111
 	py34-django{111,20}
@@ -22,14 +23,14 @@ deps =
 	py27: mock
 	pytest
 	pytest-cov
-	apache-libcloud
-	boto
-	boto3
-	dropbox
-	google-cloud-storage
-	paramiko
-	azure>=3.0.0
-	azure-storage-blob>=1.3.1
+extras =
+    azure
+    boto
+    boto3
+    dropbox
+    google
+    libcloud
+    sftp
 
 [testenv:integration]
 ignore_errors = True
@@ -48,8 +49,8 @@ setenv =
 deps =
     Django>=1.11, <1.12
     pytest-django
-    azure>=3.0.0
-	azure-storage-blob>=1.3.1
+extras =
+    azure
 
 [testenv:flake8]
 deps =


### PR DESCRIPTION
https://tox.readthedocs.io/en/latest/config.html#conf-extras

Allows simplifying the configuration. Can reuse the version strings from
setup.py, allowing it to be a single source of truth.