### PR TITLE
Add documentation for undocumented AWS settings

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -29,10 +29,24 @@ To allow ``django-admin collectstatic`` to automatically put your static files i
 
 ``AWS_SECRET_ACCESS_KEY``
     Your Amazon Web Services secret access key, as a string.
+      
+``AWS_S3_ACCESS_KEY_ID``
+    Your Amazon Web Services access key, as a string, used specifically by django-storages.
 
+``AWS_S3_SECRET_ACCESS_KEY``
+    Your Amazon Web Services secret access key, as a string, used specifically by django-storages.
+    
 .. note::
 
-      If ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` are not set, boto3 internally looks up IAM credentials.
+      If neither ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` nor ``AWS_S3_ACCESS_KEY_ID`` and ``AWS_S3_SECRET_ACCESS_KEY``
+      are set, boto3 internally looks up IAM credentials.
+
+      If ``AWS_S3_ACCESS_KEY_ID`` and ``AWS_S3_SECRET_ACCESS_KEY`` are set, django-storages will use these credentials.
+      instead of ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``.
+      
+      ``AWS_S3_ACCESS_KEY_ID`` and ``AWS_S3_SECRET_ACCESS_KEY`` are particularly useful when boto3 obtains temporary AWS credentials
+      via the EC2 IAM Role and you use generated URLs. Otherwise, generated URLs will expire when the temporary credentials
+      used to generate URLs expire.
 
 ``AWS_STORAGE_BUCKET_NAME``
     Your Amazon Web Services storage bucket name, as a string.


### PR DESCRIPTION
Add documentation for ``AWS_S3_ACCESS_KEY_ID`` and ``AWS_S3_SECRET_ACCESS_KEY`` and example use case.

We recently started using the IAM role associated with the EC2 instance to obtain AWS credentials for `boto3`. Shortly thereafter, we noticed that the generated URLs were expiring well before the number of seconds we specified in ``AWS_QUERYSTRING_EXPIRE``. We determined that the Role-based credentials were expiring and was causing the URL to expire prematurely.

In the source code I noticed the undocumented settings ``AWS_S3_ACCESS_KEY_ID`` and ``AWS_S3_SECRET_ACCESS_KEY``. I created a new IAM service account with S3 access and passed these new credentials with the undocumented settings. ``django-storage`` started using these credentials and generated URLs expired as expected. Other `boto3` calls in the application continued to use the Role-based credentials.

Links to undocumented settings:
[AWS_S3_ACCESS_KEY_ID](https://github.com/jschneier/django-storages/blob/b74339679d40838c74d92962bede8796eb0da850/storages/backends/s3boto3.py#L244)
[AWS_S3_SECRET_ACCESS_KEY](https://github.com/jschneier/django-storages/blob/b74339679d40838c74d92962bede8796eb0da850/storages/backends/s3boto3.py#L245)

To save others some time, I've updated the documentation section to reflect my findings.