### PR TITLE
[ftp] Don't append slash to NLST in exists()

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -213,7 +213,7 @@ class FTPStorage(BaseStorage):
 
         self._start_connection()
         try:
-            nlst = self._connection.nlst(os.path.dirname(name) + "/")
+            nlst = self._connection.nlst(os.path.dirname(name))
             if name in nlst or os.path.basename(name) in nlst:
                 return True
             else:


### PR DESCRIPTION
We're using multiple different thirdparty ftp servers and we've now stumbled over a case, where the `.exists(name)` call did not work correctly.

In this case, the `location` looked like `ftp://username:password@example.org:21/`, so it CWDs to the root. In the root there were multiple files like 20240724.txt, 20240723.txt,...

When I used `storage.exists("20240724.txt")` it returned False (note, `allow_overwrite` was False). The problem with this setup is, that this exists-call resulted in the call of `self._connection.nlst("/")` (which is also not correct, if a different path/CWD is used), which returned a list with items like `["/20240724.txt", "/20240723.txt"]`, so all items have a "/" prepended, therefore the actual name "20240724.txt" cannot be found. This is not the case, when `self._connection.nlst("")` is used.

I've tested my change (where no "/" gets added) with other setups (e.g. other CWD and also with the changes of #1433 with no CWD at all), and in all cases my fix works without issues. Therefore I'm hoping we can merge this.

With this change the code is also consistent with similar usages, like [`.size()`](https://github.com/jschneier/django-storages/blob/123b9b97c362d1136c7622151951f3f626077185/storages/backends/ftp.py#L232), where no slash gets added either.