### PR TITLE
Restore AZURE_CUSTOM_DOMAIN to behave as at 1.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 django-storages CHANGELOG
 =========================
 
+Azure
+-----
+
+- ``AZURE_CUSTOM_DOMAIN`` now once again behaves as it did at 1.11: that is, it is a full domain, rather than only a replacement for the ``blob.core.windows.net`` part of the domain.
+
 1.12.1 (2021-10-11)
 *******************
 

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -151,10 +151,11 @@ class AzureStorage(BaseStorage):
         if self.connection_string is not None:
             return BlobServiceClient.from_connection_string(self.connection_string)
 
-        account_domain = self.custom_domain or "blob.core.windows.net"
-        account_url = "{}://{}.{}".format(
-            self.azure_protocol, self.account_name, account_domain
+        account_domain = self.custom_domain or "{}.blob.core.windows.net".format(
+            self.account_name
         )
+        account_url = "{}://{}".format(self.azure_protocol, account_domain)
+
         credential = None
         if self.account_key:
             credential = self.account_key

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -231,7 +231,7 @@ class AzureStorageTest(TestCase):
             bsc_mocked.return_value.get_container_client.return_value = client_mock
             self.assertEqual(storage.client, client_mock)
             bsc_mocked.assert_called_once_with(
-                'https://foo_name.foo_domain',
+                'https://foo_domain',
                 credential='foo_key')
 
     def test_container_client_params_sas_token(self):
@@ -247,7 +247,7 @@ class AzureStorageTest(TestCase):
             bsc_mocked.return_value.get_container_client.return_value = client_mock
             self.assertEqual(storage.client, client_mock)
             bsc_mocked.assert_called_once_with(
-                'http://foo_name.foo_domain',
+                'http://foo_domain',
                 credential='foo_token')
 
     def test_container_client_params_token_credential(self):


### PR DESCRIPTION
Per discussion at https://github.com/jschneier/django-storages/issues/1073#issuecomment-944389156