### PR TITLE
Add Azure `parameters` as kwargs for `storage.url`

### DIFF
--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -61,6 +61,20 @@ Then on settings set::
     DEFAULT_FILE_STORAGE = 'storages.backends.azure_storage.AzureStorage'
     STATICFILES_STORAGE = 'custom_storage.custom_azure.PublicAzureStorage'
 
++++++++++++++++++++++
+Private VS Public URL
++++++++++++++++++++++
+
+The difference between public and private URLs is that private includes the SAS token.
+With private URLs you can override certain properties stored for the blob by specifying
+query parameters as part of the shared access signature. These properties include the
+cache-control, content-type, content-encoding, content-language, and content-disposition.
+See https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-properties#remarks
+
+You can specify these parameters by::
+    az_storage = AzureStorage()
+    az_url = az_storage.url(blob_name, parameters={'content_type': 'text/html;'})
+
 
 Settings
 ********

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -275,8 +275,9 @@ class AzureStorage(BaseStorage):
         # azure expects time in UTC
         return datetime.utcnow() + timedelta(seconds=expire)
 
-    def url(self, name, expire=None):
+    def url(self, name, expire=None, parameters=None):
         name = self._get_valid_path(name)
+        params = parameters or {}
 
         if expire is None:
             expire = self.expiration_secs
@@ -292,7 +293,9 @@ class AzureStorage(BaseStorage):
                 account_key=self.account_key,
                 user_delegation_key=user_delegation_key,
                 permission=BlobSasPermissions(read=True),
-                expiry=expiry)
+                expiry=expiry,
+                **params
+            )
             credential = sas_token
 
         container_blob_url = self.client.get_blob_client(name).url


### PR DESCRIPTION
It enables using kwargs, such as `content_type`, `content_disposition`, ..., when generating a shared access signature for a blob
https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/storage/azure-storage-blob/azure/storage/blob/_shared_access_signature.py#L482-L574