### PR TITLE
small change for better extending the S3BotoStorage class

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ By order of apparition, thanks:
     * Alex Watt (Google Cloud Storage patch)
     * Jumpei Yoshimura (S3 docs)
     * Jon Dufresne
+    * Iskren Stanislav (S3 with Boto3)
 
 
 

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -269,18 +269,28 @@ class S3BotoStorage(Storage):
     @property
     def connection(self):
         if self._connection is None:
+            # don't use directly self.access_key, self.secret_key 
+            # as we might need to refresh their values. Instead
+            # use self._get_access_keys()
+            # as it can be customized in different subclasses
             kwargs = self._get_connection_kwargs()
+            self.access_key, self.secret_key = self._get_access_keys()
 
             self._connection = self.connection_class(
-                self.access_key,
-                self.secret_key,
+                access_key, secret_key,
                 **kwargs
             )
         return self._connection
 
     def _get_connection_kwargs(self):
+        # don't use directly self.security_token 
+        # as we might need to refresh their values. Instead
+        # use self._get_security_token()
+        # as it can be customized in different subclasses
+        security_token = self._get_security_token()
+
         return dict(
-            security_token=self.security_token,
+            security_token=security_token,
             is_secure=self.use_ssl,
             calling_format=self.calling_format,
             host=self.host,

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -269,7 +269,7 @@ class S3BotoStorage(Storage):
     @property
     def connection(self):
         if self._connection is None:
-            # don't use directly self.access_key, self.secret_key 
+            # don't use directly self.access_key, self.secret_key
             # as we might need to refresh their values. Instead
             # use self._get_access_keys()
             # as it can be customized in different subclasses
@@ -283,7 +283,7 @@ class S3BotoStorage(Storage):
         return self._connection
 
     def _get_connection_kwargs(self):
-        # don't use directly self.security_token 
+        # don't use directly self.security_token
         # as we might need to refresh their values. Instead
         # use self._get_security_token()
         # as it can be customized in different subclasses

--- a/storages/backends/s3boto.py
+++ b/storages/backends/s3boto.py
@@ -274,7 +274,7 @@ class S3BotoStorage(Storage):
             # use self._get_access_keys()
             # as it can be customized in different subclasses
             kwargs = self._get_connection_kwargs()
-            self.access_key, self.secret_key = self._get_access_keys()
+            access_key, secret_key = self._get_access_keys()
 
             self._connection = self.connection_class(
                 access_key, secret_key,

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -302,12 +302,18 @@ class S3Boto3Storage(Storage):
     def connection(self):
         connection = getattr(self._connections, 'connection', None)
         if connection is None:
+            # don't use directly self.access_key, self.secret_key 
+            # as we might need to refresh their values. Instead
+            # use self._get_access_keys() and self._get_security_token()
+            # as it can be customized in different subclasses
+            access_key, secret_key = self._get_access_keys()
+            security_token = self._get_security_token()
             session = boto3.session.Session()
             self._connections.connection = session.resource(
                 's3',
-                aws_access_key_id=self.access_key,
-                aws_secret_access_key=self.secret_key,
-                aws_session_token=self.security_token,
+                aws_access_key_id=access_key,
+                aws_secret_access_key=secret_key,
+                aws_session_token=security_token,
                 region_name=self.region_name,
                 use_ssl=self.use_ssl,
                 endpoint_url=self.endpoint_url,

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -302,7 +302,7 @@ class S3Boto3Storage(Storage):
     def connection(self):
         connection = getattr(self._connections, 'connection', None)
         if connection is None:
-            # don't use directly self.access_key, self.secret_key 
+            # don't use directly self.access_key, self.secret_key
             # as we might need to refresh their values. Instead
             # use self._get_access_keys() and self._get_security_token()
             # as it can be customized in different subclasses


### PR DESCRIPTION
relates to #606 
This one will allow to extend the base class and configure how the credentials are stored/managed/refreshed.
Useful in case of Django deployed on AWS Lambda (15 min live) when using Zappa as a deploy tool. Zappa is configured to use aws-role for the update/deploy actions.
And AWS roles rotate their security credentials each 1h to 12hours, depending on the configured values.

check comments 
https://github.com/jschneier/django-storages/issues/606#issuecomment-461762380
https://github.com/jschneier/django-storages/issues/606#issuecomment-461774432