### PR TITLE
Handle empty S3 folders

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ By order of apparition, thanks:
     * Taras Petriichuk (Dropbox write_mode option)
     * Zoe Liao (S3 docs)
     * Jonathan Ehwald
+    * François Freitag (S3)
 
 
 Extra thanks to Marty for adding this in Django,

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -478,7 +478,9 @@ class S3Boto3Storage(BaseStorage):
             for entry in page.get('CommonPrefixes', ()):
                 directories.append(posixpath.relpath(entry['Prefix'], path))
             for entry in page.get('Contents', ()):
-                files.append(posixpath.relpath(entry['Key'], path))
+                key = entry['Key']
+                if key != path:
+                    files.append(posixpath.relpath(key, path))
         return directories, files
 
     def size(self, name):

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -469,6 +469,27 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         self.assertEqual(dirs, ['path'])
         self.assertEqual(files, ['2.txt'])
 
+    def test_storage_listdir_empty(self):
+        # Files:
+        #   dir/
+        pages = [
+            {
+                'Contents': [
+                    {'Key': 'dir/'},
+                ],
+            },
+        ]
+
+        paginator = mock.MagicMock()
+        paginator.paginate.return_value = pages
+        self.storage._connections.connection.meta.client.get_paginator.return_value = paginator
+
+        dirs, files = self.storage.listdir('dir/')
+        paginator.paginate.assert_called_with(Bucket=None, Delimiter='/', Prefix='dir/')
+
+        self.assertEqual(dirs, [])
+        self.assertEqual(files, [])
+
     def test_storage_size(self):
         obj = self.storage.bucket.Object.return_value
         obj.content_length = 4098


### PR DESCRIPTION
Users can create empty folders on S3, by creating an object which name
ends with a forward slash, for example `folder/`. Using the `listdir`
operation on an empty folder returns `[], ["."]`. This is unexpected,
there are no file named `.` in the folder.

The reason for its presence is AWS S3 returning the following content
when listing the content of the directory:
```
{
    'Contents': [
        {... 'Key': 'folder/', ...}
    ],
   ...
}
```
Then, `posixpath.relpath("folder/", "folder/")` returns ".".