### PR TITLE
Allow the use of AWS profiles for S3 access

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ By order of apparition, thanks:
     * Taras Petriichuk (Dropbox write_mode option)
     * Zoe Liao (S3 docs)
     * Jonathan Ehwald
+    * Dan Hook
 
 
 Extra thanks to Marty for adding this in Django,

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -32,7 +32,14 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
 
 .. note::
 
-      If ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` are not set, boto3 internally looks up IAM credentials.
+      If ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, and ``AWS_S3_SESSION_PROFILE`` are not set, boto3 internally looks up IAM credentials.
+
+``AWS_S3_SESSION_PROFILE``
+    The AWS profile to use instead of ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``
+
+.. note::
+      If this is set, then ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` are ignored
+
 
 ``AWS_STORAGE_BUCKET_NAME``
     Your Amazon Web Services storage bucket name, as a string.
@@ -98,8 +105,8 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
 
 ``AWS_S3_SIGNATURE_VERSION`` (optional)
 
-  As of ``boto3`` version 1.13.21 the default signature version used for generating presigned 
-  urls is still ``v2``. To be able to access your s3 objects in all regions through presigned 
+  As of ``boto3`` version 1.13.21 the default signature version used for generating presigned
+  urls is still ``v2``. To be able to access your s3 objects in all regions through presigned
   urls, explicitly set this to ``s3v4``.
 
   Set this to use an alternate version such as ``s3``. Note that only certain regions

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -24,22 +24,29 @@ To allow ``django-admin.py`` collectstatic to automatically put your static file
 
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
-``AWS_ACCESS_KEY_ID``
-    Your Amazon Web Services access key, as a string.
+There are several different methods for specifying the AWS credentials used to create the S3 client.  In the order that ``S3Boto3Storage``
+searches for them:
 
-``AWS_SECRET_ACCESS_KEY``
-    Your Amazon Web Services secret access key, as a string.
-
-.. note::
-
-      If ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``, and ``AWS_S3_SESSION_PROFILE`` are not set, boto3 internally looks up IAM credentials.
+#. ``AWS_S3_SESSION_PROFILE``
+#. ``AWS_S3_ACCESS_KEY_ID`` and ``AWS_S3_SECRET_KEY_ID``
+#. ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``
+#. The environment variables AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY
+#. The environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+#. Use Boto3's default session
 
 ``AWS_S3_SESSION_PROFILE``
-    The AWS profile to use instead of ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``
+    The AWS profile to use instead of ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``. All configuration information
+    other than the key id and secret key is ignored in favor of the other settings specified below.
 
 .. note::
-      If this is set, then ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` are ignored
+      If this is set, then it is a configuration error to also set ``AWS_S3_ACCESS_KEY_ID`` and ``AWS_S3_SECRET_ACCESS_KEY``.
+      ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` are ignored
 
+``AWS_S3_ACCESS_KEY_ID or AWS_ACCESS_KEY_ID``
+    Your Amazon Web Services access key, as a string.
+
+``AWS_S3_SECRET_ACCESS_KEY or AWS_SECRET_ACCESS_KEY``
+    Your Amazon Web Services secret access key, as a string.
 
 ``AWS_STORAGE_BUCKET_NAME``
     Your Amazon Web Services storage bucket name, as a string.

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -338,18 +338,29 @@ class S3Boto3Storage(BaseStorage):
     def connection(self):
         connection = getattr(self._connections, 'connection', None)
         if connection is None:
