### PR TITLE
Add AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY alternative settings to S3 docs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ By order of apparition, thanks:
     * Taras Petriichuk (Dropbox write_mode option)
     * Zoe Liao (S3 docs)
     * Jonathan Ehwald
+    * Solomon Astley (S3 docs)
 
 
 Extra thanks to Marty for adding this in Django,

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -29,10 +29,10 @@ If you want to use something like `ManifestStaticFilesStorage`_ then you must in
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3ManifestStaticStorage'
 
 ``AWS_ACCESS_KEY_ID``
-    Your Amazon Web Services access key, as a string.
+    Your Amazon Web Services access key, as a string. You can also use ``AWS_S3_ACCESS_KEY_ID``.
 
 ``AWS_SECRET_ACCESS_KEY``
-    Your Amazon Web Services secret access key, as a string.
+    Your Amazon Web Services secret access key, as a string. You can also use ``AWS_S3_SECRET_ACCESS_KEY``.
 
 .. note::
 


### PR DESCRIPTION
I noticed that the docs don't currently mention that you can use more specific settings variable names `AWS_S3_ACCESS_KEY_ID` and `AWS_S3_SECRET_ACCESS_KEY` to configure your S3 access. This is useful in situations where you would like to use a separate access key to e.g. send emails via Amazon SES. I checked in the source code, and it seems that these variable names [are supported](https://github.com/jschneier/django-storages/blob/master/storages/backends/s3boto3.py#L246-L247).