### PR TITLE
add default implementation of get_default_settings to BaseStorage

### DIFF
--- a/storages/base.py
+++ b/storages/base.py
@@ -19,3 +19,6 @@ class BaseStorage(Storage):
                     )
                 )
             setattr(self, name, value)
+
+    def get_default_settings(self):
+        return {}


### PR DESCRIPTION
Based on my comment https://github.com/jschneier/django-storages/pull/524#issuecomment-600760753
> I'm not sure an empty {} is warranted because it's likely that a storage is providing some options, and it should use the get_default_settings for that? Or do you suspect people would create a new storage based off the BaseStorage that would have no settings? I guess for maybe a private source/single use storage that might be the case.

@jdufresne not sure if you had seen my subsequent comment (linked), but figured I could create a PR to discuss.