### PR TITLE
Add FileSystemOverwriteStorage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,17 @@
 django-storages CHANGELOG
 =========================
 
+UNRELEASED
+**********
+
+Filesystem
+----------
+
+Add new ``FileSystemOverwriteStorage`` backend - similar to Django's existing filesystem storage,
+but overwrites existing files instead of always saving with unique names. (`#1252`_)
+
+.. _#1252: https://github.com/jschneier/django-storages/pull/1252
+
 1.14.2 (2023-10-08)
 *******************
 

--- a/docs/backends/filesystem.rst
+++ b/docs/backends/filesystem.rst
@@ -1,0 +1,21 @@
+Filesystem
+==========
+
+django-storages contains an alternative filesystem storage backend.
+
+Unlike Django's builtin filesystem storage, this one always overwrites files of the same name, and never renames files.
+
+
+Usage
+*****
+
+::
+
+    from storages.backends.filesystem import FileSystemOverwriteStorage
+    
+    storage = FileSystemOverwriteStorage(location='/media/photos')
+    storage.save("myfile.txt", ContentFile("content 1"))
+    
+    # This will overwrite the previous file, *not* create a new file.
+    storage.save("myfile.txt", ContentFile("content 2"))
+

--- a/storages/backends/filesystem.py
+++ b/storages/backends/filesystem.py
@@ -1,0 +1,27 @@
+import os
+import pathlib
+
+from django.core.exceptions import SuspiciousFileOperation
+from django.core.files.storage import FileSystemStorage
+
+
+class FileSystemOverwriteStorage(FileSystemStorage):
+    """
+    Filesystem storage that never renames files.
+    Files uploaded via this storage class will automatically overwrite any files of the same name.
+    """
+
+    # Don't throw errors if the file already exists when saving.
+    # https://manpages.debian.org/bullseye/manpages-dev/open.2.en.html#O_EXCL
+    OS_OPEN_FLAGS = FileSystemStorage.OS_OPEN_FLAGS & ~os.O_EXCL
+
+    # Don't check what files already exist; just use the original name.
+    def get_available_name(self, name, max_length=None):
+        # Do validate it though (just like FileSystemStorage does)
+        name = str(name).replace("\\", "/")
+        dir_name, _ = os.path.split(name)
+        if ".." in pathlib.PurePath(dir_name).parts:
+            raise SuspiciousFileOperation(
+                "Detected path traversal attempt in '%s'" % dir_name
+            )
+        return name

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,37 @@
+import tempfile
+
+import pytest
+from django.core.exceptions import SuspiciousFileOperation
+from django.core.files.base import ContentFile
+
+from storages.backends import filesystem
+
+
+@pytest.fixture()
+def storage():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        yield filesystem.FileSystemOverwriteStorage(location=tmpdirname)
+
+
+def test_save_overwrite(storage):
+    content = ContentFile("content")
+    name = "testfile.txt"
+    storage.save(name, content)
+
+    assert storage.exists(name)
+    assert storage.size(name) == len(content)
+
+    content2 = ContentFile("content2")
+    storage.save(name, content2)
+    # No rename was done; the same file was overwritten
+    assert storage.exists(name)
+    assert storage.size(name) == len(content2)
+
+
+def test_filename_validate(storage):
+    content = ContentFile("content")
+    with pytest.raises(SuspiciousFileOperation):
+        storage.save("/badfile.txt", content)
+
+    with pytest.raises(SuspiciousFileOperation):
+        storage.save("foo/../../../badfile.txt", content)


### PR DESCRIPTION
Improved implementation of #1209

# Background: 

This ticket is going in loops:

Refer https://code.djangoproject.com/ticket/28144

I guess django-storages apparently _did_ once have this class, and it was removed. 

Per that above ticket, Django later added a fix to make it _possible_ to override the not-overwriting behaviour (an `OS_OPEN_FLAGS` attribute)

Looks like there was (a LONG time ago) some discussion about including this feature in Django: https://code.djangoproject.com/ticket/4339 (it was closed wontfix due to the trivial nature of a custom implementation)

So, that puts us back here - we need somewhere to store that custom implementation, and django-storages seems like the right project for the job...

I've added a test and some basic docs (I don't think much is required, since there's no special configuration etc, unlike the other backends)