### PR TITLE
Revert "[s3] raise ImproperlyConfigured if no bucket name is set (#1313)

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -288,8 +288,6 @@ class S3Storage(CompressStorageMixin, BaseStorage):
         super().__init__(**settings)
 
         check_location(self)
-        if not self.bucket_name:
-            raise ImproperlyConfigured("Setting a bucket name is required.")
 
         if (self.access_key or self.secret_key) and self.session_profile:
             raise ImproperlyConfigured(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -956,11 +956,6 @@ class S3StorageTests(TestCase):
                 access_key="foo", secret_key="boo", session_profile="moo"
             )
 
-    def test_bucket_name_required(self):
-        with override_settings(AWS_STORAGE_BUCKET_NAME=None):
-            with self.assertRaises(ImproperlyConfigured):
-                s3.S3Storage()
-
 
 class S3StaticStorageTests(TestCase):
     def setUp(self):


### PR DESCRIPTION
This reverts commit 9eeb8c3dbc8874fe01532ccaa09700362805922c.

See the discussion on the PR for people who are seeing issues in CI and testing.