### PR TITLE
Allow S3Transfer config to be customised

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ By order of apparition, thanks:
     * Alex Watt (Google Cloud Storage patch)
     * Jumpei Yoshimura (S3 docs)
     * Jon Dufresne
+    * Michal Charemza
 
 
 

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -143,6 +143,12 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
   support the legacy ``s3`` (also known as ``v2``) version. You can check to see
   if your region is one of them in the `S3 region list`_.
 
+``AWS_S3_TRANSFER_CONFIG`` (optional - boto3 only)
+
+  An instance of `boto3.s3.transfer.TransferConfig`_ used for uploads and downloads. Use this to control concurrency-related aspects of uploads and downloads, such as number of threads.
+
+.. _boto3.s3.transfer.TransferConfig: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/customizations/s3.html#boto3.s3.transfer.TransferConfig
+
 .. note::
 
   The signature versions are not backwards compatible so be careful about url endpoints if making this change


### PR DESCRIPTION
A typical use for this would be to control number of threads, or even disabling threads. For example, some transfers are unlikely to be faster than the transfer to/from S3, and so triggering threads is unlikely to be helpful.

The setting AWS_S3_TRANSFER_CONFIG is used twice so that S3Boto3Storage and S3Boto3StorageFile, which can be used directly in client code, can both be customised.