### PR TITLE
Add S3 support for `http_method` in `storage.url`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ By order of apparition, thanks:
     * Chris Rink
     * Shaung Cheng (S3 docs)
     * Andrew Perry (Bug fixes in SFTPStorage)
+    * Manuel Kaufmann (humitos)
 
 
 Extra thanks to Marty for adding this in Django,

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -668,7 +668,7 @@ class S3Boto3Storage(Storage):
         split_url = split_url._replace(query="&".join(joined_qs))
         return split_url.geturl()
 
-    def url(self, name, parameters=None, expire=None):
+    def url(self, name, parameters=None, expire=None, http_method='GET'):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(self._clean_name(name))
         if self.custom_domain:
@@ -681,7 +681,7 @@ class S3Boto3Storage(Storage):
         params['Bucket'] = self.bucket.name
         params['Key'] = self._encode_name(name)
         url = self.bucket.meta.client.generate_presigned_url('get_object', Params=params,
-                                                             ExpiresIn=expire)
+                                                             ExpiresIn=expire, HttpMethod=http_method)
         if self.querystring_auth:
             return url
         return self._strip_signing_parameters(url)

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -668,7 +668,7 @@ class S3Boto3Storage(Storage):
         split_url = split_url._replace(query="&".join(joined_qs))
         return split_url.geturl()
 
-    def url(self, name, parameters=None, expire=None, http_method='GET'):
+    def url(self, name, parameters=None, expire=None, http_method=None):
         # Preserve the trailing slash after normalizing the path.
         name = self._normalize_name(self._clean_name(name))
         if self.custom_domain:

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -558,7 +558,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             'get_object',
             Params={'Bucket': self.storage.bucket.name, 'Key': name},
             ExpiresIn=self.storage.querystring_expire,
-            HttpMethod='GET',
+            HttpMethod=None,
         )
 
         custom_expire = 123
@@ -568,7 +568,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             'get_object',
             Params={'Bucket': self.storage.bucket.name, 'Key': name},
             ExpiresIn=custom_expire,
-            HttpMethod='GET',
+            HttpMethod=None,
         )
 
         custom_method = 'HEAD'

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -557,7 +557,8 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.storage.bucket.meta.client.generate_presigned_url.assert_called_with(
             'get_object',
             Params={'Bucket': self.storage.bucket.name, 'Key': name},
-            ExpiresIn=self.storage.querystring_expire
+            ExpiresIn=self.storage.querystring_expire,
+            HttpMethod='GET',
         )
 
         custom_expire = 123
@@ -566,7 +567,18 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.storage.bucket.meta.client.generate_presigned_url.assert_called_with(
             'get_object',
             Params={'Bucket': self.storage.bucket.name, 'Key': name},
-            ExpiresIn=custom_expire
+            ExpiresIn=custom_expire,
+            HttpMethod='GET',
+        )
+
+        custom_method = 'HEAD'
+
+        self.assertEqual(self.storage.url(name, http_method=custom_method), url)
+        self.storage.bucket.meta.client.generate_presigned_url.assert_called_with(
+            'get_object',
+            Params={'Bucket': self.storage.bucket.name, 'Key': name},
+            ExpiresIn=self.storage.querystring_expire,
+            HttpMethod=custom_method,
         )
 
     def test_generated_url_is_encoded(self):


### PR DESCRIPTION
I went ahead and wrote a proposal for #853.

Allow to pass `http_method` to `storage.url` in order to calculate the signature accordingly. By default, it uses ~~'GET'~~ `None` to keep backward compatibility.

Please, let me know if this makes sense to you and suggest any changes you consider appropriate.