### PR TITLE
Fix: Generate Signed Urls through a service account by providing service_account_email and access_token

### DIFF
--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -57,7 +57,7 @@ In most cases, the default service accounts are not sufficient to read/write and
 present when generating signed urls. The service account private key is unavailable when running on a compute service.
 Compute Services (App Engine, Cloud Run, Cloud Functions, Compute Engine...) fetch `access tokens from the metadata server <https://cloud.google.com/docs/authentication/application-default-credentials>`__ .
 These services do not have access to the service account private key. This means that when trying to sign data in these services,
-you **MUST** use one of the Cloud IAM sign functions (SignBlob, SignJwt) to sign data and directly signing data isn't possible by any means.
+you **MUST** use Cloud IAM sign function (SignBlob) to sign data and directly signing data isn't possible by any means.
 
 Luckily this can be worked around by passing `service_account_email` and `access_token` to the generate_signed_url function.
 When both of those args are provided, generate_signed_url will use the IAM SignBlob API to sign the url and no private key file is needed.
@@ -233,7 +233,7 @@ Settings
 
   default: ``False``
 
-  Signing urls requires a service account key file to be present in the env or IAM SignBlob/JWT API call
+  Signing urls requires a service account key file to be present in the env or IAM SignBlob API call
   through a service account email and access_token. Certain GCP services (ex: Compute services) don't have access to the key file in the env.
   This setting needs to be `True` when running on such services as they fetch access tokens from metadata server instead of having key files
   If using `v4` of generate_signed_url, `google-cloud-storage>=v1.36.1 <https://github.com/googleapis/python-storage/releases/tag/v1.36.1>`_ is required .

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -59,6 +59,23 @@ For development use cases, or other instances outside Google infrastructure:
 #. Ensure the key is mounted/available to your running Django app.
 #. Set an environment variable of GOOGLE_APPLICATION_CREDENTIALS to the path of the json file.
 
+**Note Regarding Authentication**
+
+There is currently a limitation in the GCS client for Python which by default requires a service account private key file to be
+present when generating signed urls. **This is important to realize**. The service account private key is unavailable when running on a compute service.
+Compute Services (App Engine, Cloud Run, Cloud Functions, Compute Engine...) fetch access tokens from a metadata service.
+Those services do not have access to the service account private key. That means you must use one of the IAM sign functions (SignBlob, SignJwt)
+to have Google sign using their managed private key. This means, you can't directly sign data. You must use the Cloud IAM API to do signing.
+
+Luckily this can be worked around by passing `service_account_email` and `access_token` to the generate_signed_url function.
+When both of those args are provided, generate_signed_url will use the IAM service SignBlob API to sign the url and no private key file is needed.
+
+Google also now recommends avoiding service account json key files as they are insecure, risky and hard to manage. This avoids the need for that
+when developing locally.
+
+`GS_SA_EMAIL` will be what is what provided to generate_signed_url param: service_account_email. Note, this service account will need credentials to
+sign and download/upload files as necessary. Read more `here <https://cloud.google.com/storage/docs/access-control/signing-urls-with-helpers>`__
+
 Alternatively, you can use the setting ``credentials`` or ``GS_CREDENTIALS`` as described below.
 
 
@@ -219,3 +236,14 @@ Settings
   It supports `timedelta`, `datetime`, or `integer` seconds since epoch time.
 
   Note: The maximum value for this option is 7 days (604800 seconds) in version `v4` (See this `Github issue  <https://github.com/googleapis/python-storage/issues/456#issuecomment-856884993>`_)
