### PR TITLE
Replace deprecated py.test command with pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
 	DJANGO_SETTINGS_MODULE = tests.settings
 	PYTHONWARNINGS = all
 	PYTHONDONTWRITEBYTECODE = 1
-commands = py.test --cov=storages --ignore=tests/integration/ tests/ {posargs}
+commands = pytest --cov=storages --ignore=tests/integration/ tests/ {posargs}
 deps =
 	django111: Django>=1.11,<2.0
 	django20: Django>=2.0,<2.1
@@ -39,11 +39,10 @@ extras =
 ignore_errors = True
 whitelist_externals =
     docker
-    py.test
 commands =
     docker pull arafato/azurite
     docker run --name azure-storage -d -t -p 10000:10000 -p 10001:10001 -p 10002:10002 arafato/azurite
-	py.test tests/integration/
+	pytest tests/integration/
     docker stop azure-storage
     docker rm azure-storage
 setenv =


### PR DESCRIPTION
The pytest project recommends using the command pytest as an entry
point, not py.test.

https://docs.pytest.org/en/latest/faq.html#why-can-i-use-both-pytest-and-py-test-commands

> Why can I use both pytest and py.test commands?
>
> pytest used to be part of the py package, which provided several
> developer utilities, all starting with py.<TAB>, thus providing nice
> TAB-completion. If you install pip install pycmd you get these tools
> from a separate package. Once pytest became a separate package, the
> py.test name was retained due to avoid a naming conflict with another
> tool. This conflict was eventually resolved, and the pytest command
> was therefore introduced. In future versions of pytest, we may
> deprecate and later remove the py.test command to avoid perpetuating
> the confusion.