### PR TITLE
Added error handling at import django.utils.six module. #758

### DIFF
--- a/storages/backends/apache_libcloud.py
+++ b/storages/backends/apache_libcloud.py
@@ -9,8 +9,13 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.six import string_types
-from django.utils.six.moves.urllib.parse import urljoin
+
+try:
+    from django.utils.six import string_types
+    from django.utils.six.moves.urllib.parse import urljoin
+except ImportError:
+    string_types = str
+    from urllib.parse import urljoin
 
 try:
     from libcloud.storage.providers import get_driver

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -24,9 +24,13 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.utils import setting
+
+try:
+    from django.utils.six.moves.urllib import parse as urlparse
+except ImportError:
+    from urllib import parse as urlparse
 
 
 class FTPStorageException(Exception):

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -15,13 +15,18 @@ from django.utils.deconstruct import deconstructible
 from django.utils.encoding import (
     filepath_to_uri, force_bytes, force_text, smart_text,
 )
-from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.timezone import is_naive, make_naive
 
 from storages.utils import (
     check_location, get_available_overwrite_name, lookup_env, safe_join,
     setting,
 )
+
+try:
+    from django.utils.six.moves.urllib import parse as urlparse
+except ImportError:
+    from urllib import parse as urlparse
+
 
 try:
     import boto3.session

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -16,9 +16,13 @@ import paramiko
 from django.core.files.base import File
 from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
-from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.utils import setting
+
+try:
+    from django.utils.six.moves.urllib import parse as urlparse
+except ImportError:
+    from urllib import parse as urlparse
 
 
 @deconstructible

--- a/tests/test_s3boto.py
+++ b/tests/test_s3boto.py
@@ -12,9 +12,13 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.test import TestCase
 from django.utils import timezone as tz
-from django.utils.six.moves.urllib import parse as urlparse
 
 from storages.backends import s3boto
+
+try:
+    from django.utils.six.moves.urllib import parse as urlparse
+except ImportError:
+    from urllib import parse as urlparse
 
 
 class S3BotoTestCase(TestCase):

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -13,10 +13,15 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
-from django.utils.six.moves.urllib import parse as urlparse
 from django.utils.timezone import is_aware, utc
 
 from storages.backends import s3boto3
+
+try:
+    from django.utils.six.moves.urllib import parse as urlparse
+except ImportError:
+    from urllib import parse as urlparse
+
 
 try:
     from unittest import mock


### PR DESCRIPTION
I fixed #758.
If django-storages ends support for Python2, close this.