### PR TITLE
Raise not exists error when attempting to get size for unexisting S3 file

### DIFF
--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -647,6 +647,17 @@ class S3StorageTests(TestCase):
         name = "file.txt"
         self.assertEqual(self.storage.size(name), obj.content_length)
 
+    def test_storage_size_not_exists(self):
+        self.storage.bucket.Object.side_effect = ClientError(
+            {"Error": {}, "ResponseMetadata": {"HTTPStatusCode": 404}},
+            "HeadObject",
+        )
+        name = "file.txt"
+        with self.assertRaisesMessage(
+            FileNotFoundError, "File does not exist: file.txt"
+        ):
+            self.storage.size(name)
+
     def test_storage_mtime(self):
         # Test both USE_TZ cases
         for use_tz in (True, False):


### PR DESCRIPTION
As of now, attempting to get the file size from `S3Storage` always raises a `botocore.ClientError`, which is vague and may not fall under existing file-management related error handling.

Since may other methods in S3 storage already implement this kind of logic I have put the same in the `S3Storage.size` method. Now if the S3 error is a "not found" a more explanatory `FileNotFoundError` is raised instead.