### PR TITLE
Fix typo in code comment

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -220,7 +220,7 @@ class GoogleCloudStorage(BaseStorage):
     def get_object_parameters(self, name):
         """Override this to return a dictionary of overwritable blob-property to value.
 
-        Returns GS_OBJECT_PARAMETRS by default. See the docs for all possible options.
+        Returns GS_OBJECT_PARAMETERS by default. See the docs for all possible options.
         """
         object_parameters = self.object_parameters.copy()
         return object_parameters


### PR DESCRIPTION
Replaces `GS_OBJECT_PARAMETRS` with `GS_OBJECT_PARAMETERS`.