### PR TITLE
Correct name of warning filter "all" → "always"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 [testenv]
 setenv =
 	DJANGO_SETTINGS_MODULE = tests.settings
-	PYTHONWARNINGS = all
+	PYTHONWARNINGS = always
 	PYTHONDONTWRITEBYTECODE = 1
 commands = pytest --cov=storages --ignore=tests/integration/ tests/ {posargs}
 deps =


### PR DESCRIPTION
Per the Python documentation, there is no "all" filter. It looks like
"always" was intended:

https://docs.python.org/3/library/warnings.html#the-warnings-filter

The filter "all" happens to work as it is an undocumented alias, but
might as well used the documented name.

https://github.com/python/cpython/blob/v3.8.2/Lib/warnings.py#L244