### PR TITLE
Don't look at user's AWS config when running tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,10 @@ setenv =
 	DJANGO_SETTINGS_MODULE = tests.settings
 	PYTHONWARNINGS = always
 	PYTHONDONTWRITEBYTECODE = 1
-commands = pytest --cov=storages {posargs}
+	# Use a non-existent file to prevent boto3 from loading
+	# any configuration from the user's environment
+	AWS_CONFIG_FILE = {toxinidir}/tests/no_such_file.conf
+commands = pytest --cov=storages tests/ {posargs}
 deps =
 	cryptography
 	django3.2: django~=3.2.9


### PR DESCRIPTION
If you set up a different config file locally and then run tests, the tests easily fail, and who knows what it's doing with user's credentials :/