### PR TITLE
[general] Apply additional validation in overwrite path

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,6 +140,11 @@ class TestGetAvailableOverwriteName(TestCase):
         with self.assertRaises(SuspiciousFileOperation):
             gaon(name, len(name) - 5)
 
+    def test_suspicious_file(self):
+        name = "superlong/file/with/../path.txt"
+        with self.assertRaises(SuspiciousFileOperation):
+            gaon(name, 50)
+
 
 class TestReadBytesWrapper(TestCase):
     def test_with_bytes_file(self):


### PR DESCRIPTION
Fix for CVE-2024-39330 that I reported earlier, Django relied on non-overridden `get_available_name` for security which was overridden in this library. This is fixed on 4.2+.