### PR TITLE
Stop using deprecated Travis container environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,6 @@ matrix:
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster
 
-before_install:
-  # Workaround Travis environment.
-  - sudo rm /etc/boto.cfg
-
 install:
   - pip install tox
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # https://travis-ci.org/jschneier/django-storages/
 dist: xenial
-sudo: false
 language: python
 
 cache: pip


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration