### PR TITLE
Defend against settings.AWS_S3_URL_PROTOCOL set to None

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -429,7 +429,7 @@ class S3Storage(CompressStorageMixin, BaseStorage):
                     "image/svg+xml",
                 ),
             ),
-            "url_protocol": setting("AWS_S3_URL_PROTOCOL", "https:"),
+            "url_protocol": setting("AWS_S3_URL_PROTOCOL") or "https:",
             "endpoint_url": setting("AWS_S3_ENDPOINT_URL"),
             "proxies": setting("AWS_S3_PROXIES"),
             "region_name": setting("AWS_S3_REGION_NAME"),

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -717,6 +717,14 @@ class S3StorageTests(TestCase):
         self.storage.url("test_name")
         self.storage.unsigned_connection.meta.client.generate_presigned_url.assert_called_once()
 
+    def test_url_protocol(self):
+        self.assertFalse(hasattr(settings, "AWS_S3_URL_PROTOCOL"))
+        self.assertEqual(self.storage.url_protocol, "https:")
+
+        with override_settings(AWS_S3_URL_PROTOCOL=None):
+            storage = s3.S3Storage()
+            self.assertEqual(storage.url_protocol, "https:")
+
     @mock.patch("storages.backends.s3.datetime")
     def test_storage_url_custom_domain_signed_urls(self, dt):
         key_id = "test-key"


### PR DESCRIPTION
We had a situation, that somebody put in our settings:
```
AWS_S3_URL_PROTOCOL = os.environ.get("AWS_S3_URL_PROTOCOL")
```
here it was falsely assumed, that not setting this environment variable will make `django-storages` to fallback to default `https:` (which didn't happened and we want to fix it in this pull request).