### PR TITLE
Remove support for end-of-life Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ matrix:
     - python: 3.5
       env: TOXENV=integration
     - python: 3.5
-      env: TOXENV=py35-django111
-    - python: 3.6
-      env: TOXENV=py36-django111
-    - python: 3.7
-      env: TOXENV=py37-django111
-    - python: 3.5
       env: TOXENV=py35-django22
     - python: 3.6
       env: TOXENV=py36-django22

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ UNRELEASED
 
 - Removed support for end-of-life Python 2.7 and 3.4.
 
+- Removed support for end-of-life Django 1.11.
+
 - The minimum supported version of boto3 is now 1.4.4.
 
 - The ``S3Boto3Storage`` backend no longer accepts the argument ``acl``. Use

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Web Environment
     Framework :: Django
-    Framework :: Django :: 1.11
     Framework :: Django :: 2.2
     Framework :: Django :: 3.0
     Intended Audience :: Developers
@@ -29,7 +28,7 @@ classifiers =
 zip_safe=False
 python_requires = >=3.5
 install_requires =
-    Django >= 1.11
+    Django >= 2.2
 packages =
     storages
     storages.backends

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 minversion = 1.9
 envlist =
-	py{35,36,37}-django111
 	py{35,36,37,38}-django22
 	py{36,37,38}-django30
 	py{36,37,38}-djangomaster
@@ -15,7 +14,6 @@ setenv =
 	PYTHONDONTWRITEBYTECODE = 1
 commands = pytest --cov=storages --ignore=tests/integration/ tests/ {posargs}
 deps =
-	django111: Django>=1.11,<2.0
 	django22: Django>=2.2,<3.0
 	django30: Django>=3.0,<3.1
 	djangomaster: https://github.com/django/django/archive/master.tar.gz
@@ -45,7 +43,6 @@ setenv =
     PYTHONDONTWRITEBYTECODE = 1
     DJANGO_SETTINGS_MODULE = tests.integration.settings
 deps =
-    Django>=1.11, <1.12
     pytest-django
 extras =
     azure


### PR DESCRIPTION
Django 1.11 went end of life April 1, 2020. It is no longer receiving
bug fixes, including for security issues.

Removing support will reduce testing time and resources.

For more details on supported Django versions, see:
https://www.djangoproject.com/download/