### PR TITLE
Remove default 'dist: xenial' from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # https://travis-ci.org/jschneier/django-storages/
-dist: xenial
 language: python
 
 cache: pip


### PR DESCRIPTION
Since May 2019, Travis has used Ubuntu Xenial 16.04 as the default
Travis CI build environment.

For additional details, see:

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment