### PR TITLE
Handle parameters for presigned CloudFront

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -572,7 +572,7 @@ class S3Boto3Storage(BaseStorage):
                 self._s3_service_model['operations']['GetObject'], sm)
         serializer = botocore.serialize.create_serializer('rest-json')
         url_dict = serializer.serialize_to_request(params, om)
-        return urlencode(url_dict['query_string'])
+        return urlencode(url_dict['query_string'], safe='/",')
 
     def url(self, name, parameters=None, expire=None, http_method=None):
         # Preserve the trailing slash after normalizing the path.
@@ -585,7 +585,7 @@ class S3Boto3Storage(BaseStorage):
         params['Key'] = name
         # The "ResponseExpires" value ends up with a comma, which
         #  often gets un-escaped by some over-zealos URL re-parsers. :/
-        # Changing the signed URL then breaks the signature.
+        # It also doesn't make sense behind CloudFront
         # params['ResponseExpires'] = expiration
 
         if self.custom_domain:

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -583,7 +583,10 @@ class S3Boto3Storage(BaseStorage):
         params = parameters.copy() if parameters else {}
         params['Bucket'] = self.bucket.name
         params['Key'] = name
-        params['ResponseExpires'] = expiration
+        # The "ResponseExpires" value ends up with a comma, which
+        #  often gets un-escaped by some over-zealos URL re-parsers. :/
+        # Changing the signed URL then breaks the signature.
+        # params['ResponseExpires'] = expiration
 
         if self.custom_domain:
             url_parts = urlsplit(None)


### PR DESCRIPTION
Prior code discarded parameters on pre-signed cloudfront URLs. This code fixes that, using the botocore methods which validate parameters allowed on S3 get object calls.

Also set expiration time header/parameter for both cloudfront and regular S3 signed URLs, since that seems to make sense for cache purposes; cache expires when url expires.

Closes #997