### PR TITLE
Add setting to disable signed URLs for GCS uniform buckets

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -115,7 +115,15 @@ a signed (expiring) url.
 
 .. note::
     When using this setting, make sure you have ``fine-grained`` access control enabled on your bucket,
-    as opposed to ``Uniform`` access control, or else, file  uploads will return with HTTP 400.
+    as opposed to ``Uniform`` access control, or else, file  uploads will return with HTTP 400. If you
+    already have a bucket with ``Uniform`` access control set to public read, please keep 
+    ``GS_DEFAULT_ACL`` to ``None`` and set ``GS_QUERYSTRING_AUTH`` to ``False``.
+
+``GS_QUERYSTRING_AUTH`` (optional, default is True)
+
+If set to ``False`` it forces the url not to be signed. This setting is useful if you need to have a
+bucket configured with ``Uniform`` access control configured with public read. In that case you should
+force the flag ``GS_QUERYSTRING_AUTH = False`` and ``GS_DEFAULT_ACL = None``
 
 ``GS_FILE_CHARSET`` (optional)
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -242,7 +242,7 @@ class GoogleCloudStorage(BaseStorage):
         name = self._normalize_name(clean_name(name))
         blob = self.bucket.blob(name)
         no_signed_url = (
-            self.default_acl == 'publicRead' or self.querystring_auth is False)
+            self.default_acl == 'publicRead' or not self.querystring_auth)
 
         if not self.custom_endpoint and no_signed_url:
             return blob.public_url

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -102,6 +102,7 @@ class GoogleCloudStorage(BaseStorage):
             "custom_endpoint": setting('GS_CUSTOM_ENDPOINT', None),
             "location": setting('GS_LOCATION', ''),
             "default_acl": setting('GS_DEFAULT_ACL'),
+            "querystring_auth": setting('GS_QUERYSTRING_AUTH', True),
             "expiration": setting('GS_EXPIRATION', timedelta(seconds=86400)),
             "file_overwrite": setting('GS_FILE_OVERWRITE', True),
             "cache_control": setting('GS_CACHE_CONTROL'),
@@ -240,10 +241,12 @@ class GoogleCloudStorage(BaseStorage):
         """
         name = self._normalize_name(clean_name(name))
         blob = self.bucket.blob(name)
+        no_signed_url = (
+            self.default_acl == 'publicRead' or self.querystring_auth is False)
 
-        if not self.custom_endpoint and self.default_acl == 'publicRead':
+        if not self.custom_endpoint and no_signed_url:
             return blob.public_url
-        elif self.default_acl == 'publicRead':
+        elif no_signed_url:
             return '{storage_base_url}/{quoted_name}'.format(
                 storage_base_url=self.custom_endpoint,
                 quoted_name=_quote(name, safe=b"/~"),


### PR DESCRIPTION
Rebased version of existing PR by @dulacp in #910 that fixes merge conflict and should pass CI tests.

As per docs in #910 
>  To support Uniform permissions buckets on Google Cloud Storage, we need to keep GS_DEFAULT_ACL to None, but it forces each url to be signed, which is useless since the uniform permission is usually meant to give world read access. This new parameter solves this use case reported in #783, #846 and #909.
