### PR TITLE
S3Boto3: Fix ValueError I/O operation on closed file

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -488,18 +488,6 @@ class S3Boto3Storage(Storage):
         if self.preload_metadata:
             self._entries[encoded_name] = obj
 
-        # If both `name` and `content.name` are empty or None, your request
-        # can be rejected with `XAmzContentSHA256Mismatch` error, because in
-        # `django.core.files.storage.Storage.save` method your file-like object
-        # will be wrapped in `django.core.files.File` if no `chunks` method
-        # provided. `File.__bool__`  method is Django-specific and depends on
-        # file name, for this reason`botocore.handlers.calculate_md5` can fail
-        # even if wrapped file-like object exists. To avoid Django-specific
-        # logic, pass internal file-like object if `content` is `File`
-        # class instance.
-        if isinstance(content, File):
-            content = content.file
-
         self._save_content(obj, content, parameters=parameters)
         # Note: In boto3, after a put, last_modified is automatically reloaded
         # the next time it is accessed; no need to specifically reload it.

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -116,7 +116,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         obj = self.storage.bucket.Object.return_value
         obj.upload_fileobj.assert_called_with(
-            content.file,
+            content,
             ExtraArgs={
                 'ContentType': 'text/plain',
                 'ACL': self.storage.default_acl,
@@ -135,7 +135,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         obj = self.storage.bucket.Object.return_value
         obj.upload_fileobj.assert_called_with(
-            content.file,
+            content,
             ExtraArgs={
                 'ContentType': 'text/plain',
                 'ACL': 'private',
@@ -154,7 +154,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
         obj = self.storage.bucket.Object.return_value
         obj.upload_fileobj.assert_called_with(
-            content.file,
+            content,
             ExtraArgs={
                 'ContentType': 'image/jpeg',
                 'ACL': self.storage.default_acl,
@@ -170,7 +170,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.storage.save(name, content)
         obj = self.storage.bucket.Object.return_value
         obj.upload_fileobj.assert_called_with(
-            content.file,
+            content,
             ExtraArgs={
                 'ContentType': 'application/octet-stream',
                 'ContentEncoding': 'gzip',


### PR DESCRIPTION
This commit fixed a [bug in Django](https://code.djangoproject.com/ticket/26495) that was addressed in the 1.10 release. It then had the knock on effects of causing #382. Since this library only supports 1.11+ this can be safely reverted. 

This reverts commit c73680e7d7f906b841f77dd1aa4f5c3cfa8fb3a2.

Closes #382.