### PR TITLE
docs: Add missing import for S3 backend

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -363,6 +363,7 @@ Model
 An object without a file has limited functionality::
 
     from django.db import models
+    from django.core.files.base import ContentFile
 
     class MyModel(models.Model):
       normal = models.FileField()


### PR DESCRIPTION
Documentation on S3 is missing `from django.core.files.base import ContentFile` import here:

![Screenshot from 2020-10-29 12-01-08](https://user-images.githubusercontent.com/2254825/97591981-ecba5280-19de-11eb-87a3-d70375125965.png)
