### PR TITLE
SFTP_BASE_URL

### DIFF
--- a/docs/backends/sftp.rst
+++ b/docs/backends/sftp.rst
@@ -117,7 +117,7 @@ Settings
 
   Absolute path of know host file, if it isn't set ``"~/.ssh/known_hosts"`` will be used.
 
-``base_url``
+``base_url`` or ``SFTP_BASE_URL``
 
   Default: Django ``MEDIA_URL`` setting
 

--- a/storages/backends/sftpstorage.py
+++ b/storages/backends/sftpstorage.py
@@ -49,7 +49,7 @@ class SFTPStorage(ClosingContextManager, BaseStorage):
             "gid": setting("SFTP_STORAGE_GID"),
             "known_host_file": setting("SFTP_KNOWN_HOST_FILE"),
             "root_path": setting("SFTP_STORAGE_ROOT", ""),
-            "base_url": setting("MEDIA_URL"),
+            "base_url": setting("SFTP_BASE_URL") or setting("MEDIA_URL"),
         }
 
     def _connect(self):


### PR DESCRIPTION
This PR adds SFTP_BASE_URL so that it can be used alongside other kinds of storages. 