### PR TITLE
Lint Python code with ruff instead of flake8 and isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,6 @@ jobs:
 
       - name: Quality tests
         env:
-          TOXENV: flake8
+          TOXENV: ruff
         run: |
           tox

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,90 @@
+# NOTE: You have to use single-quoted strings in TOML for regular expressions.
+# It's the equivalent of r-strings in Python.  Multiline strings are treated as
+# verbose regular expressions by Black.  Use [ ] to denote a significant space
+# character.
+
+# When switching from ruff.toml to pyproject.toml, use the section names that
+# start with [tool.ruff
+
+# [tool.ruff]
+select = [
+  "AIR",    # Airflow
+  "ASYNC",  # flake8-async
+  "B",      # flake8-bugbear
+  "C4",     # flake8-comprehensions
+  "C90",    # McCabe cyclomatic complexity
+  "CPY",    # flake8-copyright
+  "DJ",     # flake8-django
+  "E",      # pycodestyle
+  "EXE",    # flake8-executable
+  "F",      # Pyflakes
+  "FLY",    # flynt
+  "FURB",   # refurb
+  "G",      # flake8-logging-format
+  "I",      # isort
+  "ICN",    # flake8-import-conventions
+  "INP",    # flake8-no-pep420
+  "INT",    # flake8-gettext
+  "ISC",    # flake8-implicit-str-concat
+  "NPY",    # NumPy-specific rules
+  "PD",     # pandas-vet
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PYI",    # flake8-pyi
+  "RUF",    # Ruff-specific rules
+  "SLOT",   # flake8-slots
+  "T10",    # flake8-debugger
+  "T20",    # flake8-print
+  "TCH",    # flake8-type-checking
+  "TID",    # flake8-tidy-imports
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "A",    # flake8-builtins
+  # "ANN",  # flake8-annotations
+  # "ARG",  # flake8-unused-arguments
+  # "BLE",  # flake8-blind-except
+  # "COM",  # flake8-commas
+  # "D",    # pydocstyle
+  # "DTZ",  # flake8-datetimez
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "FA",   # flake8-future-annotations
+  # "FBT",  # flake8-boolean-trap
+  # "FIX",  # flake8-fixme
+  # "N",    # pep8-naming
+  # "PT",   # flake8-pytest-style
+  # "PTH",  # flake8-use-pathlib
+  # "Q",    # flake8-quotes
+  # "RET",  # flake8-return
+  # "RSE",  # flake8-raise
+  # "S",    # flake8-bandit
+  # "SIM",  # flake8-simplify
+  # "SLF",  # flake8-self
+  # "TD",   # flake8-todos
+  # "TRY",  # tryceratops
+  # "UP",   # pyupgrade
+]
+ignore = [
+  "B028",
+  "B904",
+  "PGH004",
+ ]
+line-length = 119
+target-version = "py37"
+
+[isort]
+# [tool.ruff.isort]
+force-single-line = true
+known-first-party = ["storages"]
+
+[per-file-ignores]
+# [tool.ruff.per-file-ignores]
+"docs/conf.py" = ["E402", "INP001"]
+"storages/backends/ftp.py" = ["PERF203"]
+"tests/test_s3.py" = ["B018"]
+
+[pylint]
+# [tool.ruff.pylint]
+allow-magic-value-types = ["int", "str"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,17 +50,3 @@ sftp =
     paramiko >= 1.15.0
 s3 =
     boto3 >= 1.4.4
-
-[flake8]
-exclude =
-    .tox,
-    docs,
-    venv
-max-line-length = 119
-
-[isort]
-force_single_line = true
-default_section = THIRDPARTY
-include_trailing_comma = true
-known_first_party = storages
-line_length = 119

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -120,7 +120,6 @@ class FTPStorage(Storage):
                         'Cannot create directory chain %s' % path
                     )
         self._connection.cwd(pwd)
-        return
 
     def _put_file(self, name, content):
         # Connection must be open!

--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -496,8 +496,7 @@ class S3Storage(CompressStorageMixin, BaseStorage):
         paginator = self.connection.meta.client.get_paginator('list_objects')
         pages = paginator.paginate(Bucket=self.bucket_name, Delimiter='/', Prefix=path)
         for page in pages:
-            for entry in page.get('CommonPrefixes', ()):
-                directories.append(posixpath.relpath(entry['Prefix'], path))
+            directories += [posixpath.relpath(entry['Prefix'], path) for entry in page.get('CommonPrefixes', ())]
             for entry in page.get('Contents', ()):
                 key = entry['Key']
                 if key != path:

--- a/storages/utils.py
+++ b/storages/utils.py
@@ -71,7 +71,7 @@ def safe_join(base, *paths):
     """
     base_path = base
     base_path = base_path.rstrip('/')
-    paths = [p for p in paths]
+    paths = list(paths)
 
     final_path = base_path + '/'
     for path in paths:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -765,7 +765,7 @@ class S3StorageTests(TestCase):
         def thread_storage_connection():
             connections.append(self.storage.connection)
 
-        for x in range(2):
+        for _x in range(2):
             t = threading.Thread(target=thread_storage_connection)
             t.start()
             t.join()

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
 	py{3.8,3.9,3.10,3.11}-django4.1
 	py{3.8,3.9,3.10,3.11}-django4.2
 	py{3.10,3.11,3.12}-djangomain
-	flake8
+	ruff
 
 [testenv]
 setenv =
@@ -14,15 +14,15 @@ setenv =
 	PYTHONDONTWRITEBYTECODE = 1
 commands = pytest --cov=storages tests/ {posargs}
 deps =
+	cryptography
 	django3.2: django~=3.2.9
 	django4.1: django~=4.1.0
 	django4.2: django~=4.2.0
 	djangomain: https://github.com/django/django/archive/main.tar.gz
-	cryptography
+	moto
 	pytest
 	pytest-cov
 	rsa
-	moto
 extras =
     azure
     boto3
@@ -31,11 +31,9 @@ extras =
     libcloud
     sftp
 
-[testenv:flake8]
+[testenv:ruff]
 deps =
-	flake8
-	isort>=5.0.0
+	ruff
 commands =
-	flake8
-	isort --check-only --diff .
+	ruff .
 skip_install = true


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 600 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.
