### PR TITLE
[azure] Use `AZURE_CUSTOM_DOMAIN` only for retrieving blob URLs, and use storage URL for other operations

### DIFF
--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -144,7 +144,7 @@ The following settings are available:
 
 ``AZURE_CUSTOM_DOMAIN``
 
-    The custom domain to use. This can be set in the Azure Portal. For
+    The custom domain to use for generating URLs for files. For
     example, ``www.mydomain.com`` or ``mycdn.azureedge.net``.
 
 ``AZURE_CONNECTION_STRING``

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -260,11 +260,7 @@ class AzureStorage(BaseStorage):
 
     def exists(self, name):
         blob_client = self.client.get_blob_client(self._get_valid_path(name))
-        try:
-            blob_client.get_blob_properties()
-            return True
-        except ResourceNotFoundError:
-            return False
+        return blob_client.exists()
 
     def delete(self, name):
         try:

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -123,7 +123,9 @@ class AzureStorage(BaseStorage):
     def __init__(self, **settings):
         super().__init__(**settings)
         self._service_client = None
+        self._custom_service_client = None
         self._client = None
+        self._custom_client = None
         self._user_delegation_key = None
         self._user_delegation_key_expiry = datetime.utcnow()
 
@@ -150,11 +152,11 @@ class AzureStorage(BaseStorage):
             "api_version": setting('AZURE_API_VERSION', None),
         }
 
-    def _get_service_client(self):
+    def _get_service_client(self, use_custom_domain):
         if self.connection_string is not None:
             return BlobServiceClient.from_connection_string(self.connection_string)
 
-        account_domain = self.custom_domain or "{}.blob.{}".format(
+        account_domain = self.custom_domain if self.custom_domain and use_custom_domain else "{}.blob.{}".format(
             self.account_name,
             self.endpoint_suffix,
         )
@@ -178,8 +180,14 @@ class AzureStorage(BaseStorage):
     @property
     def service_client(self):
         if self._service_client is None:
-            self._service_client = self._get_service_client()
+            self._service_client = self._get_service_client(use_custom_domain=False)
         return self._service_client
+
+    @property
+    def custom_service_client(self):
+        if self._custom_service_client is None:
+            self._custom_service_client = self._get_service_client(use_custom_domain=True)
+        return self._custom_service_client
 
     @property
     def client(self):
@@ -188,6 +196,14 @@ class AzureStorage(BaseStorage):
                 self.azure_container
             )
         return self._client
+
+    @property
+    def custom_client(self):
+        if self._custom_client is None:
+            self._custom_client = self.custom_service_client.get_container_client(
+                self.azure_container
+            )
+        return self._custom_client
 
     def get_user_delegation_key(self, expiry):
         # We'll only be able to get a user delegation key if we've authenticated with a
@@ -309,7 +325,7 @@ class AzureStorage(BaseStorage):
             )
             credential = sas_token
 
-        container_blob_url = self.client.get_blob_client(name).url
+        container_blob_url = self.custom_client.get_blob_client(name).url
         return BlobClient.from_blob_url(container_blob_url, credential=credential).url
 
     def _get_content_settings_parameters(self, name, content=None):

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -219,7 +219,7 @@ class AzureStorage(BaseStorage):
         ):
             now = datetime.utcnow()
             key_expiry_time = now + timedelta(days=7)
-            self._user_delegation_key = self.service_client.get_user_delegation_key(
+            self._user_delegation_key = self.custom_service_client.get_user_delegation_key(
                 key_start_time=now, key_expiry_time=key_expiry_time
             )
             self._user_delegation_key_expiry = key_expiry_time

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -113,7 +113,7 @@ class AzureStorageTest(TestCase):
         # storage will raise when file name is too long as well,
         # the form should validate this
         client_mock = mock.MagicMock()
-        client_mock.exists.side_effect = [False, True]
+        client_mock.exists.side_effect = [True, False]
         self.storage._client.get_blob_client.return_value = client_mock
         self.assertRaises(ValueError, self.storage.get_available_name, 'a' * 1025)
         name = self.storage.get_available_name('a' * 1000, max_length=100)  # max_len == 1024
@@ -258,7 +258,7 @@ class AzureStorageTest(TestCase):
             bsc_mocked.return_value.get_container_client.return_value = client_mock
             self.assertEqual(storage.client, client_mock)
             bsc_mocked.assert_called_once_with(
-                'https://foo_name.blob.core.windows.net',
+                'http://foo_name.blob.core.windows.net',
                 credential='foo_token')
 
         with mock.patch(

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 from unittest import mock
 
 import django
-from azure.core.exceptions import ResourceNotFoundError
 from azure.storage.blob import BlobProperties
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.base import ContentFile


### PR DESCRIPTION
Fixes #1116, #1097

This restores the previous behaviour that was in 1.11 (with old Azure backend) so that the custom domain is used only for retrieving the blob URLs. All other operations like uploads go through the actual storage account URL. I updated the docs to clarify this too.

In 1.12, we switched to the new storage SDK and also changed it so that all storage operations go through the custom domain instead (not sure if intentional or not). Doing so uncovered several upstream issues that affect storage operations when connecting directly to the custom domain. More details in #1116.

I also made a small change to simplify the `exists()` method a bit.