### PR TITLE
[s3] fix disabling cloudfront signing with class variable

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -300,7 +300,8 @@ class S3Storage(CompressStorageMixin, BaseStorage):
 
     def __init__(self, **settings):
         omitted = object()
-        self.cloudfront_signer = settings.pop("cloudfront_signer", omitted)
+        if not hasattr(self, "cloudfront_signer"):
+            self.cloudfront_signer = settings.pop("cloudfront_signer", omitted)
 
         super().__init__(**settings)
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -894,6 +894,12 @@ class S3StorageTests(TestCase):
             storage = s3.S3Storage(cloudfront_signer=None)
             self.assertIsNone(storage.cloudfront_signer)
 
+            # allow disabling cloudfront signing in subclass
+            class Storage(s3.S3Storage):
+                cloudfront_signer = None
+
+            self.assertIsNone(Storage().cloudfront_signer)
+
         storage = s3.S3Storage(cloudfront_key_id=key_id, cloudfront_key=pem)
         self.assertIsNotNone(storage.cloudfront_signer)
 


### PR DESCRIPTION
This change fixes setting ``cloudfront_signer=None`` as a class variable to disable cloudfront signing (or passing a custom implementation), and is a follow up to https://github.com/jschneier/django-storages/pull/1326