### PR TITLE
AWS_S3_REGION_NAME is still needed

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -123,7 +123,7 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
     Whether or not to verify the connection to S3. Can be set to False to not verify certificates or a path to a CA cert bundle.
 
 ``AWS_S3_ENDPOINT_URL`` (optional: default is ``None``, boto3 only)
-    Custom S3 URL to use when connecting to S3, including scheme. Overrides ``AWS_S3_REGION_NAME`` and ``AWS_S3_USE_SSL``.
+    Custom S3 URL to use when connecting to S3, including scheme. Overrides ``AWS_S3_REGION_NAME`` and ``AWS_S3_USE_SSL``. To avoid ``AuthorizationQueryParametersError`` error, ``AWS_S3_REGION_NAME`` should also be set.
 
 ``AWS_S3_ADDRESSING_STYLE`` (default is ``None``, boto3 only)
     Possible values ``virtual`` and ``path``.


### PR DESCRIPTION
Tested in region `cn-northwest-1` with Django 2.2.1, django-storage 1.7.1 and boto3 1.9.166, `AWS_S3_REGION_NAME` setting is still needed even with `AWS_S3_ENDPOINT_URL`. Otherwise, you may come across the `AuthorizationQueryParametersError` with example message _Error parsing the X-Amz-Credential parameter; the region 'ap-southeast-1' is wrong; expecting 'cn-northwest-1'_.