### PR TITLE
Fix subheading weight

### DIFF
--- a/docs/backends/oracle-cloud.rst
+++ b/docs/backends/oracle-cloud.rst
@@ -18,7 +18,7 @@ The ``ORACLE_NAMESPACE`` value can be found on the bucket details page
 
 
 References
-==========
+----------
 
 - `Customer Secret Key`_
 - `Amazon S3 Compatibility API docs`_


### PR DESCRIPTION
Before this change, `References` used to show up in the list of backends at the documentation landing page.