### PR TITLE
Remove host parameter as obligatory in SFTPStorage

### DIFF
--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -22,8 +22,8 @@ from storages.utils import setting
 
 @deconstructible
 class SFTPStorage(BaseStorage):
-    def __init__(self, host=None, **settings):
-        super().__init__(host=host, **settings)
+    def __init__(self, **settings):
+        super().__init__(**settings)
         self._host = self.host
         self._params = self.params
         self._interactive = self.interactive

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -13,7 +13,7 @@ from storages.backends import sftpstorage
 
 class SFTPStorageTest(TestCase):
     def setUp(self):
-        self.storage = sftpstorage.SFTPStorage(hostname='foo')
+        self.storage = sftpstorage.SFTPStorage(host='foo')
 
     def test_init(self):
         pass
@@ -178,7 +178,7 @@ class SFTPStorageTest(TestCase):
 
 class SFTPStorageFileTest(TestCase):
     def setUp(self):
-        self.storage = sftpstorage.SFTPStorage(hostname='foo')
+        self.storage = sftpstorage.SFTPStorage(host='foo')
         self.file = sftpstorage.SFTPStorageFile('bar', self.storage, 'wb')
 
     @patch('storages.backends.sftpstorage.SFTPStorage.sftp', **{

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -13,7 +13,7 @@ from storages.backends import sftpstorage
 
 class SFTPStorageTest(TestCase):
     def setUp(self):
-        self.storage = sftpstorage.SFTPStorage('foo')
+        self.storage = sftpstorage.SFTPStorage(hostname='foo')
 
     def test_init(self):
         pass
@@ -178,7 +178,7 @@ class SFTPStorageTest(TestCase):
 
 class SFTPStorageFileTest(TestCase):
     def setUp(self):
-        self.storage = sftpstorage.SFTPStorage('foo')
+        self.storage = sftpstorage.SFTPStorage(hostname='foo')
         self.file = sftpstorage.SFTPStorageFile('bar', self.storage, 'wb')
 
     @patch('storages.backends.sftpstorage.SFTPStorage.sftp', **{


### PR DESCRIPTION
This allows the SFTP_STORAGE_HOST setting to actually be used.

In the current implementation, the host=None in init causes the host attribute on SFTPStorage to always revert to None if using the DEFAULT_FILE_STORAGE setting in Django. Removing the default value for host in the init signature allows the default parameter from SFTP_STORAGE_HOST to be applied.