-            session = boto3.session.Session()
-            self._connections.connection = session.resource(
-                's3',
-                aws_access_key_id=self.access_key,
-                aws_secret_access_key=self.secret_key,
-                aws_session_token=self.security_token,
-                region_name=self.region_name,
-                use_ssl=self.use_ssl,
-                endpoint_url=self.endpoint_url,
-                config=self.config,
-                verify=self.verify,
-            )
+            if setting('AWS_S3_SESSION_PROFILE'):
+                session = boto3.Session(profile_name=setting('AWS_S3_SESSION_PROFILE'))
+                self._connections.connection = session.resource(
+                    's3',
+                    region_name=self.region_name,
+                    use_ssl=self.use_ssl,
+                    endpoint_url=self.endpoint_url,
+                    config=self.config,
+                    verify=self.verify,
+                )
+            else:
+                session = boto3.session.Session()
+                self._connections.connection = session.resource(
+                    's3',
+                    aws_access_key_id=self.access_key,
+                    aws_secret_access_key=self.secret_key,
+                    aws_session_token=self.security_token,
+                    region_name=self.region_name,
+                    use_ssl=self.use_ssl,
+                    endpoint_url=self.endpoint_url,
+                    config=self.config,
+                    verify=self.verify,
+                )
         return self._connections.connection
 
     @property

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -360,6 +360,11 @@ class S3Boto3Storage(BaseStorage):
         return self._connections.connection
 
     def _create_session(self):
+        """
+        If a user specifies a profile name and this class obtains access keys
+        from another source such as environment variables,we want the profile
+        name to take precedence.
+        """
         if self.session_profile:
             session = boto3.Session(profile_name=self.session_profile)
         else:

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -348,30 +348,27 @@ class S3Boto3Storage(BaseStorage):
     def connection(self):
         connection = getattr(self._connections, 'connection', None)
         if connection is None:
-            if self.session_profile:
-                session = boto3.Session(profile_name=self.session_profile)
-                self._connections.connection = session.resource(
-                    's3',
-                    region_name=self.region_name,
-                    use_ssl=self.use_ssl,
-                    endpoint_url=self.endpoint_url,
-                    config=self.config,
-                    verify=self.verify,
-                )
-            else:
-                session = boto3.session.Session()
-                self._connections.connection = session.resource(
-                    's3',
+            session = self._create_session()
+            self._connections.connection = session.resource(
+                's3',
+                region_name=self.region_name,
+                use_ssl=self.use_ssl,
+                endpoint_url=self.endpoint_url,
+                config=self.config,
+                verify=self.verify,
+            )
+        return self._connections.connection
+
+    def _create_session(self):
+        if self.session_profile:
+            session = boto3.Session(profile_name=self.session_profile)
+        else:
+            session = boto3.Session(
                     aws_access_key_id=self.access_key,
                     aws_secret_access_key=self.secret_key,
-                    aws_session_token=self.security_token,
-                    region_name=self.region_name,
-                    use_ssl=self.use_ssl,
-                    endpoint_url=self.endpoint_url,
-                    config=self.config,
-                    verify=self.verify,
-                )
-        return self._connections.connection
+                    aws_session_token=self.security_token
+            )
+        return session
 
     @property
     def bucket(self):

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -56,7 +56,7 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         settings.AWS_S3_SESSION_PROFILE = "test_profile"
         with mock.patch('boto3.Session') as mock_session:
             storage = s3boto3.S3Boto3Storage()
-            connection = storage.connection
+            _ = storage.connection
             mock_session.assert_called_once_with(profile_name="test_profile")
 
     def test_pickle_with_bucket(self):

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -52,6 +52,13 @@ class S3Boto3StorageTests(S3Boto3TestCase):
         path = self.storage._clean_name("path\\to\\somewhere")
         self.assertEqual(path, "path/to/somewhere")
 
+    def test_s3_session(self):
+        settings.AWS_S3_SESSION_PROFILE = "test_profile"
+        with mock.patch('boto3.Session') as mock_session:
+            storage = s3boto3.S3Boto3Storage()
+            connection = storage.connection
+            mock_session.assert_called_once_with(profile_name="test_profile")
+
     def test_pickle_with_bucket(self):
         """
         Test that the storage can be pickled with a bucket attached


### PR DESCRIPTION
This uses the setting AWS_S3_SESSION_PROFILE as an alternative to using static credentials in AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.  
This addresses the spirit of https://github.com/jschneier/django-storages/issues/774 and implements the suggestion in https://github.com/jschneier/django-storages/issues/895