### PR TITLE
Fix leading "/" on windows

### DIFF
--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -83,7 +83,28 @@ class DropBoxStorage(Storage):
     def _full_path(self, name):
         if name == '/':
             name = ''
-        return safe_join(self.root_path, name).replace('\\', '/')
+        print('Root path in dropbox.storage : ', self.root_path)
+        
+        # If the machine is windows do not append the drive letter to file path
+        if os.name == 'nt':
+            final_path = os.path.join(self.root_path, name).replace('\\', '/')
+            
+            # Separator on linux system
+            sep = '//'
+            base_path = self.root_path
+
+            if (not os.path.normcase(final_path).startswith(os.path.normcase(base_path + sep)) and
+                    os.path.normcase(final_path) != os.path.normcase(base_path) and
+                    os.path.dirname(os.path.normcase(base_path)) != os.path.normcase(base_path)):
+                raise SuspiciousFileOperation(
+                    'The joined path ({}) is located outside of the base path '
+                    'component ({})'.format(final_path, base_path))
+            
+            print('Full file path in storage.dropbox._full_path : ', final_path)
+            return final_path
+        
+        else:
+            return safe_join(self.root_path, name).replace('\\', '/')
 
     def delete(self, name):
         self.client.files_delete(self._full_path(name))

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -100,7 +100,6 @@ class DropBoxStorage(Storage):
                     'The joined path ({}) is located outside of the base path '
                     'component ({})'.format(final_path, base_path))
             
-            print('Full file path in storage.dropbox._full_path : ', final_path)
             return final_path
         
         else:

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -82,9 +82,7 @@ class DropBoxStorage(Storage):
 
     def _full_path(self, name):
         if name == '/':
-            name = ''
-        print('Root path in dropbox.storage : ', self.root_path)
-        
+            name = ''        
         # If the machine is windows do not append the drive letter to file path
         if os.name == 'nt':
             final_path = os.path.join(self.root_path, name).replace('\\', '/')


### PR DESCRIPTION
The django utility django.utils._os.safe_join is used if the operating system is not
windows 'nt'. 
On a windows system os.path.abspath() will prefix the drive letter to the passed path.  This does not work with the dropbox SDK - the dropbox SDK expects '/' prefixed (not a drive letter).
If the operating system is windows 'nt' then the passed name will be checked against a path style specified for the dropbox SDK.  This means that os.path.abspath() is not used to normalize / absolutize the passed file name
AKA the root is kept as '/' and no drive is prefixed