### PR TITLE
Google Storage Backend: settings ACLs when file is uploaded

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -175,9 +175,7 @@ class GoogleCloudStorage(Storage):
         file = GoogleCloudFile(encoded_name, 'rw', self)
         file.blob.cache_control = self.cache_control
         file.blob.upload_from_file(content, rewind=True, size=content.size,
-                                   content_type=file.mime_type)
-        if self.default_acl:
-            file.blob.acl.save_predefined(self.default_acl)
+                                   content_type=file.mime_type, predefined_acl=self.default_acl)
         return cleaned_name
 
     def delete(self, name):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -175,11 +175,13 @@ class GoogleCloudStorage(Storage):
         file = GoogleCloudFile(encoded_name, 'rw', self)
         file.blob.cache_control = self.cache_control
         if self.default_acl:
-          file.blob.upload_from_file(content, rewind=True, size=content.size,
-                                   content_type=file.mime_type, predefined_acl=self.default_acl)
+            file.blob.upload_from_file(
+                content, rewind=True, size=content.size,
+                content_type=file.mime_type, predefined_acl=self.default_acl)
         else:
-          file.blob.upload_from_file(content, rewind=True, size=content.size,
-                                   content_type=file.mime_type)
+            file.blob.upload_from_file(
+                content, rewind=True, size=content.size,
+                content_type=file.mime_type)
         return cleaned_name
 
     def delete(self, name):

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -174,8 +174,12 @@ class GoogleCloudStorage(Storage):
         encoded_name = self._encode_name(name)
         file = GoogleCloudFile(encoded_name, 'rw', self)
         file.blob.cache_control = self.cache_control
-        file.blob.upload_from_file(content, rewind=True, size=content.size,
+        if self.default_acl:
+          file.blob.upload_from_file(content, rewind=True, size=content.size,
                                    content_type=file.mime_type, predefined_acl=self.default_acl)
+        else:
+          file.blob.upload_from_file(content, rewind=True, size=content.size,
+                                   content_type=file.mime_type)
         return cleaned_name
 
     def delete(self, name):

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -131,7 +131,8 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, rewind=True, size=len(data), content_type=mimetypes.guess_type(filename)[0], predefined_acl='publicRead')
+            content, rewind=True, size=len(data), content_type=mimetypes.guess_type(filename)[0],
+            predefined_acl='publicRead')
 
     def test_delete(self):
         self.storage.delete(self.filename)

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -131,8 +131,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage._client.get_bucket.assert_called_with(self.bucket_name)
         self.storage._bucket.get_blob().upload_from_file.assert_called_with(
-            content, rewind=True, size=len(data), content_type=mimetypes.guess_type(filename)[0])
-        self.storage._bucket.get_blob().acl.save_predefined.assert_called_with('publicRead')
+            content, rewind=True, size=len(data), content_type=mimetypes.guess_type(filename)[0], predefined_acl='publicRead')
 
     def test_delete(self):
         self.storage.delete(self.filename)


### PR DESCRIPTION
There is no need to make a separate call to set ACLs on a file (blob). ACLs can be passed as a parameter to the "upload_from_file" function.

On a side note, the reason I started looking at this code is that over the last few days I started getting errors when uploading files to Google cloud: "503 GET https://www.googleapis.com/storage/v1/b/BUCKET_NAME/o/FILE_PATH/acl: Backend Error"

I don't have a clear explanation on why this was happening, I am guessing that setting ACLs right after the file was uploaded may have caused some contention issues on Google side. (the issue was totally random)

With the change proposed in this PR I don't see any more issues when uploading files.