### PR TITLE
check if underlying file object is closed in closed method

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -131,6 +131,10 @@ class S3Boto3StorageFile(CompressedFileMixin, File):
     @property
     def size(self):
         return self.obj.content_length
+    
+    @property
+    def closed(self):
+        return not self._file or self._file.closed
 
     def _get_file(self):
         if self._file is None:

--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -131,7 +131,7 @@ class S3Boto3StorageFile(CompressedFileMixin, File):
     @property
     def size(self):
         return self.obj.content_length
-    
+
     @property
     def closed(self):
         return not self._file or self._file.closed

--- a/tests/test_s3boto3.py
+++ b/tests/test_s3boto3.py
@@ -787,3 +787,24 @@ class S3ManifestStaticStorageTests(TestCase):
 
     def test_save(self):
         self.storage.save('x.txt', ContentFile(b'abc'))
+
+
+class S3Boto3StorageFileTests(TestCase):
+    def setUp(self) -> None:
+        self.storage = s3boto3.S3Boto3Storage()
+        self.storage._connections.connection = mock.MagicMock()
+
+    def test_closed(self):
+        f = s3boto3.S3Boto3StorageFile('test', 'wb', self.storage)
+
+        with self.subTest("is True after init"):
+            self.assertTrue(f.closed)
+
+        with self.subTest("is False after file access"):
+            # Ensure _get_file has been called
+            f.file
+            self.assertFalse(f.closed)
+
+        with self.subTest("is True after close"):
+            f.close()
+            self.assertTrue(f.closed)


### PR DESCRIPTION
Currently it appears that `S3Boto3StorageFile` uses the `closed` property defined by `FileProxyMixin`, which checks the condition `not self.file or self.file.closed` ([source](https://github.com/django/django/blob/main/django/core/files/utils.py#L54)). Since `self.file` in `S3Boto3StorageFile` is a property that delegates to `_get_file`, this check reopens the file. Thus `closed` always returns `False`.