### PR TITLE
Add Python 3.8 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,17 +42,24 @@ matrix:
       env: TOXENV=py36-django22
     - python: 3.7
       env: TOXENV=py37-django22
+    - python: 3.8
+      env: TOXENV=py38-django22
     - python: 3.6
       env: TOXENV=py36-django30
     - python: 3.7
       env: TOXENV=py37-django30
+    - python: 3.8
+      env: TOXENV=py38-django30
     - python: 3.6
       env: TOXENV=py36-djangomaster
     - python: 3.7
       env: TOXENV=py37-djangomaster
+    - python: 3.8
+      env: TOXENV=py38-djangomaster
   allow_failures:
     - env: TOXENV=py36-djangomaster
     - env: TOXENV=py37-djangomaster
+    - env: TOXENV=py38-djangomaster
 
 install:
   - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     test_suite='tests',
     zip_safe=False

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ envlist =
 	py{27,34,35,36,37}-django111
 	py{34,35,36,37}-django20
 	py{35,36,37}-django21
-	py{35,36,37}-django22
-	py{36,37}-django30
-	py{36,37}-djangomaster
+	py{35,36,37,38}-django22
+	py{36,37,38}-django30
+	py{36,37,38}-djangomaster
 	integration
 	flake8
 


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019.