### PR TITLE
Allow using AWS_QUERYSTRING_AUTH & AWS_S3_CUSTOM_DOMAIN at the same time

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -671,9 +671,7 @@ class S3Boto3Storage(Storage):
     def url(self, name, parameters=None, expire=None):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(self._clean_name(name))
-        if self.custom_domain:
-            return "{}//{}/{}".format(self.url_protocol,
-                                      self.custom_domain, filepath_to_uri(name))
+
         if expire is None:
             expire = self.querystring_expire
 
@@ -682,6 +680,19 @@ class S3Boto3Storage(Storage):
         params['Key'] = self._encode_name(name)
         url = self.bucket.meta.client.generate_presigned_url('get_object', Params=params,
                                                              ExpiresIn=expire)
+
+        if self.custom_domain:
+            # Key parameter can't be empty. Use "/" and remove it later.
+            params['Key'] = '/'
+            root_url_signed = self.bucket.meta.client.generate_presigned_url('get_object',
+                                                                             Params=params,
+                                                                             ExpiresIn=expire)
+            # Remove signing parameter and previouly added key "/".
+            root_url = self._strip_signing_parameters(root_url_signed)[:-1]
+            # Replace bucket domain with custom domain.
+            custom_url = "{}//{}/".format(self.url_protocol, self.custom_domain)
+            url = url.replace(root_url, custom_url)
+
         if self.querystring_auth:
             return url
         return self._strip_signing_parameters(url)


### PR DESCRIPTION
Hi, 

I am currently trying to mock S3 in development with the help of https://github.com/adobe/S3Mock. Unfortunately I can't use signed URLs and a custom domain at the same time. This _should_ fix that.