### PR TITLE
[s3] update secure url creation handling

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -80,6 +80,9 @@ searches for them:
 ``AWS_QUERYSTRING_EXPIRE`` (optional; default is 3600 seconds)
     The number of seconds that a generated URL is valid for.
 
+``AWS_S3_URL_PROTOCOL`` (optional: default is ``https:``)
+    The protocol to use when constructing a custom domain, ``AWS_S3_CUSTOM_DOMAIN`` must be ``True`` for this to have any effect.
+
 ``AWS_S3_FILE_OVERWRITE`` (optional: default is ``True``)
     By default files with the same name will overwrite each other. Set this to ``False`` to have extra characters appended.
 
@@ -96,7 +99,7 @@ searches for them:
     Name of the AWS S3 region to use (eg. eu-west-1)
 
 ``AWS_S3_USE_SSL`` (optional: default is ``True``)
-    Whether or not to use SSL when connecting to S3.
+    Whether or not to use SSL when connecting to S3, this is passed to the boto3 session resource constructor.
 
 ``AWS_S3_VERIFY`` (optional: default is ``None``)
     Whether or not to verify the connection to S3. Can be set to False to not verify certificates or a path to a CA cert bundle.

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -255,12 +255,6 @@ class S3Boto3Storage(CompressStorageMixin, BaseStorage):
 
         check_location(self)
 
-        # Backward-compatibility: given the anteriority of the SECURE_URL setting
-        # we fall back to https if specified in order to avoid the construction
-        # of unsecure urls.
-        if self.secure_urls:
-            self.url_protocol = 'https:'
-
         self._bucket = None
         self._connections = threading.local()
 
@@ -315,7 +309,6 @@ class S3Boto3Storage(CompressStorageMixin, BaseStorage):
             'custom_domain': setting('AWS_S3_CUSTOM_DOMAIN'),
             'cloudfront_signer': cloudfront_signer,
             'addressing_style': setting('AWS_S3_ADDRESSING_STYLE'),
-            'secure_urls': setting('AWS_S3_SECURE_URLS', True),
             'file_name_charset': setting('AWS_S3_FILE_NAME_CHARSET', 'utf-8'),
             'gzip': setting('AWS_IS_GZIPPED', False),
             'gzip_content_types': setting('GZIP_CONTENT_TYPES', (
@@ -325,7 +318,7 @@ class S3Boto3Storage(CompressStorageMixin, BaseStorage):
                 'application/x-javascript',
                 'image/svg+xml',
             )),
-            'url_protocol': setting('AWS_S3_URL_PROTOCOL', 'http:'),
+            'url_protocol': setting('AWS_S3_URL_PROTOCOL', 'https:'),
             'endpoint_url': setting('AWS_S3_ENDPOINT_URL'),
             'proxies': setting('AWS_S3_PROXIES'),
             'region_name': setting('AWS_S3_REGION_NAME'),


### PR DESCRIPTION
Remove AWS_S3_SECURE_URLS setting
Update AWS_S3_URL_PROTOCOL setting to default to https:
Document AWS_S3_URL_PROTOCOL

Resolves #1126, #1150