### PR TITLE
s3: Fix newline handling for text-mode files

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -1,5 +1,6 @@
 import mimetypes
 import os
+import io
 import posixpath
 import tempfile
 import threading
@@ -123,7 +124,6 @@ class S3File(CompressedFileMixin, File):
         self._storage = storage
         self.name = name[len(self._storage.location) :].lstrip("/")
         self._mode = mode
-        self._force_mode = (lambda b: b) if "b" in mode else (lambda b: b.decode())
         self.obj = storage.bucket.Object(name)
         if "w" not in mode:
             # Force early RAII-style exception if object does not exist
@@ -184,6 +184,8 @@ class S3File(CompressedFileMixin, File):
                 self._file.seek(0)
                 if self._storage.gzip and self.obj.content_encoding == "gzip":
                     self._file = self._decompress_file(mode=self._mode, file=self._file)
+                elif "b" not in self._mode:
+                    self._file = io.TextIOWrapper(self._file._file, encoding="utf-8")
             self._closed = False
         return self._file
 
@@ -195,12 +197,12 @@ class S3File(CompressedFileMixin, File):
     def read(self, *args, **kwargs):
         if "r" not in self._mode:
             raise AttributeError("File was not opened in read mode.")
-        return self._force_mode(super().read(*args, **kwargs))
+        return super().read(*args, **kwargs)
 
     def readline(self, *args, **kwargs):
         if "r" not in self._mode:
             raise AttributeError("File was not opened in read mode.")
-        return self._force_mode(super().readline(*args, **kwargs))
+        return super().readline(*args, **kwargs)
 
     def readlines(self):
         return list(self)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -305,11 +305,25 @@ class S3StorageTests(TestCase):
         self.assertEqual(content_str, "")
         file.close()
 
+    def test_storage_open_read_with_newlines(self):
+        """
+        Test opening a file in "r" mode with various newline characters
+        """
+        name = "test_storage_open_read_with_newlines.txt"
+        with io.BytesIO() as temp_file:
+            temp_file.write(b"line1\nline2\r\nmore\rtext\n")
+            temp_file.seek(0)
+            file = self.storage.open(name, "r")
+            file._file = temp_file
+            content_str = file.read()
+            file.close()
+        self.assertEqual(content_str, "line1\nline2\nmore\ntext\n")
+
     def test_storage_open_readlines(self):
         """
         Test readlines with file opened in "r" and "rb" modes
         """
-        name = "test_open_readlines_string.txt"
+        name = "test_storage_open_readlines.txt"
         with io.BytesIO() as temp_file:
             temp_file.write(b"line1\nline2")
             file = self.storage.open(name, "r")
@@ -323,6 +337,19 @@ class S3StorageTests(TestCase):
             file._file = temp_file
             content_lines = file.readlines()
             self.assertEqual(content_lines, [b"line1\n", b"line2"])
+
+    def test_storage_open_readlines_with_newlines(self):
+        """
+        Test readlines with file opened in "r" mode with various newline characters
+        """
+        name = "test_storage_open_readlines_with_newlines.txt"
+        with io.BytesIO() as temp_file:
+            temp_file.write(b"line1\nline2\r\nmore\rtext")
+            file = self.storage.open(name, "r")
+            file._file = temp_file
+
+            content_lines = file.readlines()
+            self.assertEqual(content_lines, ['line1\n', 'line2\n', 'more\n', 'text'])
 
     def test_storage_open_write(self):
         """

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -305,52 +305,6 @@ class S3StorageTests(TestCase):
         self.assertEqual(content_str, "")
         file.close()
 
-    def test_storage_open_read_with_newlines(self):
-        """
-        Test opening a file in "r" mode with various newline characters
-        """
-        name = "test_storage_open_read_with_newlines.txt"
-        with io.BytesIO() as temp_file:
-            temp_file.write(b"line1\nline2\r\nmore\rtext\n")
-            temp_file.seek(0)
-            file = self.storage.open(name, "r")
-            file._file = temp_file
-            content_str = file.read()
-            file.close()
-        self.assertEqual(content_str, "line1\nline2\nmore\ntext\n")
-
-    def test_storage_open_readlines(self):
-        """
-        Test readlines with file opened in "r" and "rb" modes
-        """
-        name = "test_storage_open_readlines.txt"
-        with io.BytesIO() as temp_file:
-            temp_file.write(b"line1\nline2")
-            file = self.storage.open(name, "r")
-            file._file = temp_file
-
-            content_lines = file.readlines()
-            self.assertEqual(content_lines, ["line1\n", "line2"])
-
-            temp_file.seek(0)
-            file = self.storage.open(name, "rb")
-            file._file = temp_file
-            content_lines = file.readlines()
-            self.assertEqual(content_lines, [b"line1\n", b"line2"])
-
-    def test_storage_open_readlines_with_newlines(self):
-        """
-        Test readlines with file opened in "r" mode with various newline characters
-        """
-        name = "test_storage_open_readlines_with_newlines.txt"
-        with io.BytesIO() as temp_file:
-            temp_file.write(b"line1\nline2\r\nmore\rtext")
-            file = self.storage.open(name, "r")
-            file._file = temp_file
-
-            content_lines = file.readlines()
-            self.assertEqual(content_lines, ['line1\n', 'line2\n', 'more\n', 'text'])
-
     def test_storage_open_write(self):
         """
         Test opening a file in write mode
