### PR TITLE
[s3] Restore AWS_DEFAULT_ACL handling

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -44,6 +44,11 @@ To allow ``django-admin collectstatic`` to automatically put your static files i
   To view a full list of possible parameters (there are many) see the `Boto3 docs for uploading files`_.
   Some of the included ones are ``CacheControl``, ``SSEKMSKeyId``, ``StorageClass``, ``Tagging`` and ``Metadata``.
 
+``AWS_DEFAULT_ACL`` (optional; default is ``None`` which means the file will inherit the bucket's permission)
+
+   Use this to set an ACL on your file such as ``public-read``. By default the file will inherit the bucket's ACL.
+   If the ``ACL`` parameter is set in ``AWS_S3_OBJECT_PARAMETERS``, then this setting is ignored.
+
 ``AWS_QUERYSTRING_AUTH`` (optional; default is ``True``)
     Setting ``AWS_QUERYSTRING_AUTH`` to ``False`` to remove query parameter
     authentication from generated URLs. This can be useful if your S3 buckets

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -320,6 +320,7 @@ class S3Boto3Storage(BaseStorage):
             "use_ssl": setting('AWS_S3_USE_SSL', True),
             "verify": setting('AWS_S3_VERIFY', None),
             "max_memory_size": setting('AWS_S3_MAX_MEMORY_SIZE', 0),
+            "default_acl": setting('AWS_DEFAULT_ACL', None),
         }
 
     def __getstate__(self):
@@ -496,6 +497,10 @@ class S3Boto3Storage(BaseStorage):
             params['ContentEncoding'] = encoding
 
         params.update(self.get_object_parameters(name))
+
+        if 'ACL' not in params and self.default_acl:
+            params['ACL'] = self.default_acl
+
         return params
 
     def get_object_parameters(self, name):

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -114,12 +114,32 @@ class S3Boto3StorageTests(S3Boto3TestCase):
             }
         )
 
-    def test_storage_save_with_acl(self):
+    def test_storage_save_with_default_acl(self):
         """
         Test saving a file with user defined ACL.
         """
         name = 'test_storage_save.txt'
         content = ContentFile('new content')
+        self.storage.default_acl = 'private'
+        self.storage.save(name, content)
+        self.storage.bucket.Object.assert_called_once_with(name)
+
+        obj = self.storage.bucket.Object.return_value
+        obj.upload_fileobj.assert_called_with(
+            content,
+            ExtraArgs={
+                'ContentType': 'text/plain',
+                'ACL': 'private',
+            }
+        )
+
+    def test_storage_object_parameters_not_overwritten_by_default(self):
+        """
+        Test saving a file with user defined ACL.
+        """
+        name = 'test_storage_save.txt'
+        content = ContentFile('new content')
+        self.storage.default_acl = 'public-read'
         self.storage.object_parameters = {'ACL': 'private'}
         self.storage.save(name, content)
         self.storage.bucket.Object.assert_called_once_with(name)


### PR DESCRIPTION
This restores `AWS_DEFAULT_ACL` handling. It was too aggressive to remove it.