### PR TITLE
Pin isort and flake8 dependencies to major versions.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,8 +49,8 @@ extras =
 
 [testenv:flake8]
 deps =
-	flake8
-	isort
+	flake8<4
+	isort<5
 commands =
 	flake8
 	isort --recursive --check-only --diff storages/ tests/


### PR DESCRIPTION
isort5 contains some breaking changes causing tests to fail on master. This is a quick fix, it should be upgraded to 5 at some point.