+
+``sa_email`` or ``GS_SA_EMAIL``
+
+  default: ``''``
+
+  This is the service account email to be used for signing the url. Signing urls either requires a service account key file to be present in the env or IAM API call.
+  Compute services (App Engine, Cloud Run, Cloud Functions, Compute Engine...) for example don't have access to the key file in the env. Providing, sa_email, will use
+  the IAM API in order to sign the URL thus avoiding the need for a private service account json key file.
+
+  As above please note that, Default Google Compute Engine (GCE) Service accounts are
+  `unable to sign urls <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -68,7 +68,7 @@ Those services do not have access to the service account private key. That means
 to have Google sign using their managed private key. This means, you can't directly sign data. You must use the Cloud IAM API to do signing.
 
 Luckily this can be worked around by passing `service_account_email` and `access_token` to the generate_signed_url function.
-When both of those args are provided, generate_signed_url will use the IAM service SignBlob API to sign the url and no private key file is needed.
+When both of those args are provided, generate_signed_url will use the IAM SignBlob API to sign the url and no private key file is needed.
 
 Google also now recommends avoiding service account json key files as they are insecure, risky and hard to manage. This avoids the need for that
 when developing locally.
@@ -239,11 +239,9 @@ Settings
 
 ``sa_email`` or ``GS_SA_EMAIL``
 
-  default: ``''``
+  default: ``None``
 
-  This is the service account email to be used for signing the url. Signing urls either requires a service account key file to be present in the env or IAM API call.
-  Compute services (App Engine, Cloud Run, Cloud Functions, Compute Engine...) for example don't have access to the key file in the env. Providing, sa_email, will use
-  the IAM API in order to sign the URL thus avoiding the need for a private service account json key file.
-
-  As above please note that, Default Google Compute Engine (GCE) Service accounts are
-  `unable to sign urls <https://googlecloudplatform.github.io/google-cloud-python/latest/storage/blobs.html#google.cloud.storage.blob.Blob.generate_signed_url>`_.
+  This is the service account email to be used for signing the url. Signing urls requires a service account key file to be present in the env or IAM SignBlob/JWT API call
+  through a provided service account email. Compute services (App Engine, Cloud Run, Cloud Functions, Compute Engine...) for example don't have access to the key file in the env.
+  Providing, sa_email, will use the IAM API in order to sign the URL thus avoiding the need for a private service account json key file. If using `v4` of generate_signed_url,
+  `google-cloud-storage>=v1.36.1 <https://github.com/googleapis/python-storage/releases/tag/v1.36.1>`_ is required .

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -237,8 +237,7 @@ Settings
 
   Signing urls requires a service account key file to be present in the env or IAM SignBlob API call
   through a service account email and access_token. Certain GCP services (ex: Compute services) don't have access to the key file in the env.
-  This setting needs to be `True` when running on such services as they fetch access tokens from metadata server instead of having key files
-  If using `v4` of generate_signed_url, `google-cloud-storage>=v1.36.1 <https://github.com/googleapis/python-storage/releases/tag/v1.36.1>`_ is required .
+  This setting needs to be `True` when running on such services as they fetch access tokens from metadata server instead of having key files.
 
 ``sa_email`` or ``GS_SA_EMAIL``
 
@@ -246,5 +245,4 @@ Settings
 
   The service account email to use for signing url. If a service account is being used for authentication (attached to your service),
   this setting doesn't need to be provided unless you want to use another service account than the one attached to your service for signing urls.
-  Can be used in local development env as well to sign using sa_email instead of the user credentials or keeping a insecure service account key file
-  If using `v4` of generate_signed_url, `google-cloud-storage>=v1.36.1 <https://github.com/googleapis/python-storage/releases/tag/v1.36.1>`_ is required .
+  Can be used in local development env as well to sign using sa_email instead of the user credentials or keeping a insecure service account key file.

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -61,6 +61,8 @@ you **MUST** use Cloud IAM sign function (SignBlob) to sign data and directly si
 
 Luckily this can be worked around by passing `service_account_email` and `access_token` to the generate_signed_url function.
 When both of those args are provided, generate_signed_url will use the IAM SignBlob API to sign the url and no private key file is needed.
+In order to enable this, use setting `iam_blob_sign` and the optional `sa_email` (if providing a service account email different than the one attached
+to GCP Environment).
 
 Last resort you can still use the service account key file for authentication (not recommended by Google):
 

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -59,6 +59,8 @@ In most cases, the default service accounts are not sufficient to read/write and
 Settings for Signed Urls
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. _iam-sign-blob-api:
+
 IAM Sign Blob API
 *****************
 
@@ -253,13 +255,10 @@ Settings
 
   default: ``False``
 
-  Generate signed urls using the IAM Sign Blob API which doesn't require a service account private key file to be present in the env.
-  Set this setting to ``True`` if storing private key file isn't viable and you would rather generate signed urls using the IAM Sign Blob API.
+  Generate signed urls using the IAM Sign Blob API. See :ref:`iam-sign-blob-api` for more info.
 
 ``sa_email`` or ``GS_SA_EMAIL``
 
   default: ``None``
 
-  Allows override of the service account to be used for generating signed urls using the IAM Sign Blob API.
-  This setting is completely optional and should be used if the service account associated with your service/app isn't
-  the one with the permissions to SignBlob. Also helpful for development use cases where private key file is not recommended.
+  Override the service account used for generating signed urls using the IAM Sign Blob API. See :ref:`iam-sign-blob-api` for more info.

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -1,7 +1,7 @@
 Google Cloud Storage
 ====================
 
-This backend provides Django File API for `Google Cloud Storage <https://cloud.google.com/storage/>`_
+This backend implements the Django File API for `Google Cloud Storage <https://cloud.google.com/storage/>`_
 using the Python library provided by Google.
 
 
