### PR TITLE
enables passing `security_token` to constructor

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -306,6 +306,7 @@ class S3Boto3Storage(CompressStorageMixin, BaseStorage):
         return {
             'access_key': setting('AWS_S3_ACCESS_KEY_ID', setting('AWS_ACCESS_KEY_ID')),
             'secret_key': setting('AWS_S3_SECRET_ACCESS_KEY', setting('AWS_SECRET_ACCESS_KEY')),
+            'security_token': setting('AWS_SESSION_TOKEN', setting('AWS_SECURITY_TOKEN')),
             'session_profile': setting('AWS_S3_SESSION_PROFILE'),
             'file_overwrite': setting('AWS_S3_FILE_OVERWRITE', True),
             'object_parameters': setting('AWS_S3_OBJECT_PARAMETERS', {}),


### PR DESCRIPTION
Without this line, `BaseStorage.__init__` raises an `ImproperlyConfigured` exception which prevents passing security_token as a parameter to `S3Boto3Storage.__init__`.

We use django-storages to manage a multi-tenant / multi-S3-bucket / multi-aws-account service. As a result, multiple `S3Boto3Storage` classes get instantiated with the proper information (access_key, secret_key and security_token).

This line fixes our problem. I am not sure if there was a reason why `security_token` is not
listed in default settings and/or if as a result it breaks some other use cases.