### PR TITLE
Create empty file if no bytes written to S3 file in 'w' mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ By order of apparition, thanks:
     * Jon Dufresne
     * Rodrigo Gadea (Dropbox fixes)
     * Martey Dodoo
+    * Chris Rink
 
 
 

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -93,9 +93,6 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
 ``AWS_S3_FILE_OVERWRITE`` (optional: default is ``True``)
     By default files with the same name will overwrite each other. Set this to ``False`` to have extra characters appended.
 
-``AWS_S3_CREATE_EMPTY_FILE`` (optional: default is ``False``)
-    By default, if you open a file as by ``S3Boto3Storage.open`` in write mode and then close it before writing anything out, the file will not be created. This differs from Django's ``FileSystemStorage``. Set this to ``True`` to force creation of an empty file if no bytes are written (and if the file does not already exist).
-
 ``AWS_S3_HOST`` (optional - boto only, default is ``s3.amazonaws.com``)
 
   To ensure you use `AWS Signature Version 4`_ it is recommended to set this to the host of your bucket. See the

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -93,6 +93,9 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
 ``AWS_S3_FILE_OVERWRITE`` (optional: default is ``True``)
     By default files with the same name will overwrite each other. Set this to ``False`` to have extra characters appended.
 
+``AWS_S3_CREATE_EMPTY_FILE`` (optional: default is ``False``)
+    By default, if you open a file as by ``S3Boto3Storage.open`` in write mode and then close it before writing anything out, the file will not be created. This differs from Django's ``FileSystemStorage``. Set this to ``True`` to force creation of an empty file if no bytes are written (and if the file does not already exist).
+
 ``AWS_S3_HOST`` (optional - boto only, default is ``s3.amazonaws.com``)
 
   To ensure you use `AWS Signature Version 4`_ it is recommended to set this to the host of your bucket. See the

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -171,7 +171,6 @@ class S3Boto3StorageFile(File):
         """
         assert "w" in self._mode
         assert self._raw_bytes_written == 0
-        assert self._storage.create_empty_files
 
         try:
             # Check if the object exists on the server; if so, don't do anything
@@ -197,7 +196,7 @@ class S3Boto3StorageFile(File):
         else:
             if self._multipart is not None:
                 self._multipart.abort()
-            if self._storage.create_empty_files and self._raw_bytes_written == 0:
+            if self._raw_bytes_written == 0:
                 self._create_empty_on_close()
         if self._file is not None:
             self._file.close()
@@ -257,7 +256,6 @@ class S3Boto3Storage(Storage):
     use_ssl = setting('AWS_S3_USE_SSL', True)
     verify = setting('AWS_S3_VERIFY', None)
     max_memory_size = setting('AWS_S3_MAX_MEMORY_SIZE', 0)
-    create_empty_files = setting('AWS_S3_CREATE_EMPTY_FILE', False)
 
     def __init__(self, acl=None, bucket=None, **settings):
         # check if some of the settings we've provided as class attributes

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -169,6 +169,7 @@ class S3Boto3StorageFile(File):
             f = storage.open("file.txt", mode="w")
             f.close()
         """
+        assert "w" in self._mode
         assert self._raw_bytes_written == 0
         assert self._storage.create_empty_files
 

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -197,7 +197,7 @@ class S3Boto3StorageFile(File):
             if self._multipart is not None:
                 self._multipart.abort()
             if self._storage.create_empty_files and self._raw_bytes_written == 0:
-                self._create_on_close()
+                self._create_empty_on_close()
         if self._file is not None:
             self._file.close()
             self._file = None

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -72,6 +72,7 @@ class S3Boto3StorageFile(File):
             # Force early RAII-style exception if object does not exist
             self.obj.load()
         self._is_dirty = False
+        self._raw_bytes_written = 0
         self._file = None
         self._multipart = None
         # 5 MB is the minimum part size (if there is more than one part).
@@ -116,19 +117,26 @@ class S3Boto3StorageFile(File):
             raise AttributeError("File was not opened in write mode.")
         self._is_dirty = True
         if self._multipart is None:
