### PR TITLE
Use skip_install=true for flake8 tox target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+minversion = 1.9
 envlist =
 	py{27,34,35,36,37}-django111
 	py{34,35,36,37}-django20
@@ -57,3 +58,4 @@ deps =
 commands =
 	flake8
 	isort --recursive --check-only --diff storages/ tests/
+skip_install = true


### PR DESCRIPTION
Avoids installing the package (and any potential dependencies) to the
virtualenv before running flake8 commands. The package is not required
to be installed to do simple static code analysis. Results in a slightly
faster run, as fetching and installing dependencies is skipped.

For additional information on the configuration option, see:

https://tox.readthedocs.io/en/latest/config.html#confval-skip_install=BOOL

> Do not install the current package. This can be used when you need the
> virtualenv management but do not want to install the current package
> into that environment.