### PR TITLE
[sftp] Catch FileNotFoundError rather than OSError in .exists()

### DIFF
--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -150,7 +150,7 @@ class SFTPStorage(BaseStorage):
         try:
             self.sftp.stat(self._remote_path(name))
             return True
-        except OSError:
+        except FileNotFoundError:
             return False
 
     def _isdir_attr(self, item):


### PR DESCRIPTION
This was covering up socket.timeout exceptions.

Fixes #1064.