### PR TITLE
override mimetypes guess for gzip in S3Boto3Storage

### DIFF
--- a/storages/backends/s3boto3.py
+++ b/storages/backends/s3boto3.py
@@ -473,6 +473,10 @@ class S3Boto3Storage(CompressStorageMixin, BaseStorage):
         params = {}
 
         _type, encoding = mimetypes.guess_type(name)
+        # override the mimetypes guess for .gz, see #917
+        if str(name).endswith('.gz'):
+            _type = 'application/gzip'
+            encoding = None
         content_type = getattr(content, 'content_type', None)
         content_type = content_type or _type or self.default_content_type
 


### PR DESCRIPTION
Basically, gzip files that have been uploaded to S3 using django-storages are extracted automatically upon subsequent download.

This behavior is not always desired (is it ever?) but currently there is no way to prevent this on the django-storages side.

The proposed fix simply prevents the automatic extraction altogether by overriding the mimetype, but that may not be ideal.

That's why I'm hoping this PR will jumpstart the discussion on issue #917 