### PR TITLE
add docs for AWS_S3_SECURE_URLS and AWS_S3_URL_PROTOCOL

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -104,6 +104,20 @@ searches for them:
 ``AWS_S3_ENDPOINT_URL`` (optional: default is ``None``)
     Custom S3 URL to use when connecting to S3, including scheme. Overrides ``AWS_S3_REGION_NAME`` and ``AWS_S3_USE_SSL``. To avoid ``AuthorizationQueryParametersError`` error, ``AWS_S3_REGION_NAME`` should also be set.
 
+``AWS_S3_SECURE_URLS`` (optional: default is ``True``)
+    Whether or not to use `https` or `http` in domain URI. Backward-compatibility: given the anteriority of the SECURE_URL setting
+    we fall back to https if specified in order to avoid the construction
+    of unsecure urls.
+
+``AWS_S3_URL_PROTOCOL`` (optional: default is ``http``)
+    URI scheme when building domain URI. Default is `http`, but is set to `https` when `AWS_S3_SECURE_URLS` above is
+    left as default `True`.
+
+.. note::
+
+    To use a this variable to set a custom URI scheme (URL protocol, such as `s3`), `AWS_S3_SECURE_URLS` must be set to
+    `False`.
+
 ``AWS_S3_ADDRESSING_STYLE`` (optional: default is ``None``)
     Possible values ``virtual`` and ``path``.
 


### PR DESCRIPTION
Solves [Issue 1150](https://github.com/jschneier/django-storages/issues/1150).
- Add documentation for AWS_S3_SECURE_URLS
- Add documentation for AWS_S3_URL_PROTOCOL

Reasoning:

To use a custom URI scheme, one would have to set
```
AWS_S3_URL_PROTOCOL = "s3:" (or whatever)
AWS_S3_SECURE_URLS = False (to keep from using https)
```

Code that handles these settings:
https://github.com/jschneier/django-storages/blob/620a13336f23a8c658914b2daa28661e2d350e8f/storages/backends/s3boto3.py#L258-L262
```
if self.secure_urls:
    self.url_protocol = 'https:'
    ...

'secure_urls': setting('AWS_S3_SECURE_URLS', True),
...
'url_protocol': setting('AWS_S3_URL_PROTOCOL', 'http:'),
```