### PR TITLE
Remove duplicate settings assignment in glcoud backend

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -89,11 +89,6 @@ class GoogleCloudFile(File):
 class GoogleCloudStorage(BaseStorage):
     def __init__(self, **settings):
         super(GoogleCloudStorage, self).__init__(**settings)
-        # check if some of the settings we've provided as class attributes
-        # need to be overwritten with values passed in here
-        for name, value in settings.items():
-            if hasattr(self, name):
-                setattr(self, name, value)
 
         check_location(self)
 


### PR DESCRIPTION
Assigning the settings is already handled by the BaseStorage class.

Mistakenly left in as part of 955ee63b31c5f3e053fd5461c7c6dec06d2911af
due to a bad rebase.