### PR TITLE
[gcloud] fix double decompression when using gzip

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -62,10 +62,9 @@ class GoogleCloudFile(CompressedFileMixin, File):
             )
             if "r" in self._mode:
                 self._is_dirty = False
+                # This automatically decompresses the file
                 self.blob.download_to_file(self._file, checksum="crc32c")
                 self._file.seek(0)
-            if self._storage.gzip and self.blob.content_encoding == "gzip":
-                self._file = self._decompress_file(mode=self._mode, file=self._file)
         return self._file
 
     def _set_file(self, value):


### PR DESCRIPTION
The `self.blob.download_to_file` already performs decompression per this [StackOverflow](https://stackoverflow.com/questions/67744979/how-to-prevent-gcs-from-automatically-decompressing-objects-when-using-python-sd) post. Rather than attempting to decompress the gzip file a second time and receiving an error, allow `self.blob.download_to_file` to decompress it.

An alternative to this would be to use the `raw_download=True` kwarg for `self.blob.download_to_file` if that is desirable.

This closes #1456.