### PR TITLE
Allow custom endpoints with Google Cloud Storage.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ By order of apparition, thanks:
     * Jumpei Yoshimura (S3 docs)
     * Jon Dufresne
     * Rodrigo Gadea (Dropbox fixes)
+    * Martey Dodoo
 
 
 

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -149,6 +149,11 @@ must fit in memory. Recommended if you are going to be uploading large files.
 
 Sets Cache-Control HTTP header for the file, more about HTTP caching can be found `here <https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control>`_
 
+``GS_CUSTOM_ENDPOINT`` (optional: default is ``None``)
+
+Sets a `custom endpoint <https://cloud.google.com/storage/docs/request-endpoints>`_,
+that will be used instead of ``https://storage.googleapis.com`` when generating URLs for files.
+
 ``GS_LOCATION`` (optional: default is ``''``)
 
 Subdirectory in which the files will be stored.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         'boto': ['boto>=2.32.0'],
         'boto3': ['boto3>=1.4.4'],
         'dropbox': ['dropbox>=7.2.1'],
-        'google': ['google-cloud-storage>=0.22.0'],
+        'google': ['google-cloud-storage>=1.15.0'],
         'libcloud': ['apache-libcloud'],
         'sftp': ['paramiko'],
     },

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -372,6 +372,22 @@ class GCloudStorageTests(GCloudTestCase):
         self.assertEqual(url, 'http://signed_url')
         blob.generate_signed_url.assert_called_with(timedelta(seconds=3600))
 
+    def test_custom_endpoint(self):
+        self.storage.custom_endpoint = "https://example.com"
+
+        self.storage.default_acl = 'publicRead'
+        url = "{}/{}".format(self.storage.custom_endpoint, self.filename)
+        self.assertEqual(self.storage.url(self.filename), url)
+
+        signed_url = 'https://signed_url'
+        self.storage.default_acl = 'projectPrivate'
+        self.storage._bucket = mock.MagicMock()
+        blob = mock.MagicMock()
+        generate_signed_url = mock.MagicMock(return_value=signed_url)
+        blob.generate_signed_url = generate_signed_url
+        self.storage._bucket.blob.return_value = blob
+        self.assertEqual(self.storage.url(self.filename), signed_url)
+
     def test_get_available_name(self):
         self.storage.file_overwrite = True
         self.assertEqual(self.storage.get_available_name(


### PR DESCRIPTION
Add new `GS_CUSTOM_ENDPOINT` setting to allow usage of custom domains/URLs with Google Cloud Storage, similar to `AWS_S3_CUSTOM_DOMAIN`.