### PR TITLE
[azure] fix get_modified_time()

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -334,9 +334,8 @@ class AzureStorage(BaseStorage):
         Returns an (aware) datetime object containing the last modified time if
         USE_TZ is True, otherwise returns a naive datetime in the local timezone.
         """
-        properties = self.client.get_blob_properties(
-            self._get_valid_path(name),
-            timeout=self.timeout)
+        blob_client = self.client.get_blob_client(self._get_valid_path(name))
+        properties = blob_client.get_blob_properties(timeout=self.timeout)
         if not setting('USE_TZ', False):
             return timezone.make_naive(properties.last_modified)
 

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -391,7 +391,9 @@ class AzureStorageTest(TestCase):
         props = BlobProperties()
         accepted_time = datetime.datetime(2017, 5, 11, 8, 52, 4)
         props.last_modified = accepted_time
-        self.storage._client.get_blob_properties.return_value = props
+        client_mock = mock.MagicMock()
+        client_mock.get_blob_properties.return_value = props
+        self.storage._client.get_blob_client.return_value = client_mock
         time = self.storage.modified_time("name")
         self.assertEqual(accepted_time, time)
 


### PR DESCRIPTION
Fixes #1131 

fix is basically as suggested, but I've formatted it for consistency with https://github.com/jschneier/django-storages/blob/0ceb9e03b89a00395cad9bd5ce3909cf99221cd1/storages/backends/azure_storage.py#L253-L256