@@ -1171,6 +1125,48 @@ class S3StorageTestsWithMoto(TestCase):
             s3_object_fetched["ContentType"],
             s3.S3Storage.default_content_type,
         )
+
+    def test_storage_open_read_with_newlines(self):
+        """
+        Test opening a file in "r" and "rb" mode with various newline characters
+        """
+        name = "test_storage_open_read_with_newlines.txt"
+        with io.BytesIO() as temp_file:
+            temp_file.write(b"line1\nline2\r\nmore\rtext\n")
+            self.storage.save(name, temp_file)
+            file = self.storage.open(name, "r")
+            content_str = file.read()
+            file.close()
+        self.assertEqual(content_str, "line1\nline2\nmore\ntext\n")
+
+        with io.BytesIO() as temp_file:
+            temp_file.write(b"line1\nline2\r\nmore\rtext\n")
+            self.storage.save(name, temp_file)
+            file = self.storage.open(name, "rb")
+            content_str = file.read()
+            file.close()
+        self.assertEqual(content_str, b"line1\nline2\r\nmore\rtext\n")
+
+    def test_storage_open_readlines_with_newlines(self):
+        """
+        Test readlines with file opened in "r" and "rb" mode with various newline characters
+        """
+        name = "test_storage_open_readlines_with_newlines.txt"
+        with io.BytesIO() as temp_file:
+            temp_file.write(b"line1\nline2\r\nmore\rtext")
+            self.storage.save(name, temp_file)
+            file = self.storage.open(name, "r")
+            content_lines = file.readlines()
+            file.close()
+        self.assertEqual(content_lines, ['line1\n', 'line2\n', 'more\n', 'text'])
+
+        with io.BytesIO() as temp_file:
+            temp_file.write(b"line1\nline2\r\nmore\rtext")
+            self.storage.save(name, temp_file)
+            file = self.storage.open(name, "rb")
+            content_lines = file.readlines()
+            file.close()
+        self.assertEqual(content_lines, [b'line1\n', b'line2\r\n', b'more\r', b'text'])
 
 
 class TestBackwardsNames(TestCase):

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -19,7 +19,7 @@ from django.core.files.base import File
 from django.test import TestCase
 from django.test import override_settings
 from django.utils.timezone import is_aware
-from moto import mock_aws
+from moto import mock_s3
 
 from storages.backends import s3
 from tests.utils import NonSeekableContentFile
@@ -1040,10 +1040,10 @@ class S3FileTests(TestCase):
         self.assertIsNone(f._multipart)
 
 
-@mock_aws
+@mock_s3
 class S3StorageTestsWithMoto(TestCase):
     """
-    Using mock_aws as a class decorator automatically decorates methods,
+    Using mock_s3 as a class decorator automatically decorates methods,
     but NOT classmethods or staticmethods.
     """
 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -19,7 +19,7 @@ from django.core.files.base import File
 from django.test import TestCase
 from django.test import override_settings
 from django.utils.timezone import is_aware
-from moto import mock_s3
+from moto import mock_aws
 
 from storages.backends import s3
 from tests.utils import NonSeekableContentFile
@@ -1059,10 +1059,10 @@ class S3FileTests(TestCase):
         self.assertIsNone(f._multipart)
 
 
-@mock_s3
+@mock_aws
 class S3StorageTestsWithMoto(TestCase):
     """
-    Using mock_s3 as a class decorator automatically decorates methods,
+    Using mock_aws as a class decorator automatically decorates methods,
     but NOT classmethods or staticmethods.
     """
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,8 @@ deps =
 	django4.2: django~=4.2.0
 	django5.0: django~=5.0b1
 	djangomain: https://github.com/django/django/archive/main.tar.gz
-	moto>=5.0
+	# 5 changes API a bit and also requires python 3.8+, so keep this until we drop py 3.7
+	moto<5
 	pytest
 	pytest-cov
 	rsa

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
 	DJANGO_SETTINGS_MODULE = tests.settings
 	PYTHONWARNINGS = always
 	PYTHONDONTWRITEBYTECODE = 1
-commands = pytest --cov=storages tests/ {posargs}
+commands = pytest --cov=storages {posargs}
 deps =
 	cryptography
 	django3.2: django~=3.2.9
@@ -41,3 +41,8 @@ commands =
 	ruff .
 	black --check .
 skip_install = true
+
+[pytest]
+# Default test paths to run, if no other paths are specified on the CLI
+# (specify paths after a -- e.g. `tox -- tests/test_s3.py`)
+testpaths = tests/

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
 	django4.2: django~=4.2.0
 	django5.0: django~=5.0b1
 	djangomain: https://github.com/django/django/archive/main.tar.gz
-	moto
+	moto>=5.0
 	pytest
 	pytest-cov
 	rsa


### PR DESCRIPTION
This fixes the newline issue at #1351. Files open in text mode (`r`) now get newline handling consistent with other python file-like objects.

run these specific tests with

```
tox -e py3.10-django4.2 -- tests/test_s3.py -k newlines
```