### PR TITLE
adds option for google signed url version

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -204,7 +204,10 @@ Note: Default Google Compute Engine (GCE) Service accounts are
 The ``GS_EXPIRATION`` value is handled by the underlying `Google library  <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
 It supports `timedelta`, `datetime`, or `integer` seconds since epoch time.
 
+``GS_SIGNED_URL_VERSION`` (optional: default is ``v4``)
 
+The version used for signing Google Cloud storage (`v4` or `v2`). The `v4` version restricts the expiration time 
+of signed urls to a maximum of 7 days.
 Usage
 -----
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -120,6 +120,7 @@ class GoogleCloudStorage(CompressStorageMixin, BaseStorage):
             "default_acl": setting('GS_DEFAULT_ACL'),
             "querystring_auth": setting('GS_QUERYSTRING_AUTH', True),
             "expiration": setting('GS_EXPIRATION', timedelta(seconds=86400)),
+            "signed_url_version": setting('GS_SIGNED_URL_VERSION', 'v4'),
             "gzip": setting('GS_IS_GZIPPED', False),
             "gzip_content_types": setting('GZIP_CONTENT_TYPES', (
                 'text/css',


### PR DESCRIPTION
Adds option for choosing the version (`v2` vs `v4`) for signing URLs for Google Cloud Storage files as `v4` restricts the maximum expiration time to 7 days.