-            parameters = self._storage.object_parameters.copy()
-            if self._storage.default_acl:
-                parameters['ACL'] = self._storage.default_acl
-            parameters['ContentType'] = (mimetypes.guess_type(self.obj.key)[0] or
-                                         self._storage.default_content_type)
-            if self._storage.reduced_redundancy:
-                parameters['StorageClass'] = 'REDUCED_REDUNDANCY'
-            if self._storage.encryption:
-                parameters['ServerSideEncryption'] = 'AES256'
-            self._multipart = self.obj.initiate_multipart_upload(**parameters)
+            self._multipart = self.obj.initiate_multipart_upload(
+                **self._get_write_parameters()
+            )
         if self.buffer_size <= self._buffer_file_size:
             self._flush_write_buffer()
-        return super(S3Boto3StorageFile, self).write(force_bytes(content))
+        bstr = force_bytes(content)
+        self._raw_bytes_written += len(bstr)
+        return super(S3Boto3StorageFile, self).write(bstr)
+
+    def _get_write_parameters(self):
+        parameters = self._storage.object_parameters.copy()
+        if self._storage.default_acl:
+            parameters['ACL'] = self._storage.default_acl
+        parameters['ContentType'] = (mimetypes.guess_type(self.obj.key)[0] or
+                                     self._storage.default_content_type)
+        if self._storage.reduced_redundancy:
+            parameters['StorageClass'] = 'REDUCED_REDUNDANCY'
+        if self._storage.encryption:
+            parameters['ServerSideEncryption'] = 'AES256'
+        return parameters
 
     @property
     def _buffer_file_size(self):
@@ -150,6 +158,31 @@ class S3Boto3StorageFile(File):
             self.file.seek(0)
             self.file.truncate()
 
+    def _create_empty_on_close(self):
+        """
+        Attempt to create an empty file for this key when this File is closed if no bytes
+        have been written and no object already exists on S3 for this key.
+
+        This behavior is meant to mimic the behavior of Django's builtin FileSystemStorage,
+        where files are always created after they are opened in write mode:
+
+            f = storage.open("file.txt", mode="w")
+            f.close()
+        """
+        assert self._raw_bytes_written == 0
+        assert self._storage.create_empty_files
+
+        try:
+            # Check if the object exists on the server; if so, don't do anything
+            self.obj.load()
+        except ClientError as err:
+            if err.response["ResponseMetadata"]["HTTPStatusCode"] == 404:
+                self.obj.put(
+                    Body=b"", **self._get_write_parameters(),
+                )
+            else:
+                raise
+
     def close(self):
         if self._is_dirty:
             self._flush_write_buffer()
@@ -163,6 +196,8 @@ class S3Boto3StorageFile(File):
         else:
             if self._multipart is not None:
                 self._multipart.abort()
+            if self._storage.create_empty_files and self._raw_bytes_written == 0:
+                self._create_on_close()
         if self._file is not None:
             self._file.close()
             self._file = None
@@ -221,6 +256,7 @@ class S3Boto3Storage(Storage):
     use_ssl = setting('AWS_S3_USE_SSL', True)
     verify = setting('AWS_S3_VERIFY', None)
     max_memory_size = setting('AWS_S3_MAX_MEMORY_SIZE', 0)
+    create_empty_files = setting('AWS_S3_CREATE_EMPTY_FILE', False)
 
     def __init__(self, acl=None, bucket=None, **settings):
         # check if some of the settings we've provided as class attributes

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -178,7 +178,7 @@ class S3Boto3StorageFile(File):
         except ClientError as err:
             if err.response["ResponseMetadata"]["HTTPStatusCode"] == 404:
                 self.obj.put(
-                    Body=b"", **self._get_write_parameters(),
+                    Body=b"", **self._get_write_parameters()
                 )
             else:
                 raise

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -287,7 +287,6 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         name = 'test_open_no_write.txt'
 
         # Set the encryption flag used for puts
