### PR TITLE
add explicit dependency on azure-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 azure = [
+  "azure-core>=1.13",
   "azure-storage-blob>=12",
 ]
 boto3 = [


### PR DESCRIPTION
this project directly imports from azure-core, and should express that dependency.  1.13.0 is the version that introduced `azure.core.utils.parse_connection_string`

this is pedantry really, because azure-storage-blob already pulls azure-core as a sub-dependency