### PR TITLE
Docs: Specify the allowed parameters for AZURE_OBJECT_PARAMETERS

### DIFF
--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -170,3 +170,5 @@ The following settings are available:
 
     Use this to set content settings on all objects. To set these on a per-object
     basis, subclass the backend and override ``AzureStorage.get_object_parameters``.
+    
+    This is a Python ``dict`` and the possible parameters are: ``content_type``, ``content_encoding``, ``content_language``, ``content_disposition``, ``cache_control``, and ``content_md5``.


### PR DESCRIPTION
I added all the possible parameters for `AZURE_OBJECT_PARAMETERS`, similar to the [S3 documentation](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html) with the `AWS_S3_OBJECT_PARAMETERS` setting. Since there's a fairly small number of parameters I just mentioned all of them.