### PR TITLE
Add Storage class override instructions to doc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,6 +37,7 @@ By order of apparition, thanks:
     * Jumpei Yoshimura (S3 docs)
     * Jon Dufresne
     * Rodrigo Gadea (Dropbox fixes)
+    * Shaung Cheng (S3 docs)
 
 
 

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -254,15 +254,18 @@ Standard file access options are available, and work as expected::
     >>> default_storage.exists('storage_test')
     False
 
-Overriding the Storage class
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Overriding the default Storage class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Test heading format.
+Here we demonstrate how to override the default Storage class to get you started.
+
+
 
 Model
 -----
 
 An object without a file has limited functionality::
+
     from django.db import models
 
     class MyModel(models.Model):

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -331,7 +331,7 @@ Or you may want to upload files to the bucket in some view that accepts file upl
 
 A side note is that if you have ``AWS_S3_CUSTOM_DOMAIN`` setup in your ``settings.py``, by default the storage class will always use ``AWS_S3_CUSTOM_DOMAIN`` to generate url. 
 
-If your ``AWS_S3_CUSTOM_DOMAIN`` is pointing to a different bucket than your custom storage class, the ``.url()`` function will give you the wrong url. In such case, you will have to configure your storage class and explicitly specifiy `custom_domain` as below::
+If your ``AWS_S3_CUSTOM_DOMAIN`` is pointing to a different bucket than your custom storage class, the ``.url()`` function will give you the wrong url. In such case, you will have to configure your storage class and explicitly specifiy ``custom_domain`` as below::
 
     class MediaStorage(S3Boto3Storage):
         bucket_name = 'my-media-bucket'

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -329,7 +329,7 @@ Or you may want to upload files to the bucket in some view that accepts file upl
                     ),
                 }, status=400)
 
-A side note is that if you have ``AWS_S3_CUSTOM_DOMAIN`` setup in your `settings.py`, by default the storage class will always use ``AWS_S3_CUSTOM_DOMAIN`` to generate url. 
+A side note is that if you have ``AWS_S3_CUSTOM_DOMAIN`` setup in your ``settings.py``, by default the storage class will always use ``AWS_S3_CUSTOM_DOMAIN`` to generate url. 
 
 If your ``AWS_S3_CUSTOM_DOMAIN`` is pointing to a different bucket than your custom storage class, the ``.url()`` function will give you the wrong url. In such case, you will have to configure your storage class and explicitly specifiy `custom_domain` as below::
 

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -257,9 +257,111 @@ Standard file access options are available, and work as expected::
 Overriding the default Storage class
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Here we demonstrate how to override the default Storage class to get you started.
+This section assumes you have your AWS credentials setup, e.g. ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``.
+
+You can override the default Storage class to use as your custom storage backend. Below provides some examples and common use cases to help you get started.
+
+To create a storage class using a specific bucket::
+
+    from storages.backends.s3boto3 import S3Boto3Storage
+
+    class MediaStorage(S3Boto3Storage):
+        bucket_name = 'my-media-bucket'
+
+By default, this will not automatically create the bucket for you, if you don't create the bucket beforehand. You can change this to have it auto create for you as below:
+
+    class MediaStorage(S3Boto3Storage):
+        bucket_name = 'my-media-bucket'
+        auto_create_bucket = True
 
 
+Assume that you store the above class ``MediaStorage`` in a file called ``custom_storage.py`` in the project directory tree like below::
+
+    | django project root directory
+    | ├── manage.py
+    | ├── my_django_app          
+    | │   ├── custom_storage.py
+    | │   └── ...
+    | ├── ...
+
+You can now use your custom storage class for default file storage in Django settings like below::
+
+    DEFAULT_FILE_STORAGE = 'my_django_app.custom_storage.MediaStorage'
+
+Or you may want to upload files to the bucket in some view that accepts file upload request::
+
+    import os
+
+    from django.views import View
+    from django.http import JsonResponse
+
+    from django_backend.custom_storages import MediaStorage
+    
+    class FileUploadView(View):
+        def post(self, requests, **kwargs):
+            file_obj = requests.FILES.get('file', '')
+
+            # do your validation here e.g. file size/type check
+
+            # organize a path for the file in bucket
+            file_directory_within_bucket = 'user_uplaod_files/{username}'.format(username=request.user)
+            
+            # synthesize a full file path which includes the filename
+            file_path_within_bucket = os.path.join(
+                file_directory_within_bucket,
+                file_obj.name
+            )
+
+            media_storage = MediaStorage()
+
+            if not media_storage.exists(file_path_within_bucket): # avoid overwriting existing file
+                media_storage.save(file_path_within_bucket, file_obj)
+                file_url = media_storage.url(file_path_within_bucket)
+
+                return JsonResponse({
+                    'message': 'OK',
+                    'fileUrl': file_url,
+                })
+            else:
+                return JsonResponse({
+                    'message': 'Error: file {filename} already exists at {file_directory} in bucket {bucket_name}'.format(filename=file_obj.name, file_directory=file_directory_within_bucket, bucket_name=media_storage.bucket_name),
+                }, status=400)
+
+A side note is that in order for `media_storage.url()` to work with the bucket name you specified in your custom storage class, make sure you don't have `AWS_S3_CUSTOM_DOMAIN` setup in your `settings.py`, otherwise the `.url()` function will always use `AWS_S3_CUSTOM_DOMAIN` to generate file url. If your `AWS_S3_CUSTOM_DOMAIN` and your custom storage class are using different bucket, this will generate the wrong url. 
+
+In case you need `AWS_S3_CUSTOM_DOMAIN` for CDN and it's using a different bucket from your custom storage, you will need to explicitly specifiy `custom_domain` like below::
+
+    class MediaStorage(S3Boto3Storage):
+        bucket_name = 'my-media-bucket'
+        custom_domain = '{}.s3.amazonaws.com'.format(bucket_name)
+
+You can also decide to config your custom storage class to store files under a specific directory within the bucket::
+
+    class MediaStorage(S3Boto3Storage):
+        bucket_name = 'my-app-bucket'
+        location = 'media' # store files under directory `media/` in bucket `my-app-bucket`
+
+This is especially useful when you want to have multiple storage classes share the same bucket::
+
+    class MediaStorage(S3Boto3Storage):
+        bucket_name = 'my-app-bucket'
+        location = 'media'
+    
+    class StaticStorage(S3Boto3Storage):
+        bucket_name = 'my-app-bucket'
+        location = 'static'
+
+So your bucket file can be organized like as below::
+
+    | my-app-bucket
+    | ├── media
+    | │   ├── user_video.mp4
+    | │   ├── user_file.pdf
+    | │   └── ...
+    | ├── static         
+    | │   ├── app.js
+    | │   ├── app.css
+    | │   └── ...
 
 Model
 -----

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -254,6 +254,11 @@ Standard file access options are available, and work as expected::
     >>> default_storage.exists('storage_test')
     False
 
+Overriding the Storage class
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Test heading format.
+
 Model
 -----
 


### PR DESCRIPTION
Based on issue #748, adding instructions about how to override the `S3Boto3Storage` class. Particularly mentions the behavior of `.url()` to avoid confusion when people want to get the file url for their custom storage backend. Fixed some minor formatting.