### PR TITLE
Fix Incorrect URL Format in S3Storage.url Method

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -657,7 +657,7 @@ class S3Storage(CompressStorageMixin, BaseStorage):
             expire = self.querystring_expire
 
         if self.custom_domain:
-            url = "{}//{}/{}{}".format(
+            url = "{}://{}/{}{}".format(
                 self.url_protocol,
                 self.custom_domain,
                 filepath_to_uri(name),


### PR DESCRIPTION
This PR should  solve  the issue with the ` url ` method of the S3Storage class generates URLs with an incorrect format by omitting the colon (":") after the protocol.

**PR solution** - The string formatter in the `url `method has been corrected to include the colon after the protocol. The previous formatter `"{}//{}/{}{}"` was changed to `"{}://{}/{}{}"` to properly format the URL.