### PR TITLE
Sign CloudFront urls only in case querystring_auth is enabled

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -740,7 +740,7 @@ class S3Boto3Storage(BaseStorage):
             url = "{}//{}/{}".format(
                 self.url_protocol, self.custom_domain, filepath_to_uri(name))
 
-            if self.cloudfront_signer:
+            if self.querystring_auth and self.cloudfront_signer:
                 expiration = datetime.utcnow() + timedelta(seconds=expire)
 
                 return self.cloudfront_signer.generate_presigned_url(url, date_less_than=expiration)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -612,7 +612,10 @@ class S3Boto3StorageTests(S3Boto3TestCase):
                 s3boto3._use_cryptography_signer(),
                 s3boto3._use_rsa_signer()):
             self.storage.cloudfront_signer = pem_to_signer(key_id, pem)
+            self.storage.querystring_auth = False
+            self.assertEqual(self.storage.url(filename), self.storage._strip_signing_parameters(url))
 
+            self.storage.querystring_auth = True
             with mock.patch('storages.backends.s3boto3.datetime') as mock_datetime:
                 mock_datetime.utcnow.return_value = datetime.utcfromtimestamp(0)
                 self.assertEqual(self.storage.url(filename), url)

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -604,7 +604,8 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             -----END RSA PRIVATE KEY-----'''
         ).encode('ascii')
 
-        url = 'https://mock.cloudfront.net/file.txt?Expires=3600&Signature=DbqVgh3FHtttQxof214tSAVE8Nqn3Q4Ii7eR3iykbOqAPbV89HC3EB~0CWxarpLNtbfosS5LxiP5EutriM7E8uR4Gm~UVY-PFUjPcwqdnmAiKJF0EVs7koJcMR8MKDStuWfFKVUPJ8H7ORYTOrixyHBV2NOrpI6SN5UX6ctNM50_&Key-Pair-Id=test-key'  # noqa
+        url = 'https://mock.cloudfront.net/file.txt'
+        signed_url = url + '?Expires=3600&Signature=DbqVgh3FHtttQxof214tSAVE8Nqn3Q4Ii7eR3iykbOqAPbV89HC3EB~0CWxarpLNtbfosS5LxiP5EutriM7E8uR4Gm~UVY-PFUjPcwqdnmAiKJF0EVs7koJcMR8MKDStuWfFKVUPJ8H7ORYTOrixyHBV2NOrpI6SN5UX6ctNM50_&Key-Pair-Id=test-key'  # noqa
 
         self.storage.custom_domain = "mock.cloudfront.net"
 
@@ -613,12 +614,12 @@ class S3Boto3StorageTests(S3Boto3TestCase):
                 s3boto3._use_rsa_signer()):
             self.storage.cloudfront_signer = pem_to_signer(key_id, pem)
             self.storage.querystring_auth = False
-            self.assertEqual(self.storage.url(filename), self.storage._strip_signing_parameters(url))
+            self.assertEqual(self.storage.url(filename), url)
 
             self.storage.querystring_auth = True
             with mock.patch('storages.backends.s3boto3.datetime') as mock_datetime:
                 mock_datetime.utcnow.return_value = datetime.utcfromtimestamp(0)
-                self.assertEqual(self.storage.url(filename), url)
+                self.assertEqual(self.storage.url(filename), signed_url)
 
     def test_generated_url_is_encoded(self):
         self.storage.custom_domain = "mock.cloudfront.net"


### PR DESCRIPTION
## Summary
At the moment, all URLs are being signed, even if `querystring_auth` is set to `False`.
This is needed in a scenario when a user have a mix of private and public content distributed via CloudFront and they don't want to sign public urls.

## Test Plan
Updated tests to cover the scenario.