### PR TITLE
added support for endpoint_suffix

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -141,6 +141,7 @@ class AzureStorage(BaseStorage):
             "default_content_type": 'application/octet-stream',
             "cache_control": setting("AZURE_CACHE_CONTROL"),
             "sas_token": setting('AZURE_SAS_TOKEN'),
+            "endpoint_suffix": setting('AZURE_ENDPOINT_SUFFIX', 'core.windows.net'),
             "custom_domain": setting('AZURE_CUSTOM_DOMAIN'),
             "connection_string": setting('AZURE_CONNECTION_STRING'),
             "token_credential": setting('AZURE_TOKEN_CREDENTIAL'),
@@ -150,8 +151,9 @@ class AzureStorage(BaseStorage):
         if self.connection_string is not None:
             return BlobServiceClient.from_connection_string(self.connection_string)
 
-        account_domain = self.custom_domain or "{}.blob.core.windows.net".format(
-            self.account_name
+        account_domain = self.custom_domain or "{}.blob.{}".format(
+            self.account_name,
+            self.endpoint_suffix,
         )
         account_url = "{}://{}".format(self.azure_protocol, account_domain)
 


### PR DESCRIPTION
For some reason, support for AZURE_ENDPOINT_SUFFIX was dropped in 1.12. Adding this feature back to support Azure.cn storage accounts.