### PR TITLE
Use forward slashes on Windows

### DIFF
--- a/storages/base.py
+++ b/storages/base.py
@@ -1,3 +1,6 @@
+import os
+import posixpath
+
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.storage import Storage
 
@@ -22,3 +25,15 @@ class BaseStorage(Storage):
 
     def get_default_settings(self):
         return {}
+
+    def generate_filename(self, filename):
+        """
+        Validate the filename by calling get_valid_name() and return a filename
+        to be passed to the save() method. 
+        """
+        # `filename` may include a path as returned by FileField.upload_to.
+        dirname, filename = os.path.split(filename)
+        
+        # Use posixpath so it will not use "\\" on Windows
+        return posixpath.normpath(posixpath.join(dirname, self.get_valid_name(filename)))
+    


### PR DESCRIPTION
On Windows a backslash was used as path separator (os.path.join) although for remote file systems file like SSHFS it should be a forward slash (posixpath.join).

Example: `file_en = models.FileField(upload_to='en/', storage=SFTPStorage())`, filename of uploaded file `test.pdf`

On the remote SSHFS host, the file "test.pdf" was not placed inside the directory `en`, but the filename has been `en\test.pdf`.