### PR TITLE
Add content_type to the object param function

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -512,14 +512,14 @@ class S3Boto3Storage(BaseStorage):
         if encoding:
             params['ContentEncoding'] = encoding
 
-        params.update(self.get_object_parameters(name))
+        params.update(self.get_object_parameters(name, content_type))
 
         if 'ACL' not in params and self.default_acl:
             params['ACL'] = self.default_acl
 
         return params
 
-    def get_object_parameters(self, name):
+    def get_object_parameters(self, name, content_type):
         """
         Returns a dictionary that is passed to file upload. Override this
         method to adjust this on a per-object basis to set e.g ContentDisposition.


### PR DESCRIPTION
I want to change the object parameters on a per-object basis. But I don't want the same params for every type of object. For example, I want `ContentDisposition: attachment` for images, but not for PDF files.

My current workaround is this:

```
class MediaRootS3Boto3Storage(S3Boto3Storage):
    location = "media"
    file_overwrite = False

    def _get_write_parameters(self, name, content=None):
        params = {}

        _type, encoding = mimetypes.guess_type(name)
        content_type = getattr(content, 'content_type', None)
        content_type = content_type or _type or self.default_content_type

        params['ContentType'] = content_type
        if encoding:
            params['ContentEncoding'] = encoding

        params.update(self.get_object_parameters_for_type(name, content_type))

        if 'ACL' not in params and self.default_acl:
            params['ACL'] = self.default_acl

        return params

    def get_object_parameters_for_type(self, name, content_type):
        object_params = self.object_parameters.copy()
        if 'image' in content_type:
            object_params.update(
                ContentDisposition='attachment'
            )
        return object_params
```

In this PR I update the `get_object_parameters` so it also gets `content_type` as a parameter.