### PR TITLE
Fix #1469 Use a different checksum calculation method to run in FIPS env

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dropbox = [
   "dropbox>=7.2.1",
 ]
 google = [
-  "google-cloud-storage>=1.27",
+  "google-cloud-storage>=1.32",
 ]
 libcloud = [
   "apache-libcloud",

--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -62,7 +62,7 @@ class GoogleCloudFile(CompressedFileMixin, File):
             )
             if "r" in self._mode:
                 self._is_dirty = False
-                self.blob.download_to_file(self._file)
+                self.blob.download_to_file(self._file, checksum="crc32c")
                 self._file.seek(0)
             if self._storage.gzip and self.blob.content_encoding == "gzip":
                 self._file = self._decompress_file(mode=self._mode, file=self._file)

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -42,7 +42,7 @@ class GCloudStorageTests(GCloudTestCase):
                 self.filename, chunk_size=None
             )
 
-            f.blob.download_to_file = lambda tmpfile: tmpfile.write(data)
+            f.blob.download_to_file = lambda tmpfile, **kwargs: tmpfile.write(data)
             self.assertEqual(f.read(), data)
 
     def test_open_read_num_bytes(self):
@@ -55,7 +55,7 @@ class GCloudStorageTests(GCloudTestCase):
                 self.filename, chunk_size=None
             )
 
-            f.blob.download_to_file = lambda tmpfile: tmpfile.write(data)
+            f.blob.download_to_file = lambda tmpfile, **kwargs: tmpfile.write(data)
             self.assertEqual(f.read(num_bytes), data[0:num_bytes])
 
     def test_open_read_nonexistent(self):


### PR DESCRIPTION
Python 3.10 and later versions rely on OpenSSL 1.1.1 or newer, which includes FIPS-compliance checks.

MD5 is not an approved algorithm in FIPS mode, so attempting to instantiate self.blob.download_to_file(self._file) will fail when the system is running in FIPS mode.

The change configures the `download_to_file` function to use an alternative algorithm provided by gcloud storage SDK - 'crc32c' - for checksum calculation.