### PR TITLE
Add py37-django111 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # https://travis-ci.org/jschneier/django-storages/
+dist: xenial
 sudo: false
 language: python
 
@@ -28,24 +29,18 @@ matrix:
       env: TOXENV=py36-django20
     - python: 3.7
       env: TOXENV=py37-django20
-      dist: xenial
-      sudo: true
     - python: 3.5
       env: TOXENV=py35-django21
     - python: 3.6
       env: TOXENV=py36-django21
     - python: 3.7
       env: TOXENV=py37-django21
-      dist: xenial
-      sudo: true
     - python: 3.5
       env: TOXENV=py35-djangomaster
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
-      dist: xenial
-      sudo: true
   allow_failures:
     - env: TOXENV=py35-djangomaster
     - env: TOXENV=py36-djangomaster
@@ -53,8 +48,7 @@ matrix:
 
 before_install:
   # Workaround Travis environment.
-  - if [[ $TRAVIS_DIST == xenial ]]; then sudo rm /etc/boto.cfg; fi
-  - if [[ $TRAVIS_DIST == trusty ]]; then sudo rm /etc/boto.cfg; fi
+  - sudo rm /etc/boto.cfg
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
       env: TOXENV=py35-django111
     - python: 3.6
       env: TOXENV=py36-django111
+    - python: 3.7
+      env: TOXENV=py37-django111
     - python: 3.4
       env: TOXENV=py34-django20
     - python: 3.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-	py27-django111
-	py34-django{111,20}
-	py35-django{111,20,21,master}
-	py36-django{111,20,21,master}
-	py37-django{20,21,master}
+	py{27,34,35,36,37}-django111
+	py{34,35,36,37}-django20
+	py{35,36,37}-django21
+	py{35,36,37}-djangomaster
 	integration
 	flake8
 


### PR DESCRIPTION
Django added Python 3.7 support to Django 1.11 in version 1.11.17.

https://docs.djangoproject.com/en/dev/releases/1.11.17/

> Django 1.11.17 ... adds compatibility with Python 3.7.