### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ This library is usually compatible with the currently supported versions of
 Django. Check the Trove classifiers in setup.py to be sure.
 
 django-storages is backed in part by `Tidelift`_. Check them out for all of your enterprise open source
-software commerical support needs.
+software commercial support needs.
 
 .. _Tidelift: https://tidelift.com/subscription/pkg/pypi-django-storages?utm_source=pypi-django-storages&utm_medium=referral&utm_campaign=enterprise&utm_term=repo
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,7 +242,7 @@ epub_copyright = '2011-2017, David Larlet, et. al.'
 # The format is a list of tuples containing the path and title.
 #epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 #epub_post_files = []
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/conf.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `commercial` rather than `commerical`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md