### PR TITLE
Ignore ApiError exception in url()

### DIFF
--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -131,7 +131,7 @@ class DropBoxStorage(Storage):
             media = self.client.files_get_temporary_link(self._full_path(name))
             return media.link
         except ApiError:
-            return ''
+            return None
 
     def _open(self, name, mode='rb'):
         remote_file = DropBoxFile(self._full_path(name), self)

--- a/storages/backends/dropbox.py
+++ b/storages/backends/dropbox.py
@@ -127,8 +127,11 @@ class DropBoxStorage(Storage):
         return metadata.client_modified
 
     def url(self, name):
-        media = self.client.files_get_temporary_link(self._full_path(name))
-        return media.link
+        try:
+            media = self.client.files_get_temporary_link(self._full_path(name))
+            return media.link
+        except ApiError:
+            return ''
 
     def _open(self, name, mode='rb'):
         remote_file = DropBoxFile(self._full_path(name), self)


### PR DESCRIPTION
This PR fixes https://github.com/jschneier/django-storages/issues/1157 by silencing `ApiError` in the Dropbox the `url()` function.