### PR TITLE
Add instructions for using django-storages with Scaleway Object storage

### DIFF
--- a/docs/backends/scaleway.rst
+++ b/docs/backends/scaleway.rst
@@ -19,5 +19,5 @@ With the settings above in place, with django storages set as DEFAULT_FILE_STORA
 
 If would be written to the following address:
 
-https://my-chosen-bucket.s3.nl-ams.scw.cloud/my-chosen-bucket/my_chosen_file.txt
+https://s3.nl-ams.scw.cloud/my-chosen-bucket/my_chosen_file.txt
 

--- a/docs/backends/scaleway.rst
+++ b/docs/backends/scaleway.rst
@@ -1,0 +1,24 @@
+Scaleway
+=============
+
+Scaleway Object storage implements the S3 protocol. To use it follow the instructions in the :doc:`Amazon S3 docs <amazon-S3>` with the important caveats that you must:
+
+- Set ``AWS_BUCKET_NAME`` to the Bucket you want write to (such as ``my-chosen-bucket``)
+- Set ``AWS_S3_REGION_NAME`` to your Scaleway region (such as ``nl-ams`` or ``fr-par``)
+- Set ``AWS_S3_ENDPOINT_URL`` to the value of ``https://{AWS_BUCKET_NAME}.s3.${AWS_S3_REGION_NAME}.scw.cloud``
+- Set ``AWS_ACCESS_KEY_ID`` to the value of your Access Key ID (i.e. ``SCW3XXXXXXXXXXXXXXXX``)
+- Set ``AWS_SECRET_ACCESS_KEY`` to the value of your Secret Key (i.e. ``abcdef10-ab12-cd34-ef56-acbdef123456``)
+
+With the settings above in place, with django storages set as DEFAULT_FILE_STORAGE, if you wrote a file like so:
+
+```python
+from django.core.files.storage import default_storage
+file = default_storage.open("my_chosen_file.txt", "w")
+file.write("storage contents")
+file.close()
+```
+
+If would be written to the following address:
+
+https://my-chosen-bucket.s3.nl-ams.scw.cloud/my-chosen-bucket/my_chosen_file.txt
+

--- a/docs/backends/scaleway.rst
+++ b/docs/backends/scaleway.rst
@@ -11,12 +11,11 @@ Scaleway Object storage implements the S3 protocol. To use it follow the instruc
 
 With the settings above in place, with django storages set as DEFAULT_FILE_STORAGE, if you wrote a file like so:
 
-```python
-from django.core.files.storage import default_storage
-file = default_storage.open("my_chosen_file.txt", "w")
-file.write("storage contents")
-file.close()
-```
+
+    from django.core.files.storage import default_storage
+    file = default_storage.open("my_chosen_file.txt", "w")
+    file.write("storage contents")
+    file.close()
 
 If would be written to the following address:
 

--- a/docs/backends/scaleway.rst
+++ b/docs/backends/scaleway.rst
@@ -5,7 +5,7 @@ Scaleway Object storage implements the S3 protocol. To use it follow the instruc
 
 - Set ``AWS_BUCKET_NAME`` to the Bucket you want write to (such as ``my-chosen-bucket``)
 - Set ``AWS_S3_REGION_NAME`` to your Scaleway region (such as ``nl-ams`` or ``fr-par``)
-- Set ``AWS_S3_ENDPOINT_URL`` to the value of ``https://{AWS_BUCKET_NAME}.s3.${AWS_S3_REGION_NAME}.scw.cloud``
+- Set ``AWS_S3_ENDPOINT_URL`` to the value of ``https://s3.${AWS_S3_REGION_NAME}.scw.cloud``
 - Set ``AWS_ACCESS_KEY_ID`` to the value of your Access Key ID (i.e. ``SCW3XXXXXXXXXXXXXXXX``)
 - Set ``AWS_SECRET_ACCESS_KEY`` to the value of your Secret Key (i.e. ``abcdef10-ab12-cd34-ef56-acbdef123456``)
 


### PR DESCRIPTION
hi there!

Thank you for creating Django Storage - I figured out how to use it with [Scaleway Object storage](https://www.scaleway.com/en/docs/storage/object/quickstart/) this week for a project, which is broadly compatible with AWS S3 storage, and I wanted to share this back.

~~I'm a little rusty with my restructured text, so I've made this draft PR, and once I figure out how to format the code example in the docs, I'll remove the draft status, ready for review.~~

I think I've updated it now.