@@ -42,50 +42,57 @@ To put static files on GCS via ``collectstatic`` on Django >= 4.2 you'd include 
 The settings documented in the following sections include both the key for ``OPTIONS`` (and subclassing) as
 well as the global value. Given the significant improvements provided by the new API, migration is strongly encouraged.
 
+.. _auth-settings:
+
 Authentication Settings
 ~~~~~~~~~~~~~~~~~~~~~~~
-By default, this library will try to use the credentials associated with the
-current Google Cloud infrastructure/environment for authentication.
+By default, this library will try to use the credentials associated with the current Google Cloud infrastructure/environment for authentication.
 
 In most cases, the default service accounts are not sufficient to read/write and sign files in GCS, so you will need to create a dedicated service account:
 
 #. Create a service account. (`Google Getting Started Guide <https://cloud.google.com/docs/authentication/getting-started>`__)
 #. Make sure your service account has access to the bucket and appropriate permissions. (`Using IAM Permissions <https://cloud.google.com/storage/docs/access-control/using-iam-permissions>`__)
 #. Ensure this service account is associated to the type of compute being used (Google Compute Engine (GCE), Google Kubernetes Engine (GKE), Google Cloud Run (GCR), etc)
-#. If your django app only handles ``publicRead`` storage objects then, above steps are all that is required
-#. If your django app handles signed (expiring) urls, then read through the options in the ``Settings for Signed Urls`` section
-
-Last resort you can still use the service account key file for authentication (not recommended by Google):
-
-#. Create the key and download ``your-project-XXXXX.json`` file.
-#. Ensure the key is mounted/available to your running Django app.
-#. Set an environment variable of GOOGLE_APPLICATION_CREDENTIALS to the path of the json file.
-
-Alternatively, you can use the setting ``credentials`` or ``GS_CREDENTIALS`` as described below.
+#. If your app only handles ``publicRead`` storage objects then the above steps are all that is required
+#. If your app handles signed (expiring) urls, then read through the options in the ``Settings for Signed Urls`` in the following section
 
 Settings for Signed Urls
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
+IAM Sign Blob API
+*****************
 
 .. note::
    There is currently a limitation in the GCS client for Python which by default requires a
    service account private key file to be present when generating signed urls. The service
    account private key file is unavailable when running on compute services. Compute Services
-   (App Engine, Cloud Run, Cloud Functions, Compute Engine...) fetch `access tokens from the metadata server
+   (App Engine, Cloud Run, Cloud Functions, Compute Engine, etc) fetch `access tokens from the metadata server
    <https://cloud.google.com/docs/authentication/application-default-credentials>`__
 
-Due to the above limitation, currently the only way to generate signed url without having the private key file mounted
+Due to the above limitation, currently the only way to generate a signed url without having the private key file mounted
 in the env is through the IAM Sign Blob API.
 
-IAM Sign Blob API doesn't require a private key file to be present in the env, but it does have
-`quota limits <https://cloud.google.com/iam/quotas#quotas>`__ which could be a deal-breaker. In order to enable this,
-the setting ``GS_IAM_SIGN_BLOB`` (default=`False`) needs to be `True`. When this setting is enabled,
-signed urls are generated through the IAM SignBlob API using the attached service account email and access_token instead
-of the credentials in the key file.
+.. note::
+   The IAM Sign Blob API has `quota limits <https://cloud.google.com/iam/quotas#quotas>`__ which could be a deal-breaker.
 
-``GS_IAM_SIGN_BLOB`` setting is also complemented with the optional setting ``GS_SA_EMAIL``. This setting allows
-you to override the service account to be used to generate the signed url if it is different from the one attached
-to your env. Also useful for local/development use cases where the metadata server isn't available and storing private key
-files is dangerous.
+To use the IAM Sign Blob API set ``iam_sign_blob`` or ``GS_IAM_SIGN_BLOB`` to ``True``. When this setting is enabled,
+signed urls are generated through the IAM SignBlob API using the attached service account email and access_token
+instead of the credentials in the key file.
+
+An additional optional setting ``sa_email`` or ``GS_SA_EMAIL`` is also available. It allows you to override the service account
+used to generate the signed url if it is different from the one attached to your env. It's also useful for local/development
+use cases where the metadata server isn't available and storing private key files is dangerous.
+
+Mounted Private Key
+********************
+
+If the above method is not sufficient for your needs you can still use the service account key file for authentication (not recommended by Google):
+
+#. Create the key and download ``your-project-XXXXX.json`` file.
+#. Ensure the key is mounted/available to your running app.
+#. Set an environment variable of ``GOOGLE_APPLICATION_CREDENTIALS`` to the path of the JSON file.
+
+Alternatively, you can set ``credentials`` or ``GS_CREDENTIALS`` to the path of the JSON file.
 
 Settings
 ~~~~~~~~
