### PR TITLE
Add STATICFILES_STORAGE to gcloud.rst

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -40,6 +40,10 @@ Set the default storage and bucket name in your settings.py file:
 
     DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
     GS_BUCKET_NAME = 'YOUR_BUCKET_NAME_GOES_HERE'
+    
+To allow ``django-admin.py`` collectstatic to automatically put your static files in your bucket set the following in your settings.py::
+
+    STATICFILES_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
 
 Once you're done, default_storage will be Google Cloud Storage::
 


### PR DESCRIPTION
(Text copied from [`amazon-S3.rst`](https://github.com/jschneier/django-storages/blame/master/docs/backends/amazon-S3.rst#L21))

Without STATICFILES_STORAGE set, `collectstatic` doesn't upload to Google Cloud Storage.