### PR TITLE
Update amazon-S3.rst

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -134,7 +134,9 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
 
 ``AWS_S3_SIGNATURE_VERSION`` (optional)
 
-  As of ``boto3`` version 1.4.4 the default signature version is ``s3v4``.
+  As of ``boto3`` version 1.13.21 the default signature version used for generating presigned 
+  urls is still ``v2``. To be able to access your s3 objects in all regions through presigned 
+  urls, explicitly set this to ``s3v4``.
 
   Set this to use an alternate version such as ``s3``. Note that only certain regions
   support the legacy ``s3`` (also known as ``v2``) version. You can check to see


### PR DESCRIPTION
After having trouble accessing images uploaded to region eu-north-1. I found out that the old signature was used, even though the documentation states that the new one is used by default. That the default signature version is still v2 is clarified in the following issue: https://github.com/boto/boto3/issues/2417

Please feel free to change the wording or decline the PR if this change is not appropriate.