### PR TITLE
Stop using deprecated force_text

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -13,7 +13,7 @@ from django.core.exceptions import ImproperlyConfigured, SuspiciousOperation
 from django.core.files.base import File
 from django.utils.deconstruct import deconstructible
 from django.utils.encoding import (
-    filepath_to_uri, force_bytes, force_text, smart_text,
+    filepath_to_uri, force_bytes, force_str, smart_text,
 )
 from django.utils.timezone import is_naive, make_naive
 
@@ -113,7 +113,7 @@ class S3Boto3StorageFile(File):
         self._storage = storage
         self.name = name[len(self._storage.location):].lstrip('/')
         self._mode = mode
-        self._force_mode = (lambda b: b) if 'b' in mode else force_text
+        self._force_mode = (lambda b: b) if 'b' in mode else force_str
         self.obj = storage.bucket.Object(storage._encode_name(name))
         if 'w' not in mode:
             # Force early RAII-style exception if object does not exist
@@ -558,7 +558,7 @@ class S3Boto3Storage(BaseStorage):
         return smart_text(name, encoding=self.file_name_charset)
 
     def _decode_name(self, name):
-        return force_text(name, encoding=self.file_name_charset)
+        return force_str(name, encoding=self.file_name_charset)
 
     def _compress_content(self, content):
         """Gzip a given string content."""

--- a/storages/utils.py
+++ b/storages/utils.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.exceptions import (
     ImproperlyConfigured, SuspiciousFileOperation,
 )
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 def setting(name, default=None):
@@ -54,9 +54,9 @@ def safe_join(base, *paths):
     Paths outside the base path indicate a possible security
     sensitive operation.
     """
-    base_path = force_text(base)
+    base_path = force_str(base)
     base_path = base_path.rstrip('/')
-    paths = [force_text(p) for p in paths]
+    paths = [force_str(p) for p in paths]
 
     final_path = base_path + '/'
     for path in paths:


### PR DESCRIPTION
Running on Django 3.0 warns:

> /usr/local/lib/python3.8/site-packages/storages/backends/s3boto3.py:496:
> RemovedInDjango40Warning: smart_text() is deprecated in favor of
> smart_str().

`smart_str` has been present since Django 1.11, so this has no backwards-compatibility drawbacks, squelches a warning on Django 3.0, and keeps us forward-compatible.