### PR TITLE
urldecode password field to allow passwords containing :/?

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -18,8 +18,9 @@
 import ftplib
 import io
 import os
-import re
-import urllib.parse
+from urllib.parse import unquote
+from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -58,28 +59,22 @@ class FTPStorage(BaseStorage):
 
     def _decode_location(self, location):
         """Return splitted configuration data from location."""
-        splitted_url = re.search(
-            r"^(?P<scheme>.+)://(?P<user>.+):(?P<passwd>.+)@"
-            r"(?P<host>.+):(?P<port>\d+)/(?P<path>.*)$",
-            location,
-        )
+        splitted_url = urlparse(location)
 
-        if splitted_url is None:
-            raise ImproperlyConfigured("Improperly formatted location URL")
-        if splitted_url["scheme"] not in ("ftp", "aftp", "ftps"):
+        if splitted_url.scheme not in ("ftp", "aftp", "ftps"):
             raise ImproperlyConfigured("Only ftp, aftp, ftps schemes supported")
-        if splitted_url["host"] == "":
+        if splitted_url.hostname == "":
             raise ImproperlyConfigured("You must at least provide host!")
 
-        config = {}
-        config["active"] = splitted_url["scheme"] == "aftp"
-        config["secure"] = splitted_url["scheme"] == "ftps"
-
-        config["path"] = splitted_url["path"] or "/"
-        config["host"] = splitted_url["host"]
-        config["user"] = splitted_url["user"]
-        config["passwd"] = splitted_url["passwd"]
-        config["port"] = int(splitted_url["port"])
+        config = {
+            "active": splitted_url.scheme == "aftp",
+            "secure": splitted_url.scheme == "ftps",
+            "path": unquote(splitted_url.path) or "/",
+            "host": unquote(splitted_url.hostname),
+            "user": unquote(splitted_url.username),
+            "passwd": unquote(splitted_url.password),
+            "port": splitted_url.port,
+        }
 
         return config
 
@@ -240,7 +235,7 @@ class FTPStorage(BaseStorage):
     def url(self, name):
         if self.base_url is None:
             raise ValueError("This file is not accessible via a URL.")
-        return urllib.parse.urljoin(self.base_url, name).replace("\\", "/")
+        return urljoin(self.base_url, name).replace("\\", "/")
 
 
 class FTPStorageFile(File):

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from storages.backends import ftp
 
 USER = "foo"
-PASSWORD = "b@r"
+PASSWORD = "bar"
 HOST = "localhost"
 PORT = 2121
 
@@ -50,7 +50,7 @@ class FTPTest(TestCase):
     def test_decode_location(self):
         config = self.storage._decode_location(URL)
         wanted_config = {
-            "passwd": "b@r",
+            "passwd": "bar",
             "host": "localhost",
             "user": "foo",
             "active": False,
@@ -62,7 +62,7 @@ class FTPTest(TestCase):
         # Test active FTP
         config = self.storage._decode_location("a" + URL)
         wanted_config = {
-            "passwd": "b@r",
+            "passwd": "bar",
             "host": "localhost",
             "user": "foo",
             "active": True,
@@ -79,7 +79,24 @@ class FTPTest(TestCase):
             self.storage._decode_location("http://foo.pt")
 
     def test_decode_location_urlchars_password(self):
-        self.storage._decode_location(geturl(pwd="b#r"))
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%3Ar"))["passwd"], "b:r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%2Fr"))["passwd"], "b/r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%40r"))["passwd"], "b@r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%23r"))["passwd"], "b#r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%3Fr"))["passwd"], "b?r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%25r"))["passwd"], "b%r"
+        )
 
     @override_settings(FTP_STORAGE_LOCATION=URL)
     def test_override_settings(self):
@@ -273,7 +290,7 @@ class FTPTLSTest(TestCase):
 
     def test_decode_location(self):
         wanted_config = {
-            "passwd": "b@r",
+            "passwd": "bar",
             "host": "localhost",
             "user": "foo",
             "active": False,


### PR DESCRIPTION
Hi,

We recently ran into an issue, where we have a FTP password containing the `/`. This breaks the URL parsing with the current code.

We could try to work around the issue with tweaks to the regex detection logic, but no matter what we do, some characters will still break it, as there has to be a way for our code to determine where each part of the URL stops.


The proposed (and implemented here) fix is to consider that since we're taking a URL as input and parsing it, we might as well rely on standard URL escaping to deal with any character susceptible from breaking URL parsing. As far as I can tell, the affected characters are (at least) `:/@#?%`.

This PR therefores reverts a good chunk of #1329, and adds an extra url decoding of the parsed values.



This is a breaking change, as characters that are currently accepted may need to be escaped with this new code. I'm not sure how you want to handle that, maybe a major version bump ? (Although, if you're willing to go with that, I have other breaking changes that I want to suggest, I'll open separate PRs for them as soon as I can)

Documentation updates are probably needed too, but I'd rather have your opinion on the topic before redacting anything !