### PR TITLE
ci: Drop Python 3.7 which is end-of-life

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         django-version: ["3.2", "4.1", "4.2", "main"]
         exclude:
-            - python-version: "3.7"
-              django-version: "4.1"
-            - python-version: "3.7"
-              django-version: "4.2"
-            - python-version: "3.7"
-              django-version: "main"
             - python-version: "3.8"
               django-version: "main"
             - python-version: "3.9"
@@ -54,7 +48,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -142,7 +141,7 @@ ignore = [
   "B904",
   "PGH004",
  ]
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.isort]
 force-single-line = true


### PR DESCRIPTION
https://devguide.python.org/versions/ -- **On hold** until Django 3.2 Long Term Support ends in April 2024.
* https://docs.djangoproject.com/en/4.2/releases/4.2