### PR TITLE
[s3] Pass object parameters to head_object in `exists`

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -581,8 +581,11 @@ class S3Storage(CompressStorageMixin, BaseStorage):
 
     def exists(self, name):
         name = self._normalize_name(clean_name(name))
+        params = _filter_download_params(self.get_object_parameters(name))
         try:
-            self.connection.meta.client.head_object(Bucket=self.bucket_name, Key=name)
+            self.connection.meta.client.head_object(
+                Bucket=self.bucket_name, Key=name, **params
+            )
             return True
         except ClientError as err:
             if err.response["ResponseMetadata"]["HTTPStatusCode"] == 404:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -502,6 +502,15 @@ class S3StorageTests(TestCase):
             Key="file.txt",
         )
 
+    def test_storage_exists_ssec(self):
+        params = {"SSECustomerKey": "xyz", "CacheControl": "never"}
+        self.storage.get_object_parameters = lambda name: params
+        self.storage.file_overwrite = False
+        self.assertTrue(self.storage.exists("file.txt"))
+        self.storage.connection.meta.client.head_object.assert_called_with(
+            Bucket=self.storage.bucket_name, Key="file.txt", SSECustomerKey="xyz"
+        )
+
     def test_storage_exists_false(self):
         self.storage.connection.meta.client.head_object.side_effect = ClientError(
             {"Error": {}, "ResponseMetadata": {"HTTPStatusCode": 404}},


### PR DESCRIPTION
When using server-side-encryption with customer-provided keys (SSE-C), the `head_object` call needs the SSE-C key and algorithm - otherwise the call will fail with `botocore.exceptions.ClientError: An error occurred (400) when calling the HeadObject operation: Bad Request` if the file already exists.

From the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadObject.html):
> If you encrypt an object by using server-side encryption with customer-provided encryption keys (SSE-C) when you store the object in Amazon S3, then when you retrieve the metadata from the object, you must use the following headers to provide the encryption key for the server to be able to retrieve the object's metadata. The headers are:
> - x-amz-server-side-encryption-customer-algorithm
> - x-amz-server-side-encryption-customer-key
> - x-amz-server-side-encryption-customer-key-MD5

Since `head_object` is similar to `get`, we're reusing the existing logic to infer and filter the needed parameters.

Thank you in advance for your feedback!