### PR TITLE
GoogleCloud: Use V4 signed URLs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ boto3 =
 dropbox =
     dropbox >= 7.2.1
 google =
-    google-cloud-storage >= 1.15.0
+    google-cloud-storage >= 1.27.0
 libcloud =
     apache-libcloud
 sftp =

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -282,11 +282,14 @@ class GoogleCloudStorage(BaseStorage):
                 quoted_name=_quote(name, safe=b"/~"),
             )
         elif not self.custom_endpoint:
-            return blob.generate_signed_url(self.expiration)
+            return blob.generate_signed_url(
+                expiration=self.expiration, version="v4"
+            )
         else:
             return blob.generate_signed_url(
+                bucket_bound_hostname=self.custom_endpoint,
                 expiration=self.expiration,
-                api_access_endpoint=self.custom_endpoint,
+                version="v4",
             )
 
     def get_available_name(self, name, max_length=None):


### PR DESCRIPTION
Update URL signing version from v2 to v4. Increase minimum google-cloud-storage library version so that custom endpoints work
properly.

This supersedes #837 - moving to v4 signed URLs and using `bucket_bound_hostname` will fix the bug with invalid signed URLs being generated without having to resort to the hackish solution used in that pull request.