### PR TITLE
Fixing the problem that arises when using --clear in python manage.py collectstatic

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -268,6 +268,15 @@ class AzureStorage(BaseStorage):
         return super().get_available_name(name, max_length)
 
     def exists(self, name):
+        if not name:
+            try:
+                self.service_client.get_container_client(
+                    self.azure_container
+                )
+                return True
+            except:
+                return False
+
         blob_client = self.client.get_blob_client(self._get_valid_path(name))
         return blob_client.exists()
 
@@ -390,16 +399,9 @@ class AzureStorage(BaseStorage):
 
     def listdir(self, path=""):
         """
-        Return directories and files for a given path.
-        Leave the path empty to list the root.
-        Order of dirs and files is undefined.
+        Return all files for a given path.
+        Given that Azure can't return paths it only returns files.
+        Works great for our little adventure.
         """
-        files = []
-        dirs = set()
-        for name in self.list_all(path):
-            n = name[len(path) :]
-            if "/" in n:
-                dirs.add(n.split("/", 1)[0])
-            else:
-                files.append(n)
-        return list(dirs), files
+        
+        return [], self.list_all(path)

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -269,13 +269,7 @@ class AzureStorage(BaseStorage):
 
     def exists(self, name):
         if not name:
-            try:
-                self.service_client.get_container_client(
-                    self.azure_container
-                )
-                return True
-            except:
-                return False
+            return True
 
         blob_client = self.client.get_blob_client(self._get_valid_path(name))
         return blob_client.exists()

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -397,5 +397,5 @@ class AzureStorage(BaseStorage):
         Given that Azure can't return paths it only returns files.
         Works great for our little adventure.
         """
-        
+
         return [], self.list_all(path)

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -388,45 +388,14 @@ class AzureStorageTest(TestCase):
         )
         self.storage._custom_client.list_blobs.assert_not_called()
 
-        self.assertEqual(len(dirs), 2)
-        for directory in ["some", "other"]:
-            self.assertTrue(
-                directory in dirs,
-                """ "{}" not in directory list "{}".""".format(directory, dirs),
-            )
+        self.assertEqual(len(dirs), 0)
 
-        self.assertEqual(len(files), 2)
-        for filename in ["2.txt", "4.txt"]:
+        self.assertEqual(len(files), 4)
+        for filename in ["2.txt", "4.txt", "other/path/3.txt", "some/path/1.txt"]:
             self.assertTrue(
                 filename in files,
                 """ "{}" not in file list "{}".""".format(filename, files),
             )
-
-    def test_storage_listdir_subdir(self):
-        file_names = ["some/path/1.txt", "some/2.txt"]
-
-        result = []
-        for p in file_names:
-            obj = mock.MagicMock()
-            obj.name = p
-            result.append(obj)
-        self.storage._client.list_blobs.return_value = iter(result)
-        self.storage._custom_client.list_blobs.assert_not_called()
-
-        dirs, files = self.storage.listdir("some/")
-        self.storage._client.list_blobs.assert_called_with(
-            name_starts_with="some/", timeout=20
-        )
-
-        self.assertEqual(len(dirs), 1)
-        self.assertTrue(
-            "path" in dirs, """ "path" not in directory list "{}".""".format(dirs)
-        )
-
-        self.assertEqual(len(files), 1)
-        self.assertTrue(
-            "2.txt" in files, """ "2.txt" not in files list "{}".""".format(files)
-        )
 
     def test_size_of_file(self):
         props = BlobProperties()


### PR DESCRIPTION
There is a ongoing issue with python manage.py collectstatic --clear

Due to Django trying to walk through every dir we just return all the files from the top dir.
That way we don't get a error when Django is trying to walk the files.

Tested with --clear and without --clear.