### PR TITLE
Allow SFTPStorage to be configured via class variables

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ By order of apparition, thanks:
     * Manuel Kaufmann (humitos)
     * Taras Petriichuk (Dropbox write_mode option)
     * Zoe Liao (S3 docs)
+    * Jonathan Ehwald
 
 
 Extra thanks to Marty for adding this in Django,

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -14,9 +14,9 @@ from datetime import datetime
 
 import paramiko
 from django.core.files.base import File
-from django.core.files.storage import Storage
 from django.utils.deconstruct import deconstructible
 
+from storages.base import BaseStorage
 from storages.utils import setting
 
 try:
@@ -26,31 +26,34 @@ except ImportError:
 
 
 @deconstructible
-class SFTPStorage(Storage):
-
-    def __init__(self, host=None, params=None, interactive=None, file_mode=None,
-                 dir_mode=None, uid=None, gid=None, known_host_file=None,
-                 root_path=None, base_url=None):
-        self._host = host or setting('SFTP_STORAGE_HOST')
-
-        self._params = params or setting('SFTP_STORAGE_PARAMS', {})
-        self._interactive = setting('SFTP_STORAGE_INTERACTIVE', False) \
-            if interactive is None else interactive
-        self._file_mode = setting('SFTP_STORAGE_FILE_MODE') \
-            if file_mode is None else file_mode
-        self._dir_mode = setting('SFTP_STORAGE_DIR_MODE') if \
-            dir_mode is None else dir_mode
-
-        self._uid = setting('SFTP_STORAGE_UID') if uid is None else uid
-        self._gid = setting('SFTP_STORAGE_GID') if gid is None else gid
-        self._known_host_file = setting('SFTP_KNOWN_HOST_FILE') \
-            if known_host_file is None else known_host_file
-
-        self._root_path = setting('SFTP_STORAGE_ROOT', '') \
-            if root_path is None else root_path
-        self._base_url = setting('MEDIA_URL') if base_url is None else base_url
-
+class SFTPStorage(BaseStorage):
+    def __init__(self, host=None, **settings):
+        super(SFTPStorage, self).__init__(host=host, **settings)
+        self._host = self.host
+        self._params = self.params
+        self._interactive = self.interactive
+        self._file_mode = self.file_mode
+        self._dir_mode = self.dir_mode
+        self._uid = self.uid
+        self._gid = self.gid
+        self._known_host_file = self.known_host_file
+        self._root_path = self.root_path
+        self._base_url = self.base_url
         self._sftp = None
+
+    def get_default_settings(self):
+        return {
+            'host': setting('SFTP_STORAGE_HOST'),
+            'params': setting('SFTP_STORAGE_PARAMS', {}),
+            'interactive': setting('SFTP_STORAGE_INTERACTIVE', False),
+            'file_mode': setting('SFTP_STORAGE_FILE_MODE'),
+            'dir_mode': setting('SFTP_STORAGE_DIR_MODE'),
+            'uid': setting('SFTP_STORAGE_UID'),
+            'gid': setting('SFTP_STORAGE_GID'),
+            'known_host_file': setting('SFTP_KNOWN_HOST_FILE'),
+            'root_path': setting('SFTP_STORAGE_ROOT', ''),
+            'base_url': setting('MEDIA_URL'),
+        }
 
     def _connect(self):
         self._ssh = paramiko.SSHClient()

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import paramiko
 from django.core.files.base import File
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from storages.backends import sftpstorage
 
@@ -151,6 +151,33 @@ class SFTPStorageTest(TestCase):
 
         self.assertTrue(self.storage.sftp)
         self.assertTrue(connect.called)
+
+    def test_override_settings(self):
+        with override_settings(SFTP_STORAGE_ROOT='foo1'):
+            storage = sftpstorage.SFTPStorage()
+            self.assertEqual(storage._root_path, 'foo1')
+        with override_settings(SFTP_STORAGE_ROOT='foo2'):
+            storage = sftpstorage.SFTPStorage()
+            self.assertEqual(storage._root_path, 'foo2')
+
+    def test_override_class_variable(self):
+        class MyStorage1(sftpstorage.SFTPStorage):
+            root_path = 'foo1'
+
+        storage = MyStorage1()
+        self.assertEqual(storage._root_path, 'foo1')
+
+        class MyStorage2(sftpstorage.SFTPStorage):
+            root_path = 'foo2'
+
+        storage = MyStorage2()
+        self.assertEqual(storage._root_path, 'foo2')
+
+    def test_override_init_argument(self):
+        storage = sftpstorage.SFTPStorage(root_path='foo1')
+        self.assertEqual(storage._root_path, 'foo1')
+        storage = sftpstorage.SFTPStorage(root_path='foo2')
+        self.assertEqual(storage._root_path, 'foo2')
 
 
 class SFTPStorageFileTest(TestCase):


### PR DESCRIPTION
This PR makes the SFTPStorage class configurable via class variables (similar to other backends). That way subclassing is more convenient. (#851).

As far as I can tell, these changes are backwards compatible.