### PR TITLE
Fix STORAGES settings in docs for Django 4.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,12 +25,26 @@ hasn't been released yet) then the magic incantation you are looking for is:
 
   pip install -e 'git+https://github.com/jschneier/django-storages.git#egg=django-storages'
 
-Once that is done set ``DEFAULT_FILE_STORAGE`` to the backend of your choice.
+Once that is done, if using Django 4.1 or earlier, set ``DEFAULT_FILE_STORAGE`` to the backend of your choice.
 If, for example, you want to use the boto3 backend you would set:
 
 .. code-block:: python
 
   DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+
+For Django 4.2 or later, set the ``default`` value in ``STORAGES`` to the backend of your choice. For example:
+
+.. code-block:: python
+
+  STORAGES = {
+      'default': {
+          'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+      },
+      'staticfiles': {
+          # Leave whatever setting you already have here, e.g.:
+          'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+      }
+  }
 
 
 If you are using the ``FileSystemStorage`` as your storage management class in your models ``FileField`` fields, remove them

--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -19,7 +19,7 @@ To upload your media files to S3 set::
     DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
     # django >= 4.2
-    STORAGES = {"default": "storages.backends.s3boto3.S3Boto3Storage"}
+    STORAGES = {"default": {"BACKEND": "storages.backends.s3boto3.S3Boto3Storage"}}
 
 
 To allow ``django-admin collectstatic`` to automatically put your static files in your bucket set the following in your settings.py::
@@ -28,7 +28,7 @@ To allow ``django-admin collectstatic`` to automatically put your static files i
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3StaticStorage'
 
     # django >= 4.2
-    STORAGES = {"staticfiles": "storages.backends.s3boto3.S3StaticStorage"}
+    STORAGES = {"staticfiles": {"BACKEND": "storages.backends.s3boto3.S3StaticStorage"}}
 
 If you want to use something like `ManifestStaticFilesStorage`_ then you must instead use::
 
@@ -36,7 +36,7 @@ If you want to use something like `ManifestStaticFilesStorage`_ then you must in
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3ManifestStaticStorage'
 
     # django >= 4.2
-    STORAGES = {"staticfiles": "storages.backends.s3boto3.S3ManifestStaticStorage"}
+    STORAGES = {"staticfiles": {"BACKEND": "storages.backends.s3boto3.S3ManifestStaticStorage"}}
 
 There are several different methods for specifying the AWS credentials used to create the S3 client.  In the order that ``S3Boto3Storage``
 searches for them:

--- a/docs/backends/apache_libcloud.rst
+++ b/docs/backends/apache_libcloud.rst
@@ -153,7 +153,7 @@ set::
     DEFAULT_FILE_STORAGE = 'storages.backends.apache_libcloud.LibCloudStorage'
 
     # django >= 4.2
-    STORAGES = {"default": "storages.backends.apache_libcloud.LibCloudStorage"}
+    STORAGES = {"default": {"BACKEND": "storages.backends.apache_libcloud.LibCloudStorage"}}
 
 Your default Libcloud provider will be used as the file store.
 

--- a/docs/backends/azure.rst
+++ b/docs/backends/azure.rst
@@ -64,8 +64,8 @@ Then on settings set::
 
     # django >= 4.2
     STORAGES = {
-        "default": "storages.backends.azure_storage.AzureStorage",
-        "staticfiles": "custom_storage.custom_azure.PublicAzureStorage",
+        "default": {"BACKEND": "storages.backends.azure_storage.AzureStorage"},
+        "staticfiles": {"BACKEND": "custom_storage.custom_azure.PublicAzureStorage"},
     }
 
 +++++++++++++++++++++
@@ -93,8 +93,15 @@ configuration file, usually `settings.py`.
 Set the default storage (i.e: for media files) and the static storage
 (i.e: fo static files) to use the azure backend::
 
+    # django < 4.2
     DEFAULT_FILE_STORAGE = 'storages.backends.azure_storage.AzureStorage'
     STATICFILES_STORAGE = 'storages.backends.azure_storage.AzureStorage'
+
+    # django >= 4.2
+    STORAGES = {
+        "default": {"BACKEND": "storages.backends.azure_storage.AzureStorage"},
+        "staticfiles": {"BACKEND": "storages.backends.azure_storage.AzureStorage"},
+    }
 
 The following settings are available:
 

--- a/docs/backends/dropbox.rst
+++ b/docs/backends/dropbox.rst
@@ -18,7 +18,7 @@ To use DropBoxStorage set::
     DEFAULT_FILE_STORAGE = 'storages.backends.dropbox.DropBoxStorage'
 
     # django >= 4.2
-    STORAGES = {"default": "storages.backends.dropbox.DropBoxStorage"}
+    STORAGES = {"default": {"BACKEND": "storages.backends.dropbox.DropBoxStorage"}}
 
 Two methods of authenticating are supported:
 

--- a/docs/backends/ftp.rst
+++ b/docs/backends/ftp.rst
@@ -14,7 +14,7 @@ To use FtpStorage set::
     DEFAULT_FILE_STORAGE = 'storages.backends.ftp.FTPStorage'
 
     # django >= 4.2
-    STORAGES = {"default": "storages.backends.ftp.FTPStorage"}
+    STORAGES = {"default": {"BACKEND": "storages.backends.ftp.FTPStorage"}}
 
 ``FTP_STORAGE_LOCATION``
     URL of the server that holds the files. Example ``'ftp://<user>:<pass>@<host>:<port>'``

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -46,7 +46,7 @@ Set the default storage and bucket name in your settings.py file
     DEFAULT_FILE_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
 
     # django >= 4.2
-    STORAGES = {"default": "storages.backends.gcloud.GoogleCloudStorage"}
+    STORAGES = {"default": {"BACKEND": "storages.backends.gcloud.GoogleCloudStorage"}}
 
     GS_BUCKET_NAME = 'YOUR_BUCKET_NAME_GOES_HERE'
 
@@ -57,7 +57,7 @@ To allow ``django-admin`` collectstatic to automatically put your static files i
     STATICFILES_STORAGE = 'storages.backends.gcloud.GoogleCloudStorage'
 
     # django >= 4.2
-    STORAGES = {"staticfiles": "storages.backends.gcloud.GoogleCloudStorage"}
+    STORAGES = {"staticfiles": {"BACKEND": "storages.backends.gcloud.GoogleCloudStorage"}}
 
 Once you're done, default_storage will be Google Cloud Storage
 


### PR DESCRIPTION
Changed anything like

```python
STORAGES = {"default": "storages.backends.gcloud.GoogleCloudStorage"}
```

to

```python
STORAGES = {"default": {"BACKEND": "storages.backends.gcloud.GoogleCloudStorage"}}
```

And added a bit to the README about the settings for Django >= 4.2 (not sure if the wording is how you would do it, so obviously feel free to change it!).

For #1207 