### PR TITLE
Signed urls without network call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ By order of apparition, thanks:
     * Taras Petriichuk (Dropbox write_mode option)
     * Zoe Liao (S3 docs)
     * Jonathan Ehwald
+    * Niels-Ole Kühl (Google Cloud Storage patch)
 
 
 Extra thanks to Marty for adding this in Django,

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -30,10 +30,11 @@ class GoogleCloudFile(File):
         self._mode = mode
         self._storage = storage
         self._blob = None
-        if 'w' in mode and not self.blob:
-            self.blob = Blob(
-                self.name, self._storage.bucket,
-                chunk_size=self._storage.blob_chunk_size)
+        if 'w' in mode:
+            if not self.blob:
+                self.blob = Blob(
+                    self.name, self.bucket,
+                    chunk_size=self.blob_chunk_size)
         self._file = None
         self._is_dirty = False
 
@@ -43,7 +44,7 @@ class GoogleCloudFile(File):
 
     def _get_blob(self):
         if self._blob is None:
-            # will be called every time now
+            # will be called every time if the file doesn't exist
             self._blob = self._storage.bucket.get_blob(self.name)
         return self._blob
 
@@ -51,7 +52,6 @@ class GoogleCloudFile(File):
         self._blob = value
 
     blob = property(_get_blob, _set_blob)
-
 
     def _get_file(self):
         if self._file is None:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -29,17 +29,29 @@ class GoogleCloudFile(File):
         self.mime_type = mimetypes.guess_type(name)[0]
         self._mode = mode
         self._storage = storage
-        self.blob = storage.bucket.get_blob(name)
-        if not self.blob and 'w' in mode:
+        self._blob = None
+        if 'w' in mode and not self.blob:
             self.blob = Blob(
-                self.name, storage.bucket,
-                chunk_size=storage.blob_chunk_size)
+                self.name, self._storage.bucket,
+                chunk_size=self._storage.blob_chunk_size)
         self._file = None
         self._is_dirty = False
 
     @property
     def size(self):
         return self.blob.size
+
+    def _get_blob(self):
+        if self._blob is None:
+            # will be called every time now
+            self._blob = self._storage.bucket.get_blob(self.name)
+        return self._blob
+
+    def _set_blob(self, value):
+        self._blob = value
+
+    blob = property(_get_blob, _set_blob)
+
 
     def _get_file(self):
         if self._file is None:

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -33,8 +33,8 @@ class GoogleCloudFile(File):
         if 'w' in mode:
             if not self.blob:
                 self.blob = Blob(
-                    self.name, self.bucket,
-                    chunk_size=self.blob_chunk_size)
+                    self.name, storage.bucket,
+                    chunk_size=storage.blob_chunk_size)
         self._file = None
         self._is_dirty = False
 


### PR DESCRIPTION
Lazily calling bucket.get_blob, thus avoiding the call to bucket.get_blob during url(), which should prevent blocking IO.
Fixes https://github.com/jschneier/django-storages/issues/413

Tested via `DJANGO_SETTINGS_MODULE=tests.settings pytest tests/test_gcloud.py`

I wanted to benchmark this before and after, to be sure I actually improved it, but haven't had the time to set this up so far.



