### PR TITLE
Apply black to make tox tests pass

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -189,7 +189,7 @@ class TestReadBytesWrapper(TestCase):
     # bytes when encoding with utf-8 vs windows-1252 vs utf-16
 
     def test_with_string_file_specified_encoding(self):
-        content = "\u2122\u20AC\u2030"
+        content = "\u2122\u20ac\u2030"
         file = io.StringIO(content)
         file_wrapped = utils.ReadBytesWrapper(file, encoding="utf-16")
 
@@ -197,7 +197,7 @@ class TestReadBytesWrapper(TestCase):
         self.assertEqual(file_wrapped.read(), content.encode("utf-16"))
 
     def test_with_string_file_detect_encoding(self):
-        content = "\u2122\u20AC\u2030"
+        content = "\u2122\u20ac\u2030"
         with open(
             file=os.path.join(
                 os.path.dirname(__file__), "test_files", "windows-1252-encoded.txt"
@@ -214,7 +214,7 @@ class TestReadBytesWrapper(TestCase):
             self.assertEqual(file_wrapped.read(), content.encode("windows-1252"))
 
     def test_with_string_file_fallback_encoding(self):
-        content = "\u2122\u20AC\u2030"
+        content = "\u2122\u20ac\u2030"
         file = io.StringIO(content)
         file_wrapped = utils.ReadBytesWrapper(file)
 


### PR DESCRIPTION
Hi,

While setting up a local dev environment, I realized that on the current master, attempting to run tox fails because black/ruff are unhappy.

Running `black .` fixed this, this PR contains the resulting diff.