### PR TITLE
Update amazon-S3.rst to fix "Missing required field Principal" error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,6 +42,7 @@ By order of apparition, thanks:
     * Shaung Cheng (S3 docs)
     * Andrew Perry (Bug fixes in SFTPStorage)
     * Manuel Kaufmann (humitos)
+    * Zoe Liao (S3 docs)
 
 
 Extra thanks to Marty for adding this in Django,

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -217,6 +217,9 @@ The IAM policy permissions needed for most common use cases are:
                     "s3:DeleteObject",
                     "s3:PutObjectAcl"
                 ],
+                "Principal": {
+                    "AWS": "example-AWS-account-ID"
+                },
                 "Resource": [
                     "arn:aws:s3:::example-bucket-name/*",
                     "arn:aws:s3:::example-bucket-name"
@@ -224,6 +227,11 @@ The IAM policy permissions needed for most common use cases are:
             }
         ]
     }
+
+
+For more information about Principal, please refer to `AWS JSON Policy Elements`_
+
+.. _AWS JSON Policy Elements: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
 
 Storage
 -------

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -218,7 +218,7 @@ The IAM policy permissions needed for most common use cases are:
                     "s3:PutObjectAcl"
                 ],
                 "Principal": {
-                    "AWS": "example-AWS-account-ID"
+                    "AWS": "arn:aws:iam::example-AWS-account-ID:user/example-user-name"
                 },
                 "Resource": [
                     "arn:aws:s3:::example-bucket-name/*",


### PR DESCRIPTION
1. Fix 'Missing required field Principal' error of IAM policy permissions.
![error](https://user-images.githubusercontent.com/29351339/79362033-a63c6380-7f78-11ea-9ecf-a3b77635a586.png)
2. Update AUTHORS 
