### PR TITLE
Add blob_chunk_size to get_default_settings of GoogleCloudStorage

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -34,7 +34,7 @@ class GoogleCloudFile(File):
         if not self.blob and 'w' in mode:
             self.blob = Blob(
                 self.name, storage.bucket,
-                chunk_size=setting('GS_BLOB_CHUNK_SIZE'))
+                chunk_size=storage.blob_chunk_size)
         self._file = None
         self._is_dirty = False
 
@@ -122,6 +122,7 @@ class GoogleCloudStorage(BaseStorage):
             # rolled over into a temporary file on disk. Default is 0: Do not
             # roll over.
             "max_memory_size": setting('GS_MAX_MEMORY_SIZE', 0),
+            "blob_chunk_size":setting('GS_BLOB_CHUNK_SIZE'),
         }
 
     @property

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -122,7 +122,7 @@ class GoogleCloudStorage(BaseStorage):
             # rolled over into a temporary file on disk. Default is 0: Do not
             # roll over.
             "max_memory_size": setting('GS_MAX_MEMORY_SIZE', 0),
-            "blob_chunk_size":setting('GS_BLOB_CHUNK_SIZE'),
+            "blob_chunk_size": setting('GS_BLOB_CHUNK_SIZE'),
         }
 
     @property


### PR DESCRIPTION
Create `blob_chunk_size` as a `GoogleCloudStorage` attribute so that it's easy to override `GS_BLOB_CHUNK_SIZE` in custom Google Cloud storage backends. Without this change, you have to create a new `GoogleCloudFile` and copy a lot of code to make it work