### PR TITLE
Update CHANGELOG to reflect support for Django 5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ django-storages CHANGELOG
 X.YY.Z (UNRELEASED)
 *******************
 
+General
+-------
+
+- Add support for Django 5.1 (`#1444`_)
+
 Azure
 -----
 


### PR DESCRIPTION
I forgot to update the CHANGELOG in #1444, my apologies. This pull request addresses that oversight.