@@ -114,13 +121,11 @@ Settings
 
   The list of content types to be gzipped when ``gzip`` is ``True``.
 
-.. _gs-creds:
-
 ``credentials`` or ``GS_CREDENTIALS``
 
   default: ``None``
 
-  The OAuth 2 credentials to use for the connection. If unset, falls back to the default inferred from the environment
+  The OAuth2 credentials to use for the connection. Be sure to read through all of :ref:`auth-settings` first.
   (i.e. ``GOOGLE_APPLICATION_CREDENTIALS``)::
 
     from google.oauth2 import service_account
@@ -234,8 +239,7 @@ Settings
   default: ``timedelta(seconds=86400)``)
 
   The time that a generated URL is valid before expiration. The default is 1 day.
-  Public files will return a url that does not expire. Files will be signed by
-  the credentials provided to django-storages (See :ref:`GS Credentials <gs-creds>`).
+  Public files will return a url that does not expire.
 
   Note: Default Google Compute Engine (GCE) Service accounts are
   `unable to sign urls <https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_generate_signed_url>`_.

--- a/docs/backends/gcloud.rst
+++ b/docs/backends/gcloud.rst
@@ -250,7 +250,7 @@ Settings
   default: ``False``
 
   Generate signed urls using the IAM Sign Blob API which doesn't require a service account private key file to be present in the env.
-  Set this setting to ``True`` if storing private key file isn't viable and would rather generate signed urls using an API.
+  Set this setting to ``True`` if storing private key file isn't viable and you would rather generate signed urls using the IAM Sign Blob API.
 
 ``sa_email`` or ``GS_SA_EMAIL``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dropbox = [
   "dropbox>=7.2.1",
 ]
 google = [
-  "google-cloud-storage>=1.32",
+  "google-cloud-storage>=1.36.1",
 ]
 libcloud = [
   "apache-libcloud",

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -158,7 +158,6 @@ class GoogleCloudStorage(BaseStorage):
                     scopes=['https://www.googleapis.com/auth/cloud-platform']
                 )
             self._client = Client(project=self.project_id, credentials=self.credentials)
-
         return self._client
 
     @property

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -155,7 +155,7 @@ class GoogleCloudStorage(BaseStorage):
         if self._client is None:
             if self.iam_sign_blob and not self.credentials:
                 self.credentials, self.project_id = auth.default(
-                    scopes=['https://www.googleapis.com/auth/cloud-platform']
+                    scopes=["https://www.googleapis.com/auth/cloud-platform"]
                 )
             self._client = Client(project=self.project_id, credentials=self.credentials)
         return self._client

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -333,13 +333,13 @@ class GoogleCloudStorage(BaseStorage):
                 quoted_name=_quote(name, safe=b"/~"),
             )
         else:
-            params = parameters or {}
             default_params = {
                 "bucket_bound_hostname": self.custom_endpoint,
                 "expiration": self.expiration,
                 "version": "v4",
             }
