### PR TITLE
Add test run instructions to Contributing README section

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,5 +12,5 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-   install:
-   - requirements: docs/requirements.txt
+  install:
+  - requirements: docs/requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,7 @@ Contributing
    <https://github.com/jschneier/django-storages>`_ to start making changes.
 #. Add a test case to show that the bug is fixed or the feature is implemented
    correctly.
+    #. You can run tests locally with [`tox`](https://tox.wiki/en/latest/index.html).
 #. Bug me until I can merge your pull request.
 
 Please don't update the library version in CHANGELOG.rst or ``storages/__init__.py``, the maintainer will do that on release.


### PR DESCRIPTION
Hi,

It took me a while to understand how I was supposed to run the tests, and I was halfway through manually installing each dev dependency before realizing the project used tox to run test (and set up the required dev environments).

I thought a small documentation improvement could save any new future contributor this hassle.