### PR TITLE
Check for `NoSuchKey` error response in `exists()`

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -460,8 +460,14 @@ class S3Boto3Storage(BaseStorage):
         try:
             self.connection.meta.client.head_object(Bucket=self.bucket_name, Key=name)
             return True
-        except ClientError:
-            return False
+        except ClientError as error:
+            if error.response.get('Error', {}).get('Code') == '404':
+                return False
+
+            # Some other error was encountered. As `get_available_name` calls this,
+            # we have to assume the filename is unavailable. If we return true due to some
+            # other error, we'd overwrite a file.
+            return True
 
     def listdir(self, name):
         path = self._normalize_name(self._clean_name(name))


### PR DESCRIPTION
I'm trying to determine why I'm seeing some files overwriting other files when they have the same name.

I feel like this might be the source of the issue (perhaps due to previous code catching a network error or some other error) but I don't quite have the depth of knowledge to validate that.

Does this suggested change look like it might address a bug?