-            
+            params = parameters or {}
+
             if self.iam_sign_blob:
                 if not hasattr(self.credentials, "service_account_email") and not self.sa_email:
                     raise AttributeError(

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -153,13 +153,7 @@ class GoogleCloudStorage(BaseStorage):
     @property
     def client(self):
         if self._client is None:
-            if self.project_id is None or self.credentials is None:
-                self.credentials, self.project_id = auth.default(
-                    scopes=['https://www.googleapis.com/auth/cloud-platform']
-                )
             self._client = Client(project=self.project_id, credentials=self.credentials)
-        if self.credentials and self.credentials.token_state != TokenState.FRESH:
-            self.credentials.refresh(requests.Request())
         return self._client
 
     @property
@@ -341,17 +335,9 @@ class GoogleCloudStorage(BaseStorage):
             params = parameters or {}
 
             if self.iam_sign_blob:
-                if not hasattr(self.credentials, "service_account_email") and not self.sa_email:
-                    raise AttributeError(
-                        "Sign Blob API requires service_account_email to be available "
-                        "through ADC or setting `sa_email`"
-                    )
-                if hasattr(self.credentials, "service_account_email"):
-                    default_params["service_account_email"] = self.credentials.service_account_email
-                # sa_email has the final say of which service_account_email to be used for signing if provided
-                if self.sa_email:
-                    default_params["service_account_email"] = self.sa_email
-                default_params["access_token"] = self.credentials.token
+                service_account_email, access_token = self._get_iam_sign_blob_params()
+                default_params["service_account_email"] = service_account_email
+                default_params["access_token"] = access_token
 
             for key, value in default_params.items():
                 if value and key not in params:
@@ -364,3 +350,27 @@ class GoogleCloudStorage(BaseStorage):
         if self.file_overwrite:
             return get_available_overwrite_name(name, max_length)
         return super().get_available_name(name, max_length)
+    
+    def _get_iam_sign_blob_params(self):
+        credentials, _ = auth.default(
+            scopes=['https://www.googleapis.com/auth/cloud-platform']
+        )
+        if credentials and credentials.token_state != TokenState.FRESH:
+            credentials.refresh(requests.Request())
+
+        try:
+            service_account_email = credentials.service_account_email
+        except AttributeError:
+            service_account_email = None
+
+        # sa_email has the final say of which service_account_email to be used for signing if provided
+        if self.sa_email:
+            service_account_email = self.sa_email
+
+        if not service_account_email:
+            raise AttributeError(
+                "Sign Blob API requires service_account_email to be available "
+                "through ADC or setting `sa_email`"
+            )
+
+        return service_account_email, credentials.token

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -154,11 +154,12 @@ class GoogleCloudStorage(BaseStorage):
                 self.credentials, self.project_id = auth.default(
                     scopes=['https://www.googleapis.com/auth/cloud-platform']
                 )
-                if not self.credentials.token_state == TokenState.FRESH:
-                    self.credentials.refresh(requests.Request())
                 if not hasattr(self.credentials, "service_account_email") and self.sa_email:
                     self.credentials.service_account_email = self.sa_email
             self._client = Client(project=self.project_id, credentials=self.credentials)
+
+        if self.credentials and self.credentials.token_state != TokenState.FRESH:
+            self.credentials.refresh(requests.Request())
         return self._client
 
     @property
@@ -336,7 +337,7 @@ class GoogleCloudStorage(BaseStorage):
             default_params = {
                 "bucket_bound_hostname": self.custom_endpoint,
                 "expiration": self.expiration,
-                "version": "v4"
+                "version": "v4",
             }
             if hasattr(self.credentials, "service_account_email"):
                 default_params["access_token"] = self.credentials.token

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -21,8 +21,8 @@ from storages.utils import to_bytes
 
 try:
     from google import auth
-    from google.auth.transport import requests
     from google.auth.credentials import TokenState
+    from google.auth.transport import requests
     from google.cloud.exceptions import NotFound
     from google.cloud.storage import Blob
     from google.cloud.storage import Client
@@ -364,7 +364,7 @@ class GoogleCloudStorage(BaseStorage):
         except AttributeError:
             service_account_email = None
 
-        # sa_email has the final say of which service_account_email to be used for signing if provided
+        # sa_email has final say of service_account used to sign url if provided
         if self.sa_email:
             service_account_email = self.sa_email
 

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -354,7 +354,7 @@ class GoogleCloudStorage(BaseStorage):
         if self.file_overwrite:
             return get_available_overwrite_name(name, max_length)
         return super().get_available_name(name, max_length)
-    
+
     def _get_iam_sign_blob_params(self):
         if self.credentials.token_state != TokenState.FRESH:
             self.credentials.refresh(requests.Request())

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -37,6 +37,7 @@ class GCloudStorageTests(GCloudTestCase):
         """
         data = b"This is some test read data."
 
+        self.storage._client = mock.MagicMock()
         with self.storage.open(self.filename) as f:
             self.storage._client.bucket.assert_called_with(self.bucket_name)
             self.storage._bucket.get_blob.assert_called_with(
@@ -50,6 +51,7 @@ class GCloudStorageTests(GCloudTestCase):
         data = b"This is some test read data."
         num_bytes = 10
 
+        self.storage._client = mock.MagicMock()
         with self.storage.open(self.filename) as f:
             self.storage._client.bucket.assert_called_with(self.bucket_name)
             self.storage._bucket.get_blob.assert_called_with(
@@ -108,6 +110,7 @@ class GCloudStorageTests(GCloudTestCase):
         data = "This is some test content."
         content = ContentFile(data)
 
+        self.storage._client = mock.MagicMock()
         self.storage.save(self.filename, content)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -125,6 +128,7 @@ class GCloudStorageTests(GCloudTestCase):
         filename = "ủⓝï℅ⅆℇ.txt"
         content = ContentFile(data)
 
+        self.storage._client = mock.MagicMock()
         self.storage.save(filename, content)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -146,7 +150,7 @@ class GCloudStorageTests(GCloudTestCase):
         # 'projectPrivate', 'bucketOwnerRead', 'bucketOwnerFullControl',
         # 'private', 'authenticatedRead', 'publicRead', 'publicReadWrite'
         self.storage.default_acl = "publicRead"
-
+        self.storage._client = mock.MagicMock()
         self.storage.save(filename, content)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -160,6 +164,7 @@ class GCloudStorageTests(GCloudTestCase):
         )
 
     def test_delete(self):
+        self.storage._client = mock.MagicMock()
         self.storage.delete(self.filename)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -185,6 +190,7 @@ class GCloudStorageTests(GCloudTestCase):
 
     def test_exists_bucket(self):
         # exists('') should return True if the bucket exists
+        self.storage._client = mock.MagicMock()
         self.assertTrue(self.storage.exists(""))
 
     def test_listdir(self):
@@ -367,6 +373,7 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage.default_acl = "publicRead"
         url = "{}/{}".format(self.storage.custom_endpoint, self.filename)
+        self.storage._client = mock.MagicMock()
         self.assertEqual(self.storage.url(self.filename), url)
 
         bucket_name = "hyacinth"
@@ -410,6 +417,7 @@ class GCloudStorageTests(GCloudTestCase):
             GS_OBJECT_PARAMETERS={"cache_control": "public, max-age=604800"}
         ):
             self.storage = gcloud.GoogleCloudStorage(bucket_name=self.bucket_name)
+            self.storage._client = mock.MagicMock()
             self.storage.save(filename, content)
             bucket = self.storage.client.bucket(self.bucket_name)
             blob = bucket.get_blob(filename)
@@ -423,6 +431,7 @@ class GCloudStorageTests(GCloudTestCase):
         content = ContentFile("I should be gzip'd")
 
         # When
+        self.storage._client = mock.MagicMock()
         self.storage.save(name, content)
         self.storage.save("test_storage_save_2.css", content)
 
@@ -524,6 +533,7 @@ class GoogleCloudGzipClientTests(GCloudTestCase):
         patcher = mock.patch("google.cloud.storage.Bucket.get_blob", return_value=blob)
         try:
             patcher.start()
+            self.storage._client = mock.MagicMock()
             self.storage.save(name, content)
             obj = self.storage._bucket.get_blob()
             obj.upload_from_file.assert_called_with(
@@ -551,6 +561,7 @@ class GoogleCloudGzipClientTests(GCloudTestCase):
 
         try:
             patcher.start()
+            self.storage._client = mock.MagicMock()
             self.storage.save(name, content)
             obj = self.storage._bucket.get_blob()
             obj.upload_from_file.assert_called_with(

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -507,24 +507,18 @@ class GCloudStorageTests(GCloudTestCase):
 
     def test_iam_sign_blob_setting(self):
         self.assertEqual(self.storage.iam_sign_blob, False)
-        with override_settings(
-            GS_IAM_SIGN_BLOB=True
-        ):
+        with override_settings(GS_IAM_SIGN_BLOB=True):
             storage = gcloud.GoogleCloudStorage()
             self.assertEqual(storage.iam_sign_blob, True)
 
     def test_sa_email_setting(self):
         self.assertEqual(self.storage.sa_email, None)
-        with override_settings(
-            GS_SA_EMAIL="service_account_email@gmail.com"
-        ):
+        with override_settings(GS_SA_EMAIL="service_account_email@gmail.com"):
             storage = gcloud.GoogleCloudStorage()
             self.assertEqual(storage.sa_email, "service_account_email@gmail.com")
 
     def test_iam_sign_blob_no_service_account_email_raises_attribute_error(self):
-        with override_settings(
-            GS_IAM_SIGN_BLOB=True
-        ):
+        with override_settings(GS_IAM_SIGN_BLOB=True):
             storage = gcloud.GoogleCloudStorage()
             storage._bucket = mock.MagicMock()
             storage.credentials = mock.MagicMock()
@@ -533,16 +527,17 @@ class GCloudStorageTests(GCloudTestCase):
             # simulating access token
             storage.credentials.token = "1234"
             # no sa_email or adc service_account_email found
-            with self.assertRaises(AttributeError, msg=(
-                "Sign Blob API requires service_account_email to be available "
-                "through ADC or setting `sa_email`"
-            )):
+            with self.assertRaises(
+                AttributeError,
+                msg=(
+                    "Sign Blob API requires service_account_email to be available "
+                    "through ADC or setting `sa_email`"
+                ),
+            ):
                 storage.url(self.filename)
 
     def test_iam_sign_blob_with_adc_service_account_email(self):
-        with override_settings(
-            GS_IAM_SIGN_BLOB=True
-        ):
+        with override_settings(GS_IAM_SIGN_BLOB=True):
             storage = gcloud.GoogleCloudStorage()
             storage._bucket = mock.MagicMock()
             storage.credentials = mock.MagicMock()
@@ -558,13 +553,12 @@ class GCloudStorageTests(GCloudTestCase):
                 expiration=timedelta(seconds=86400),
                 version="v4",
                 service_account_email=storage.credentials.service_account_email,
-                access_token=storage.credentials.token
+                access_token=storage.credentials.token,
             )
 
     def test_iam_sign_blob_with_sa_email_setting(self):
         with override_settings(
-            GS_IAM_SIGN_BLOB=True,
-            GS_SA_EMAIL="service_account_email@gmail.com"
+            GS_IAM_SIGN_BLOB=True, GS_SA_EMAIL="service_account_email@gmail.com"
         ):
             storage = gcloud.GoogleCloudStorage()
             storage._bucket = mock.MagicMock()
@@ -581,7 +575,7 @@ class GCloudStorageTests(GCloudTestCase):
                 expiration=timedelta(seconds=86400),
                 version="v4",
                 service_account_email=storage.sa_email,
-                access_token=storage.credentials.token
+                access_token=storage.credentials.token,
             )
 
 

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -37,7 +37,6 @@ class GCloudStorageTests(GCloudTestCase):
         """
         data = b"This is some test read data."
 
-        self.storage._client = mock.MagicMock()
         with self.storage.open(self.filename) as f:
             self.storage._client.bucket.assert_called_with(self.bucket_name)
             self.storage._bucket.get_blob.assert_called_with(
@@ -51,7 +50,6 @@ class GCloudStorageTests(GCloudTestCase):
         data = b"This is some test read data."
         num_bytes = 10
 
-        self.storage._client = mock.MagicMock()
         with self.storage.open(self.filename) as f:
             self.storage._client.bucket.assert_called_with(self.bucket_name)
             self.storage._bucket.get_blob.assert_called_with(
@@ -110,7 +108,6 @@ class GCloudStorageTests(GCloudTestCase):
         data = "This is some test content."
         content = ContentFile(data)
 
-        self.storage._client = mock.MagicMock()
         self.storage.save(self.filename, content)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -128,7 +125,6 @@ class GCloudStorageTests(GCloudTestCase):
         filename = "ủⓝï℅ⅆℇ.txt"
         content = ContentFile(data)
 
-        self.storage._client = mock.MagicMock()
         self.storage.save(filename, content)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -150,7 +146,7 @@ class GCloudStorageTests(GCloudTestCase):
         # 'projectPrivate', 'bucketOwnerRead', 'bucketOwnerFullControl',
         # 'private', 'authenticatedRead', 'publicRead', 'publicReadWrite'
         self.storage.default_acl = "publicRead"
-        self.storage._client = mock.MagicMock()
+
         self.storage.save(filename, content)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -164,7 +160,6 @@ class GCloudStorageTests(GCloudTestCase):
         )
 
     def test_delete(self):
-        self.storage._client = mock.MagicMock()
         self.storage.delete(self.filename)
 
         self.storage._client.bucket.assert_called_with(self.bucket_name)
@@ -190,7 +185,6 @@ class GCloudStorageTests(GCloudTestCase):
 
     def test_exists_bucket(self):
         # exists('') should return True if the bucket exists
-        self.storage._client = mock.MagicMock()
         self.assertTrue(self.storage.exists(""))
 
     def test_listdir(self):
@@ -373,7 +367,6 @@ class GCloudStorageTests(GCloudTestCase):
 
         self.storage.default_acl = "publicRead"
         url = "{}/{}".format(self.storage.custom_endpoint, self.filename)
-        self.storage._client = mock.MagicMock()
         self.assertEqual(self.storage.url(self.filename), url)
 
         bucket_name = "hyacinth"
@@ -417,7 +410,6 @@ class GCloudStorageTests(GCloudTestCase):
             GS_OBJECT_PARAMETERS={"cache_control": "public, max-age=604800"}
         ):
             self.storage = gcloud.GoogleCloudStorage(bucket_name=self.bucket_name)
-            self.storage._client = mock.MagicMock()
             self.storage.save(filename, content)
             bucket = self.storage.client.bucket(self.bucket_name)
             blob = bucket.get_blob(filename)
@@ -431,7 +423,6 @@ class GCloudStorageTests(GCloudTestCase):
         content = ContentFile("I should be gzip'd")
 
         # When
-        self.storage._client = mock.MagicMock()
         self.storage.save(name, content)
         self.storage.save("test_storage_save_2.css", content)
 
@@ -533,7 +524,6 @@ class GoogleCloudGzipClientTests(GCloudTestCase):
         patcher = mock.patch("google.cloud.storage.Bucket.get_blob", return_value=blob)
         try:
             patcher.start()
-            self.storage._client = mock.MagicMock()
             self.storage.save(name, content)
             obj = self.storage._bucket.get_blob()
             obj.upload_from_file.assert_called_with(
@@ -561,7 +551,6 @@ class GoogleCloudGzipClientTests(GCloudTestCase):
 
         try:
             patcher.start()
-            self.storage._client = mock.MagicMock()
             self.storage.save(name, content)
             obj = self.storage._bucket.get_blob()
             obj.upload_from_file.assert_called_with(

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -547,7 +547,7 @@ class GCloudStorageTests(GCloudTestCase):
             storage._bucket = mock.MagicMock()
             storage.credentials = mock.MagicMock()
             # simulating adc service account email
-            storage.credentials.service_account_email = "adc_service_account_email@gmail.com"
+            storage.credentials.service_account_email = "service@gmail.com"
             # simulating access token
             storage.credentials.token = "1234"
             blob = mock.MagicMock()
@@ -570,7 +570,7 @@ class GCloudStorageTests(GCloudTestCase):
             storage._bucket = mock.MagicMock()
             storage.credentials = mock.MagicMock()
             # simulating adc service account email
-            storage.credentials.service_account_email = "adc_service_account_email@gmail.com"
+            storage.credentials.service_account_email = "service@gmail.com"
             # simulating access token
             storage.credentials.token = "1234"
             blob = mock.MagicMock()

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -505,6 +505,85 @@ class GCloudStorageTests(GCloudTestCase):
                 self.filename, chunk_size=chunk_size
             )
 
+    def test_iam_sign_blob_setting(self):
+        self.assertEqual(self.storage.iam_sign_blob, False)
+        with override_settings(
+            GS_IAM_SIGN_BLOB=True
+        ):
+            storage = gcloud.GoogleCloudStorage()
+            self.assertEqual(storage.iam_sign_blob, True)
+
+    def test_sa_email_setting(self):
+        self.assertEqual(self.storage.sa_email, None)
+        with override_settings(
+            GS_SA_EMAIL="service_account_email@gmail.com"
+        ):
+            storage = gcloud.GoogleCloudStorage()
+            self.assertEqual(storage.sa_email, "service_account_email@gmail.com")
+
+    def test_iam_sign_blob_no_service_account_email_raises_attribute_error(self):
+        with override_settings(
+            GS_IAM_SIGN_BLOB=True
+        ):
+            storage = gcloud.GoogleCloudStorage()
+            storage._bucket = mock.MagicMock()
+            storage.credentials = mock.MagicMock()
+            # deleting mocked attribute to simulate no service_account_email
+            del storage.credentials.service_account_email
+            # simulating access token
+            storage.credentials.token = "1234"
+            # no sa_email or adc service_account_email found
+            with self.assertRaises(AttributeError, msg=(
+                "Sign Blob API requires service_account_email to be available "
+                "through ADC or setting `sa_email`"
+            )):
+                storage.url(self.filename)
+
+    def test_iam_sign_blob_with_adc_service_account_email(self):
+        with override_settings(
+            GS_IAM_SIGN_BLOB=True
+        ):
+            storage = gcloud.GoogleCloudStorage()
+            storage._bucket = mock.MagicMock()
+            storage.credentials = mock.MagicMock()
+            # simulating adc service account email
+            storage.credentials.service_account_email = "adc_service_account_email@gmail.com"
+            # simulating access token
+            storage.credentials.token = "1234"
+            blob = mock.MagicMock()
+            storage._bucket.blob.return_value = blob
+            storage.url(self.filename)
+            # called with adc service account email and access token
+            blob.generate_signed_url.assert_called_with(
+                expiration=timedelta(seconds=86400),
+                version="v4",
+                service_account_email=storage.credentials.service_account_email,
+                access_token=storage.credentials.token
+            )
+
+    def test_iam_sign_blob_with_sa_email_setting(self):
+        with override_settings(
+            GS_IAM_SIGN_BLOB=True,
+            GS_SA_EMAIL="service_account_email@gmail.com"
+        ):
+            storage = gcloud.GoogleCloudStorage()
+            storage._bucket = mock.MagicMock()
+            storage.credentials = mock.MagicMock()
+            # simulating adc service account email
+            storage.credentials.service_account_email = "adc_service_account_email@gmail.com"
+            # simulating access token
+            storage.credentials.token = "1234"
+            blob = mock.MagicMock()
+            storage._bucket.blob.return_value = blob
+            storage.url(self.filename)
+            # called with sa_email as it has final say
+            blob.generate_signed_url.assert_called_with(
+                expiration=timedelta(seconds=86400),
+                version="v4",
+                service_account_email=storage.sa_email,
+                access_token=storage.credentials.token
+            )
+
 
 class GoogleCloudGzipClientTests(GCloudTestCase):
     def setUp(self):


### PR DESCRIPTION
fixes #941 

- Adds `sa_email` setting in order to set the service_account_email used for signing URL if service_account key file not available in the env. Compute services (Cloud Run, Cloud Function, App Engine, Compute Engine ...) don't have access to the key file but get access tokens through the metadata server. Passing service_account_email and access_token will cause generate_signed_url to use the IAM API to signBlob using the provided service account email and token.