### PR TITLE
SFTP_BASE_URL and sftp.exists fix. #1363

### DIFF
--- a/docs/backends/sftp.rst
+++ b/docs/backends/sftp.rst
@@ -117,7 +117,7 @@ Settings
 
   Absolute path of know host file, if it isn't set ``"~/.ssh/known_hosts"`` will be used.
 
-``base_url``
+``base_url`` or ``SFTP_BASE_URL``
 
   Default: Django ``MEDIA_URL`` setting
 


### PR DESCRIPTION
PR for issue: https://github.com/jschneier/django-storages/issues/1363

Adds: SFTP_BASE_URL
Fixes: SFTPStorage.exists()

Plus a bit of logic so we only check for a parent directory's existence if there's a parent path provided.

I haven't managed to get tox to run, so if I could get some help with that, I can write a test or two for this.