### PR TITLE
Update utils.py - check for PurePath instead of Path

### DIFF
--- a/storages/utils.py
+++ b/storages/utils.py
@@ -34,9 +34,9 @@ def clean_name(name):
     Normalize the name.
 
     Includes cleaning up Windows style paths, ensuring an ending trailing slash,
-    and coercing from pathlib.Path.
+    and coercing from pathlib.PurePath.
     """
-    if isinstance(name, pathlib.Path):
+    if isinstance(name, pathlib.PurePath):
         name = str(name)
 
     # Normalize Windows style paths


### PR DESCRIPTION
Should this check be for PurePath instead of Path? We had a crash when writing to S3 in django. 

```
File "/usr/local/lib/python3.10/site-packages/storages/backends/s3boto3.py", line 596, in get_available_name
keellabs-django-1   |     name = clean_name(name)
keellabs-django-1   |   File "/usr/local/lib/python3.10/site-packages/storages/utils.py", line 47, in clean_name
keellabs-django-1   |     if name.endswith('/') and not clean_name.endswith('/'):
keellabs-django-1   | AttributeError: 'PurePosixPath' object has no attribute 'endswith'

```

See image here: https://docs.python.org/3/library/pathlib.html 

NOTE - I am not a python / django expert, please look at this carefully.