### PR TITLE
Added instructions to use S3 backend with Backblaze B2

### DIFF
--- a/docs/backends/backblaze-B2.rst
+++ b/docs/backends/backblaze-B2.rst
@@ -1,0 +1,13 @@
+Backblaze B2
+============
+
+Backblaze B2 implements an `S3 Compatible API <https://www.backblaze.com/b2/docs/s3_compatible_api.html>`_. To use it as a django-storages backend:
+
+#. Sign up for a `Backblaze B2 account <https://www.backblaze.com/b2/sign-up.html?referrer=nopref>`_, if you have not already done so.
+#. Create a public or private bucket. Note that object-level ACLs are not supported by B2 - all objects inherit their bucket's ACLs.
+#. Create an `application key <https://www.backblaze.com/b2/docs/application_keys.html>`_. Best practice is to limit access to the bucket you just created.
+#. Follow the instructions in the :doc:`Amazon S3 docs <amazon-S3>` with the following exceptions:
+
+   * Set ``AWS_S3_REGION_NAME`` to your Backblaze B2 region, for example, ``us-west-004``
+   * Set ``AWS_S3_ENDPOINT_URL`` to ``https://s3.${AWS_S3_REGION_NAME}.backblazeb2.com``
+   * Set the values of ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` to the application key id and application key you created in step 2.


### PR DESCRIPTION
Backblaze B2 is a widely used, S3-compatible cloud object storage service. After [answering a question on using B2 with django-storages on Reddit](https://www.reddit.com/r/backblaze/comments/sdb2m7/comment/hud0r20/?utm_source=share&utm_medium=web2x&context=3), I figured I'd drop the same information here.