### PR TITLE
Drop AWS_S3_ env variables in docs not working

### DIFF
--- a/docs/backends/amazon-S3.rst
+++ b/docs/backends/amazon-S3.rst
@@ -50,7 +50,6 @@ searches for them:
 #. ``session_profile`` or ``AWS_S3_SESSION_PROFILE``
 #. ``access_key`` or ``AWS_S3_ACCESS_KEY_ID`` or ``AWS_S3_SECRET_ACCESS_KEY``
 #. ``secret_key`` or ``AWS_ACCESS_KEY_ID`` or ``AWS_SECRET_ACCESS_KEY``
-#. The environment variables AWS_S3_ACCESS_KEY_ID and AWS_S3_SECRET_ACCESS_KEY
 #. The environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
 #. Use Boto3's default session
 


### PR DESCRIPTION
Spent 40 minutes to figure out the reason for an `Invalid token` raised when trying to upload a file on Scaleway object storage.