### PR TITLE
[ftp] Extend path handling

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -60,7 +60,7 @@ class FTPStorage(BaseStorage):
         """Return splitted configuration data from location."""
         splitted_url = re.search(
             r"^(?P<scheme>.+)://(?P<user>.+):(?P<passwd>.+)@"
-            r"(?P<host>.+):(?P<port>\d+)/(?P<path>.*)$",
+            r"(?P<host>.+):(?P<port>\d+)(?P<path>/.*)?$",
             location,
         )
 
@@ -75,7 +75,7 @@ class FTPStorage(BaseStorage):
         config["active"] = splitted_url["scheme"] == "aftp"
         config["secure"] = splitted_url["scheme"] == "ftps"
 
-        config["path"] = splitted_url["path"] or "/"
+        config["path"] = splitted_url["path"][1:] if splitted_url["path"] else None
         config["host"] = splitted_url["host"]
         config["user"] = splitted_url["user"]
         config["passwd"] = splitted_url["passwd"]
@@ -102,7 +102,7 @@ class FTPStorage(BaseStorage):
                     ftp.prot_p()
                 if self._config["active"]:
                     ftp.set_pasv(False)
-                if self._config["path"] != "":
+                if self._config["path"]:
                     ftp.cwd(self._config["path"])
                 self._connection = ftp
                 return

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -54,7 +54,53 @@ class FTPTest(TestCase):
             "host": "localhost",
             "user": "foo",
             "active": False,
+            "path": "",
+            "port": 2121,
+            "secure": False,
+        }
+        self.assertEqual(config, wanted_config)
+        config = self.storage._decode_location("ftp://foo:b@r@localhost:2121")
+        wanted_config = {
+            "passwd": "b@r",
+            "host": "localhost",
+            "user": "foo",
+            "active": False,
+            "path": None,
+            "port": 2121,
+            "secure": False,
+        }
+        self.assertEqual(config, wanted_config)
+        config = self.storage._decode_location("ftp://foo:b@r@localhost:2121/test/dir")
+        wanted_config = {
+            "passwd": "b@r",
+            "host": "localhost",
+            "user": "foo",
+            "active": False,
+            "path": "test/dir",
+            "port": 2121,
+            "secure": False,
+        }
+        self.assertEqual(config, wanted_config)
+        config = self.storage._decode_location("ftp://foo:b@r@localhost:2121//")
+        wanted_config = {
+            "passwd": "b@r",
+            "host": "localhost",
+            "user": "foo",
+            "active": False,
             "path": "/",
+            "port": 2121,
+            "secure": False,
+        }
+        self.assertEqual(config, wanted_config)
+        config = self.storage._decode_location(
+            "ftp://foo:b@r@localhost:2121//root/test/dir"
+        )
+        wanted_config = {
+            "passwd": "b@r",
+            "host": "localhost",
+            "user": "foo",
+            "active": False,
+            "path": "/root/test/dir",
             "port": 2121,
             "secure": False,
         }
@@ -66,7 +112,7 @@ class FTPTest(TestCase):
             "host": "localhost",
             "user": "foo",
             "active": True,
-            "path": "/",
+            "path": "",
             "port": 2121,
             "secure": False,
         }
@@ -277,7 +323,7 @@ class FTPTLSTest(TestCase):
             "host": "localhost",
             "user": "foo",
             "active": False,
-            "path": "/",
+            "path": "",
             "port": 2121,
             "secure": True,
         }


### PR DESCRIPTION
Currently, the `FTPStorage` does not allow to work in the default directory of the connection. It only allows the following:
* `ftp://foo:b@r@localhost:2121/`: This will execute a CWD to the root directory "/", which often fails on multi-tenancy services, where you only get access to a subfolder.
* `ftp://foo:b@r@localhost:2121/test`: This will execute a CWD to the directory "test" relative to the connections PWD.
* `ftp://foo:b@r@localhost:2121//root/test`: This will execute a CWD to the absolute path "/root/test".

I would like to propose the change, that you can omit the path completely, which leaves you in the directory that gets opened by default. So with the new handling both `ftp://foo:b@r@localhost:2121` and `ftp://foo:b@r@localhost:2121/` won't execute a CWD.
If you want to start in the root directory, you have to use `ftp://foo:b@r@localhost:2121//`.

What do you think?