### PR TITLE
Close SSH connection of SFTP storage

### DIFF
--- a/docs/backends/sftp.rst
+++ b/docs/backends/sftp.rst
@@ -71,3 +71,18 @@ static files) to use the sftp backend::
 .. _`paramiko SSHClient.connect() documentation`: http://docs.paramiko.org/en/latest/api/client.html#paramiko.client.SSHClient.connect
 
 .. _`Python os.chmod documentation`: http://docs.python.org/library/os.html#os.chmod
+
+
+Standalone Use
+--------------
+
+If you intend to construct a storage instance not through Django but directly,
+use the storage instance as a context manager to make sure the underlying SSH
+connection is closed after use and no longer consumes resources.
+
+.. code-block:: python
+
+    from storages.backends.sftpstorage import SFTPStorage
+
+    with SFTPStorage(...) as sftp:
+        sftp.listdir("")

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ google =
 libcloud =
     apache-libcloud
 sftp =
-    paramiko >= 1.10.0
+    paramiko >= 1.15.0
 
 [flake8]
 exclude =

--- a/tests/test_sftp.py
+++ b/tests/test_sftp.py
@@ -40,6 +40,18 @@ class SFTPStorageTest(TestCase):
         self.storage._connect()
         self.assertEqual('foo', mock_ssh.return_value.connect.call_args[0][0])
 
+    @patch('paramiko.SSHClient')
+    def test_close_unopened(self, mock_ssh):
+        with self.storage:
+            pass
+        mock_ssh.return_value.close.assert_not_called()
+
+    @patch('paramiko.SSHClient')
+    def test_close_opened(self, mock_ssh):
+        with self.storage as storage:
+            storage._connect()
+        mock_ssh.return_value.close.assert_called_once_with()
+
     def test_open(self):
         file_ = self.storage._open('foo')
         self.assertIsInstance(file_, sftpstorage.SFTPStorageFile)


### PR DESCRIPTION
Closes #1234 by making the SFTP storage close the underlying SSH connection after being used as a context manager.

This is done by adding Paramiko's convenient `ClosingContextManager` to the SFTP storage and implementing its hook for closing. I could have implemented the context manager manually, but Paramiko is required for SFTP, anyway.

In doing so, this bumps the minimum Paramiko version from 1.10.0 to 1.15.0, which is the version that [introduced `ClosingContextManager`](https://github.com/paramiko/paramiko/commit/979838040f9ff2f52e369812be87f0c7c9c1a0db) almost 9 years ago.