### PR TITLE
Allow SFTPStorage to raise exceptions upon connection error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,6 +40,7 @@ By order of apparition, thanks:
     * Martey Dodoo
     * Chris Rink
     * Shaung Cheng (S3 docs)
+    * Andrew Perry (Bug fixes in SFTPStorage)
 
 
 Extra thanks to Marty for adding this in Django,

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -78,8 +78,6 @@ class SFTPStorage(Storage):
                 self._connect()
             else:
                 raise paramiko.AuthenticationException(e)
-        except Exception as e:
-            print(e)
 
         if self._ssh.get_transport():
             self._sftp = self._ssh.open_sftp()


### PR DESCRIPTION
This PR ensure that SFTPStorage raises an exception that can be handled, rather than simply printing a message to stdout (Issue #835).