### PR TITLE
Caches Cloudfront Signers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ S3
 - Pull ``AWS_SESSION_TOKEN`` from the environment (`#1399`_)
 - Fix newline handling for text mode files (`#1381`_)
 - Do not sign URLs when ``querystring_auth=False`` e.g public buckets or static files (`#1402`_)
+- Cache CloudFront Signers (`#1417`_)
 
 Azure
 -----
@@ -22,6 +23,7 @@ Azure
 .. _#1402: https://github.com/jschneier/django-storages/pull/1402
 .. _#1403: https://github.com/jschneier/django-storages/pull/1403
 .. _#1414: https://github.com/jschneier/django-storages/pull/1414
+.. _#1417: https://github.com/jschneier/django-storages/pull/1417
 
 
 1.14.3 (2024-05-04)

--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -376,7 +376,9 @@ class S3Storage(CompressStorageMixin, BaseStorage):
     def get_cloudfront_signer(self, key_id, key):
         cache_key = f"{key_id}:{key}"
         if cache_key not in self.__class__._signers:
-            self.__class__._signers[cache_key] = _cloud_front_signer_from_pem(key_id, key)
+            self.__class__._signers[cache_key] = _cloud_front_signer_from_pem(
+                key_id, key
+            )
         return self.__class__._signers[cache_key]
 
     def get_default_settings(self):

--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -376,7 +376,7 @@ class S3Storage(CompressStorageMixin, BaseStorage):
     def get_cloudfront_signer(self, key_id, key):
         cache_key = f"{key_id}:{key}"
         if cache_key not in self.__class__._signers:
-            self._signers[cache_key] = _cloud_front_signer_from_pem(key_id, key)
+            self.__class__._signers[cache_key] = _cloud_front_signer_from_pem(key_id, key)
         return self.__class__._signers[cache_key]
 
     def get_default_settings(self):

--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -311,6 +311,8 @@ class S3Storage(CompressStorageMixin, BaseStorage):
     # settings/args are ignored.
     config = None
 
+    _signers = {}
+
     def __init__(self, **settings):
         omitted = object()
         if not hasattr(self, "cloudfront_signer"):
@@ -372,7 +374,10 @@ class S3Storage(CompressStorageMixin, BaseStorage):
                 self.cloudfront_signer = None
 
     def get_cloudfront_signer(self, key_id, key):
-        return _cloud_front_signer_from_pem(key_id, key)
+        cache_key = f"{key_id}:{key}"
+        if cache_key not in self.__class__._signers:
+            self._signers[cache_key] = _cloud_front_signer_from_pem(key_id, key)
+        return self.__class__._signers[cache_key]
 
     def get_default_settings(self):
         return {

--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -30,6 +30,8 @@ from storages.utils import safe_join
 from storages.utils import setting
 from storages.utils import to_bytes
 
+from typing import Dict
+
 try:
     import boto3.session
     import botocore
@@ -311,7 +313,7 @@ class S3Storage(CompressStorageMixin, BaseStorage):
     # settings/args are ignored.
     config = None
 
-    _signers = {}
+    _signers: Dict[str, str] = {}
 
     def __init__(self, **settings):
         omitted = object()

--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -30,8 +30,6 @@ from storages.utils import safe_join
 from storages.utils import setting
 from storages.utils import to_bytes
 
-from typing import Dict
-
 try:
     import boto3.session
     import botocore
@@ -313,7 +311,7 @@ class S3Storage(CompressStorageMixin, BaseStorage):
     # settings/args are ignored.
     config = None
 
-    _signers: Dict[str, str] = {}
+    _signers = {}  # noqa: RUF012
 
     def __init__(self, **settings):
         omitted = object()


### PR DESCRIPTION
This adds a class-level cache layer in front of cloudfront signers.  

Was debugging slowness on a django repo with 50 s3 storage fields, and the expensive `load_pem_private_key` was called for every field implementing the S3Storage class, even though the id/key was the same for each field.  This added a full 3 seconds to server start/restart time.

Caching seems desirable for all users of the library, will provide an instant speed benefit for current users, and will keep django apps snappy and responsive no matter how many filefields they add to their django project. 