### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -98,8 +98,8 @@ To allow ``django-admin.py collectstatic`` to automatically put your static file
 
 ``AWS_S3_SIGNATURE_VERSION`` (optional)
 
-  As of ``boto3`` version 1.13.21 the default signature version used for generating presigned 
-  urls is still ``v2``. To be able to access your s3 objects in all regions through presigned 
+  As of ``boto3`` version 1.13.21 the default signature version used for generating presigned
+  urls is still ``v2``. To be able to access your s3 objects in all regions through presigned
   urls, explicitly set this to ``s3v4``.
 
   Set this to use an alternate version such as ``s3``. Note that only certain regions

--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -163,5 +163,5 @@ The following settings are available:
 
 ``AZURE_CACHE_CONTROL``
 
-    A variable to set the Cache-Control HTTP response header. E.g. 
+    A variable to set the Cache-Control HTTP response header. E.g.
     ``AZURE_CACHE_CONTROL = "public,max-age=31536000,immutable"``

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -15,9 +15,9 @@ Use pip to install from PyPI::
 Authentication
 --------------
 By default, this library will try to use the credentials associated with the
-current Google Cloud infrastrcture/environment for authentication. 
+current Google Cloud infrastrcture/environment for authentication.
 
-In most cases, the default service accounts are not sufficient to read/write and sign files in GCS, you so you will need to create a dedicated service account: 
+In most cases, the default service accounts are not sufficient to read/write and sign files in GCS, you so you will need to create a dedicated service account:
 
 1. Create a service account. (`Google Getting Started Guide <https://cloud.google.com/docs/authentication/getting-started>`__)
 
@@ -114,7 +114,7 @@ a signed (expiring) url.
    the bucket to public or set the file permissions directly in GCS to public.
 
 .. note::
-    When using this setting, make sure you have ``fine-grained`` access control enabled on your bucket, 
+    When using this setting, make sure you have ``fine-grained`` access control enabled on your bucket,
     as opposed to ``Uniform`` access control, or else, file  uploads will return with HTTP 400.
 
 ``GS_FILE_CHARSET`` (optional)


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all
in one go, it helps keep future diffs cleaner by avoiding spurious white
space changes on unrelated lines.