### PR TITLE
[dropbox] Fix crash on DropBoxStorage.listdir

### DIFF
--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -80,8 +80,11 @@ class DropBoxStorage(Storage):
         self.client = Dropbox(oauth2_access_token, timeout=timeout)
 
     def _full_path(self, name):
-        if name == '/':
+        if not name or name == '/':
             name = ''
+            if self.root_path == '/':
+                return ''
+
         return safe_join(self.root_path, name).replace('\\', '/')
 
     def delete(self, name):

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -82,10 +82,7 @@ class DropBoxStorage(Storage):
     def _full_path(self, name):
         if name == '/':
             name = ''
-
-        _path = safe_join(self.root_path, name).replace('\\', '/')
-        if _path == '/':
-            return ''
+        return safe_join(self.root_path, name).replace('\\', '/')
 
     def delete(self, name):
         self.client.files_delete(self._full_path(name))
@@ -99,6 +96,10 @@ class DropBoxStorage(Storage):
     def listdir(self, path):
         directories, files = [], []
         full_path = self._full_path(path)
+
+        if full_path == '/':
+            full_path = ''
+
         metadata = self.client.files_list_folder(full_path)
         for entry in metadata.entries:
             if isinstance(entry, FolderMetadata):

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -80,12 +80,12 @@ class DropBoxStorage(Storage):
         self.client = Dropbox(oauth2_access_token, timeout=timeout)
 
     def _full_path(self, name):
-        if not name or name == '/':
+        if name == '/':
             name = ''
-            if self.root_path == '/':
-                return ''
 
-        return safe_join(self.root_path, name).replace('\\', '/')
+        _path = safe_join(self.root_path, name).replace('\\', '/')
+        if _path == '/':
+            return ''
 
     def delete(self, name):
         self.client.files_delete(self._full_path(name))

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -80,6 +80,10 @@ class DropBoxTest(TestCase):
                 return_value=FILES_MOCK)
     def test_listdir(self, *args):
         dirs, files = self.storage.listdir('/')
+        dirs2, files2 = self.storage.listdir('')
+        self.assertEqual(dirs, dirs2)
+        self.assertEqual(files2, files2)
+
         self.assertGreater(len(dirs), 0)
         self.assertGreater(len(files), 0)
         self.assertEqual(dirs[0], 'bar')
@@ -139,9 +143,6 @@ class DropBoxTest(TestCase):
         self.assertEqual(files, self.storage._full_path('.'))
         self.assertEqual(files, self.storage._full_path('..'))
         self.assertEqual(files, self.storage._full_path('../..'))
-
-        # DropBox API requires empty strings for root path see #762
-        self.assertEqual(self.storage._full_path('/'), '')
 
 
 class DropBoxFileTest(TestCase):

--- a/tests/test_dropbox.py
+++ b/tests/test_dropbox.py
@@ -140,6 +140,9 @@ class DropBoxTest(TestCase):
         self.assertEqual(files, self.storage._full_path('..'))
         self.assertEqual(files, self.storage._full_path('../..'))
 
+        # DropBox API requires empty strings for root path see #762
+        self.assertEqual(self.storage._full_path('/'), '')
+
 
 class DropBoxFileTest(TestCase):
     def setUp(self, *args):


### PR DESCRIPTION
Use an empty string instead of `/` in `DropBoxStorage.listdir`

Fix #761 Dropbox base path / should be an empty string

It solves this kind of issues:
```
Traceback (most recent call last):
  File "manage.py", line 15, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.7/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python3.7/site-packages/dbbackup/management/commands/listbackups.py", line 31, in handle
    files_attr = self.get_backup_attrs(options)
  File "/usr/local/lib/python3.7/site-packages/dbbackup/management/commands/listbackups.py", line 42, in get_backup_attrs
    filenames = self.storage.list_backups(**filters)
  File "/usr/local/lib/python3.7/site-packages/dbbackup/storage.py", line 123, in list_backups
    files = [f for f in self.list_directory() if utils.filename_to_datestring(f)]
  File "/usr/local/lib/python3.7/site-packages/dbbackup/storage.py", line 78, in list_directory
    return self.storage.listdir(path)[1]
  File "/usr/local/lib/python3.7/site-packages/storages/backends/dropbox.py", line 99, in listdir
    metadata = self.client.files_list_folder(full_path)
  File "/usr/local/lib/python3.7/site-packages/dropbox/base.py", line 1744, in files_list_folder
    None,
  File "/usr/local/lib/python3.7/site-packages/dropbox/dropbox.py", line 274, in request
    timeout=timeout)
  File "/usr/local/lib/python3.7/site-packages/dropbox/dropbox.py", line 365, in request_json_string_with_retry
    timeout=timeout)
  File "/usr/local/lib/python3.7/site-packages/dropbox/dropbox.py", line 456, in request_json_string
    raise BadInputError(request_id, r.text)
dropbox.exceptions.BadInputError: BadInputError('XXXXXXXXXXXXXXXX', 'Error in call to API function "files/list_folder": request body: path: Specify the root folder as an empty string rather than as "/".')
```