### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # https://travis-ci.org/jschneier/django-storages/
+dist: xenial
 sudo: false
 language: python
 
@@ -28,24 +29,18 @@ matrix:
       env: TOXENV=py36-django20
     - python: 3.7
       env: TOXENV=py37-django20
-      dist: xenial
-      sudo: true
     - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21
     - python: 3.7
       env: TOXENV=py37-django21
-      dist: xenial
-      sudo: true
     - python: 3.5
       env: TOXENV=py35-djangomaster
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
-      dist: xenial
-      sudo: true
   allow_failures:
     - env: TOXENV=py35-djangomaster
     - env: TOXENV=py36-djangomaster
@@ -53,8 +48,7 @@ matrix:
 
 before_install:
   # Workaround Travis environment.
-  - if [[ $TRAVIS_DIST == xenial ]]; then sudo rm /etc/boto.cfg; fi
-  - if [[ $TRAVIS_DIST == trusty ]]; then sudo rm /etc/boto.cfg; fi
+  - sudo rm /etc/boto.cfg
 
 install:
   - pip install tox


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release