### PR TITLE
Fixed typo in S3Boto3StorageFile.__init__()

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -100,7 +100,7 @@ class S3Boto3StorageFile(File):
         self._storage = storage
         self.name = name[len(self._storage.location):].lstrip('/')
         self._mode = mode
-        self._force_mode = lambda b: b if 'b' in mode else lambda b: b.decode()
+        self._force_mode = (lambda b: b) if 'b' in mode else (lambda b: b.decode())
         self.obj = storage.bucket.Object(name)
         if 'w' not in mode:
             # Force early RAII-style exception if object does not exist

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -224,6 +224,14 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         content = self.storage._compress_content(content)
         self.assertTrue(len(content.read()) > 0)
 
+    def test_storage_open_read_string(self):
+        """
+        Test opening a file in "r" mode (ie reading as string, not bytes)
+        """
+        name = 'test_open_read_string.txt'
+        content_str = self.storage.open(name, "r").read()
+        self.assertEqual(content_str, "")
+
     def test_storage_open_write(self):
         """
         Test opening a file in write mode


### PR DESCRIPTION
Fixed typo in `S3Boto3StorageFile.__init__()` that prevented files opened in "r" mode from being read.

lambda has a higher precedence than if-else, so `self._force_mode` was set to a function that returned
another lambda when `'b'` is not in `mode`.
Also added regression test.