### PR TITLE
Test against for Django 2.2 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ matrix:
       env: TOXENV=py36-django21
     - python: 3.7
       env: TOXENV=py37-django21
+    - python: 3.5
+      env: TOXENV=py35-django22
+    - python: 3.6
+      env: TOXENV=py36-django22
+    - python: 3.7
+      env: TOXENV=py37-django22
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
 	py{27,34,35,36,37}-django111
 	py{34,35,36,37}-django20
 	py{35,36,37}-django21
+	py{35,36,37}-django22
 	py{36,37}-djangomaster
 	integration
 	flake8
@@ -18,6 +19,7 @@ deps =
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
 	django21: Django>=2.1,<2.2
+	django22: Django>=2.2,<3.0
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
 	py27: mock
 	pytest


### PR DESCRIPTION
Announcement: https://www.djangoproject.com/weblog/2019/apr/01/django-22-released/
    
Release notes: https://docs.djangoproject.com/en/2.2/releases/2.2/
    
Django master dropped support for Python 3.5.