### PR TITLE
Fix FTP multiple nested paths

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -111,7 +111,7 @@ class FTPStorage(Storage):
 
     def _mkremdirs(self, path):
         pwd = self._connection.pwd()
-        path_splitted = os.path.split(path)
+        path_splitted = path.split(os.path.sep)
         for path_part in path_splitted:
             try:
                 self._connection.cwd(path_part)

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -102,7 +102,7 @@ class FTPTest(TestCase):
     def test_mkremdirs(self, mock_ftp):
         self.storage._start_connection()
         self.storage._mkremdirs('foo/bar')
-    
+
     @patch('ftplib.FTP', **{'return_value.pwd.return_value': 'foo'})
     def test_mkremdirs_n_subdirectories(self, mock_ftp):
         self.storage._start_connection()

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -102,6 +102,11 @@ class FTPTest(TestCase):
     def test_mkremdirs(self, mock_ftp):
         self.storage._start_connection()
         self.storage._mkremdirs('foo/bar')
+    
+    @patch('ftplib.FTP', **{'return_value.pwd.return_value': 'foo'})
+    def test_mkremdirs_n_subdirectories(self, mock_ftp):
+        self.storage._start_connection()
+        self.storage._mkremdirs('foo/bar/null')
 
     @patch('ftplib.FTP', **{
         'return_value.pwd.return_value': 'foo',


### PR DESCRIPTION
The function _mkremdirs in FTPStorage just consider a simple subdirectories with 2 nested paths.
With this fix subdirectories 2+ nested paths creation.