### PR TITLE
[azure] Allow creation of signed URLs for upload

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,11 +15,13 @@ Azure
 -----
 
 - Fix ``collectstatic --clear`` (`#1403`_)
+- Add ``mode`` kwarg to ``.url()`` to support creation of signed URLs for upload (`#1414`_)
 
 .. _#1399: https://github.com/jschneier/django-storages/pull/1399
 .. _#1381: https://github.com/jschneier/django-storages/pull/1381
 .. _#1402: https://github.com/jschneier/django-storages/pull/1402
 .. _#1403: https://github.com/jschneier/django-storages/pull/1403
+.. _#1414: https://github.com/jschneier/django-storages/pull/1414
 
 
 1.14.3 (2024-05-04)

--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -309,9 +309,10 @@ class AzureStorage(BaseStorage):
         # azure expects time in UTC
         return datetime.utcnow() + timedelta(seconds=expire)
 
-    def url(self, name, expire=None, parameters=None):
+    def url(self, name, expire=None, parameters=None, mode="r"):
         name = self._get_valid_path(name)
         params = parameters or {}
+        permission = BlobSasPermissions.from_string(mode)
 
         if expire is None:
             expire = self.expiration_secs
@@ -326,7 +327,7 @@ class AzureStorage(BaseStorage):
                 name,
                 account_key=self.account_key,
                 user_delegation_key=user_delegation_key,
-                permission=BlobSasPermissions(read=True),
+                permission=permission,
                 expiry=expiry,
                 **params,
             )


### PR DESCRIPTION
Allow creation of signed URLs for upload in AzureStorage (See #1413)