### PR TITLE
Fix all the Travis CI failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 # https://travis-ci.org/jschneier/django-storages/
 language: python
+dist: focal
 
 cache: pip
 

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -2,9 +2,9 @@ import datetime
 from datetime import timedelta
 from unittest import mock
 
+import django
 import pytz
 from azure.storage.blob import Blob, BlobPermissions, BlobProperties
-import django
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
@@ -111,20 +111,20 @@ class AzureStorageTest(TestCase):
     def test_get_available_invalid(self):
         self.storage.overwrite_files = False
         self.storage._service.exists.return_value = False
-        if django.VERSION < (3,):
+        if django.VERSION[:2] == (3, 0):
             # Django 2.2.21 added this security fix:
             # https://docs.djangoproject.com/en/3.2/releases/2.2.21/#cve-2021-31542-potential-directory-traversal-via-uploaded-files
             # It raises SuspiciousOperation before we get to our ValueError.
-            # The security issue doesn't apply to 3.x so they didn't change the behaviour there.
-            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, "")
-            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, "/")
-            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, ".")
-            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, "///")
-        else:
+            # The fix wasn't applied to 3.0 (no longer in support), but was applied to 3.1 & 3.2.
             self.assertRaises(ValueError, self.storage.get_available_name, "")
             self.assertRaises(ValueError, self.storage.get_available_name, "/")
             self.assertRaises(ValueError, self.storage.get_available_name, ".")
             self.assertRaises(ValueError, self.storage.get_available_name, "///")
+        else:
+            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, "")
+            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, "/")
+            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, ".")
+            self.assertRaises(SuspiciousOperation, self.storage.get_available_name, "///")
         self.assertRaises(ValueError, self.storage.get_available_name, "...")
 
     def test_url(self):


### PR DESCRIPTION
Improves the state of the travis build, removing ~~some~~ all of the red.

* the default `xenial` distro for travis is ancient; upgrading to Ubuntu Focal gave us a better `pip`, which installs `cryptography` from a wheel instead of building from source. Building from source was failing because `rustc` wasn't installed. But also it was slow; installing from a wheel is much faster.
* the azure test had been failing [since May's django security releases](https://docs.djangoproject.com/en/3.2/releases/2.2.21/#cve-2021-31542-potential-directory-traversal-via-uploaded-files), so I fixed the test to expect the new behaviour going forward.