### PR TITLE
[gcloud] do not raise exception when trying to delete a non existing blob

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -162,7 +162,10 @@ class GoogleCloudStorage(BaseStorage):
 
     def delete(self, name):
         name = self._normalize_name(clean_name(name))
-        self.bucket.delete_blob(name)
+        try:
+            self.bucket.delete_blob(name)
+        except NotFound:
+            pass
 
     def exists(self, name):
         if not name:  # root element aka the bucket


### PR DESCRIPTION
fix for #998

Add exception handling for `delete_blob` for gcloud backend.
I does not raise a 404 NotFound, if the blob to be deleted not exists. This is consistent how Azure and S3 backends handle this case.