-        self.storage.create_empty_files = True
         self.storage.encryption = True
         self.storage.reduced_redundancy = True
         self.storage.default_acl = 'public-read'
@@ -321,7 +320,6 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         name = 'test_open_no_overwrite_existing.txt'
 
         # Set the encryption flag used for puts
-        self.storage.create_empty_files = True
         self.storage.encryption = True
         self.storage.reduced_redundancy = True
         self.storage.default_acl = 'public-read'

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -278,6 +278,37 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         multipart.complete.assert_called_once_with(
             MultipartUpload={'Parts': [{'ETag': '123', 'PartNumber': 1}]})
 
+    def test_storage_open_no_write(self):
+        """
+        Test opening a file in write mode
+        """
+        name = 'test_open_no_write.txt'
+
+        # Set the encryption flag used for puts
+        self.storage.create_empty_files = True
+        self.storage.encryption = True
+        self.storage.reduced_redundancy = True
+        self.storage.default_acl = 'public-read'
+
+        file = self.storage.open(name, 'w')
+        self.storage.bucket.Object.assert_called_with(name)
+        obj = self.storage.bucket.Object.return_value
+
+        # Set the name of the mock object
+        obj.key = name
+
+        # Save the internal file before closing
+        file.close()
+
+        obj.load.assert_called_once_with()
+        obj.put.assert_called_once_with(
+            ACL='public-read',
+            Body=b"",
+            ContentType='text/plain',
+            ServerSideEncryption='AES256',
+            StorageClass='REDUCED_REDUNDANCY'
+        )
+
     def test_storage_write_beyond_buffer_size(self):
         """
         Test writing content that exceeds the buffer size

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -280,9 +280,45 @@ class S3Boto3StorageTests(S3Boto3TestCase):
 
     def test_storage_open_no_write(self):
         """
-        Test opening a file in write mode
+        Test opening file in write mode and closing without writing.
+
+        A file should be created as by obj.put(...).
         """
         name = 'test_open_no_write.txt'
+
+        # Set the encryption flag used for puts
+        self.storage.create_empty_files = True
+        self.storage.encryption = True
+        self.storage.reduced_redundancy = True
+        self.storage.default_acl = 'public-read'
+
+        file = self.storage.open(name, 'w')
+        self.storage.bucket.Object.assert_called_with(name)
+        obj = self.storage.bucket.Object.return_value
+        obj.load.side_effect = ClientError({'Error': {},
+                                            'ResponseMetadata': {'HTTPStatusCode': 404}},
+                                           'head_bucket')
+
+        # Set the name of the mock object
+        obj.key = name
+
+        # Save the internal file before closing
+        file.close()
+
+        obj.load.assert_called_once_with()
+        obj.put.assert_called_once_with(
+            ACL='public-read',
+            Body=b"",
+            ContentType='text/plain',
+            ServerSideEncryption='AES256',
+            StorageClass='REDUCED_REDUNDANCY'
+        )
+
+    def test_storage_open_no_overwrite_existing(self):
+        """
+        Test opening an existing file in write mode and closing without writing.
+        """
+        name = 'test_open_no_overwrite_existing.txt'
 
         # Set the encryption flag used for puts
         self.storage.create_empty_files = True
@@ -301,13 +337,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         file.close()
 
         obj.load.assert_called_once_with()
-        obj.put.assert_called_once_with(
-            ACL='public-read',
-            Body=b"",
-            ContentType='text/plain',
-            ServerSideEncryption='AES256',
-            StorageClass='REDUCED_REDUNDANCY'
-        )
+        obj.put.assert_not_called()
 
     def test_storage_write_beyond_buffer_size(self):
         """


### PR DESCRIPTION
This PR adds functionality to `S3Boto3StorageFile` that will create an empty file if no bytes are written to S3 after opening a file in `w` mode, similar to how `FileSystemStorage` and Python's native `open` work.

Let me know if I'm missing anything or if you have any questions. Thank you!

Fixes https://github.com/jschneier/django-storages/issues/435