### PR TITLE
Added Cache-Control header support for Azure backend

### DIFF
--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -159,3 +159,9 @@ The following settings are available:
 
     A token credential used to authenticate HTTPS requests. The token value
     should be updated before its expiration.
+
+
+``AZURE_CACHE_CONTROL``
+
+    A variable to set the Cache-Control HTTP response header. E.g. 
+    ``AZURE_CACHE_CONTROL = "public,max-age=31536000,immutable"``

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -134,6 +134,7 @@ class AzureStorage(Storage):
     overwrite_files = setting('AZURE_OVERWRITE_FILES', False)
     location = setting('AZURE_LOCATION', '')
     default_content_type = 'application/octet-stream'
+    cache_control = setting("AZURE_CACHE_CONTROL")
     is_emulated = setting('AZURE_EMULATED_MODE', False)
     endpoint_suffix = setting('AZURE_ENDPOINT_SUFFIX')
     sas_token = setting('AZURE_SAS_TOKEN')
@@ -255,7 +256,8 @@ class AzureStorage(Storage):
             stream=content,
             content_settings=ContentSettings(
                 content_type=content_type,
-                content_encoding=content_encoding),
+                content_encoding=content_encoding,
+                cache_control=self.cache_control),
             max_connections=self.upload_max_conn,
             timeout=self.timeout)
         return cleaned_name

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -304,7 +304,8 @@ class AzureStorageTest(TestCase):
                 timeout=20)
             c_mocked.assert_called_once_with(
                 content_type='text/plain',
-                content_encoding=None)
+                content_encoding=None,
+                cache_control=None)
 
     def test_storage_open_write(self):
         """


### PR DESCRIPTION
The HTTP header value can be controlled via the AZURE_CACHE_CONTROL environment variable.
For example: AZURE_CACHE_CONTROL="public, max-age=31536000"

Issues #323 and #674.