### PR TITLE
Remove testing for end-of-life Django versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,20 +21,6 @@ matrix:
       env: TOXENV=py36-django111
     - python: 3.7
       env: TOXENV=py37-django111
-    - python: 3.4
-      env: TOXENV=py34-django20
-    - python: 3.5
-      env: TOXENV=py35-django20
-    - python: 3.6
-      env: TOXENV=py36-django20
-    - python: 3.7
-      env: TOXENV=py37-django20
-    - python: 3.5
-      env: TOXENV=py35-django21
-    - python: 3.6
-      env: TOXENV=py36-django21
-    - python: 3.7
-      env: TOXENV=py37-django21
     - python: 3.5
       env: TOXENV=py35-django22
     - python: 3.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,6 @@ classifiers =
     Environment :: Web Environment
     Framework :: Django
     Framework :: Django :: 1.11
-    Framework :: Django :: 2.0
-    Framework :: Django :: 2.1
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Intended Audience :: Developers

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 minversion = 1.9
 envlist =
 	py{27,34,35,36,37}-django111
-	py{34,35,36,37}-django20
-	py{35,36,37}-django21
 	py{35,36,37,38}-django22
 	py{36,37,38}-django30
 	py{36,37,38}-djangomaster
@@ -18,8 +16,6 @@ setenv =
 commands = pytest --cov=storages --ignore=tests/integration/ tests/ {posargs}
 deps =
 	django111: Django>=1.11,<2.0
-	django20: Django>=2.0,<2.1
-	django21: Django>=2.1,<2.2
 	django22: Django>=2.2,<3.0
 	django30: Django>=3.0,<3.1
 	djangomaster: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
These versions are not recommended for production. They are no longer
receiving bug fixes, including for security issues.

Django 2.0 went EOL April 1, 2019.
Django 2.1 went EOL December 2, 2019.

For a complete list of supported Django versions, see:

https://www.djangoproject.com/download/#supported-versions

Removing testing of these EOL versions greatly reduces testing time and
resources.