### PR TITLE
[gcloud] fix no_signed_url incorrectly evaluated when setting acl publicRead via object_parameters

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -272,7 +272,7 @@ class GoogleCloudStorage(BaseStorage):
         name = self._normalize_name(clean_name(name))
         blob = self.bucket.blob(name)
         no_signed_url = (
-            self.default_acl == 'publicRead' or not self.querystring_auth)
+            self.object_parameters.get('acl', self.default_acl) == 'publicRead' or not self.querystring_auth)
 
         if not self.custom_endpoint and no_signed_url:
             return blob.public_url


### PR DESCRIPTION
fixes #1059 