### PR TITLE
Add more input validation to dropbox.py

### DIFF
--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -79,7 +79,8 @@ class DropBoxStorage(Storage):
         if oauth2_access_token is None:
             raise ImproperlyConfigured("You must configure an auth token at"
                                        "'settings.DROPBOX_OAUTH2_TOKEN'.")
-
+        if write_mode not in ["add", "overwrite",  "update"]:
+            raise ImproperlyConfigured("DROPBOX_WRITE_MODE must be set to either: 'add', 'overwrite' or 'update'")
         self.root_path = root_path
         self.write_mode = write_mode
         self.client = Dropbox(oauth2_access_token, timeout=timeout)


### PR DESCRIPTION
Proposed additional input validation from settings.py otherwise wrong values produce cryptic error:
```
File "/app/.heroku/python/lib/python3.7/site-packages/stone/backends/python_rsrc/stone_base.py", line 141, in __init__
     assert validator is not None, 'Invalid tag %r.' % tag
 AssertionError: Invalid tag True.
```

found and explained here: https://stackoverflow.com/questions/67872466/error-when-uploading-viewing-certain-pictures-rendition-not-found-django-sto