### PR TITLE
Fix install instructions

### DIFF
--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -28,10 +28,11 @@ Gzipping for static files must be done through Azure CDN.
 Install
 *******
 
-Install Azure SDK::
+Install Azure SDK (in addition to pip installing django-storages)::
 
-  pip install django-storages[azure]
+  pip install azure-core azure-storage-blob
 
+Why doesn't the older azure package work anymore? See https://stackoverflow.com/a/58900508/5305519
 
 Private VS Public Access
 ************************


### PR DESCRIPTION
The install instruction needs to be updated. The azure package is deprecated and broken down into separate packages. In addition, the new django-storages doesn't work with the old azure package due to this issue (https://stackoverflow.com/questions/50581138/cannot-import-name-blockblobservice). 

I propose this new update to the installation process. I have tested this process and it works perfectly. Feel free to reach out to me if you have any questions.