### PR TITLE
[ci] Update CI to use Ubuntu 22.04 for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         python-version:
             - "3.7"
             - "3.8"
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         python-version: ["3.7"]
 
     steps:


### PR DESCRIPTION
Upgrade GitHub Actions Ubuntu version from 20.04 to 22.04

Ubuntu 20.04 (Focal Fossa) has reached end of support in GitHub Actions, so this PR updates our workflow configurations to use Ubuntu 22.04 (Jammy Jellyfish) instead.

This change ensures our CI/CD pipelines continue to run on a supported environment.

ref: https://github.com/actions/runner-images/issues/11101