### PR TITLE
Add ftpes scheme support (as equivalent of current ftps implementation)

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -18,8 +18,9 @@
 import ftplib
 import io
 import os
-import re
-import urllib.parse
+from urllib.parse import unquote
+from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -58,28 +59,22 @@ class FTPStorage(BaseStorage):
 
     def _decode_location(self, location):
         """Return splitted configuration data from location."""
-        splitted_url = re.search(
-            r"^(?P<scheme>.+)://(?P<user>.+):(?P<passwd>.+)@"
-            r"(?P<host>.+):(?P<port>\d+)/(?P<path>.*)$",
-            location,
-        )
+        splitted_url = urlparse(location)
 
-        if splitted_url is None:
-            raise ImproperlyConfigured("Improperly formatted location URL")
-        if splitted_url["scheme"] not in ("ftp", "aftp", "ftps"):
+        if splitted_url.scheme not in ("ftp", "aftp", "ftps"):
             raise ImproperlyConfigured("Only ftp, aftp, ftps schemes supported")
-        if splitted_url["host"] == "":
+        if splitted_url.hostname == "":
             raise ImproperlyConfigured("You must at least provide host!")
 
-        config = {}
-        config["active"] = splitted_url["scheme"] == "aftp"
-        config["secure"] = splitted_url["scheme"] == "ftps"
-
-        config["path"] = splitted_url["path"] or "/"
-        config["host"] = splitted_url["host"]
-        config["user"] = splitted_url["user"]
-        config["passwd"] = splitted_url["passwd"]
-        config["port"] = int(splitted_url["port"])
+        config = {
+            "active": splitted_url.scheme == "aftp",
+            "secure": splitted_url.scheme == "ftps",
+            "path": unquote(splitted_url.path) or "/",
+            "host": unquote(splitted_url.hostname),
+            "user": unquote(splitted_url.username),
+            "passwd": unquote(splitted_url.password),
+            "port": splitted_url.port,
+        }
 
         return config
 
@@ -240,7 +235,7 @@ class FTPStorage(BaseStorage):
     def url(self, name):
         if self.base_url is None:
             raise ValueError("This file is not accessible via a URL.")
-        return urllib.parse.urljoin(self.base_url, name).replace("\\", "/")
+        return urljoin(self.base_url, name).replace("\\", "/")
 
 
 class FTPStorageFile(File):

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -11,7 +11,7 @@
 # In models.py you can write:
 # from FTPStorage import FTPStorage
 # fs = FTPStorage()
-# For a TLS configuration, you must use 'ftps' protocol
+# For a TLS configuration, you must use 'ftpes' protocol
 # class FTPTest(models.Model):
 #     file = models.FileField(upload_to='a/b/c/', storage=fs)
 
@@ -61,14 +61,14 @@ class FTPStorage(BaseStorage):
         """Return splitted configuration data from location."""
         splitted_url = urlparse(location)
 
-        if splitted_url.scheme not in ("ftp", "aftp", "ftps"):
-            raise ImproperlyConfigured("Only ftp, aftp, ftps schemes supported")
+        if splitted_url.scheme not in ("ftp", "aftp", "ftps", "ftpes"):
+            raise ImproperlyConfigured("Only ftp, aftp, ftps, ftpes schemes supported")
         if splitted_url.hostname == "":
             raise ImproperlyConfigured("You must at least provide host!")
 
         config = {
             "active": splitted_url.scheme == "aftp",
-            "secure": splitted_url.scheme == "ftps",
+            "secure": splitted_url.scheme in ["ftps", "ftpes"],
             "path": unquote(splitted_url.path) or "/",
             "host": unquote(splitted_url.hostname),
             "user": unquote(splitted_url.username),

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from storages.backends import ftp
 
 USER = "foo"
-PASSWORD = "b@r"
+PASSWORD = "bar"
 HOST = "localhost"
 PORT = 2121
 
@@ -50,7 +50,7 @@ class FTPTest(TestCase):
     def test_decode_location(self):
         config = self.storage._decode_location(URL)
         wanted_config = {
-            "passwd": "b@r",
+            "passwd": "bar",
             "host": "localhost",
             "user": "foo",
             "active": False,
@@ -62,7 +62,7 @@ class FTPTest(TestCase):
         # Test active FTP
         config = self.storage._decode_location("a" + URL)
         wanted_config = {
-            "passwd": "b@r",
+            "passwd": "bar",
             "host": "localhost",
             "user": "foo",
             "active": True,
@@ -79,7 +79,24 @@ class FTPTest(TestCase):
             self.storage._decode_location("http://foo.pt")
 
     def test_decode_location_urlchars_password(self):
-        self.storage._decode_location(geturl(pwd="b#r"))
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%3Ar"))["passwd"], "b:r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%2Fr"))["passwd"], "b/r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%40r"))["passwd"], "b@r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%23r"))["passwd"], "b#r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%3Fr"))["passwd"], "b?r"
+        )
+        self.assertEqual(
+            self.storage._decode_location(geturl(pwd="b%25r"))["passwd"], "b%r"
+        )
 
     @override_settings(FTP_STORAGE_LOCATION=URL)
     def test_override_settings(self):
@@ -273,7 +290,7 @@ class FTPTLSTest(TestCase):
 
     def test_decode_location(self):
         wanted_config = {
-            "passwd": "b@r",
+            "passwd": "bar",
             "host": "localhost",
             "user": "foo",
             "active": False,

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -286,7 +286,7 @@ class FTPStorageFileTest(TestCase):
 
 class FTPTLSTest(TestCase):
     def setUp(self):
-        self.storage = ftp.FTPStorage(location=geturl(scheme="ftps"))
+        self.storage = ftp.FTPStorage(location=geturl(scheme="ftpes"))
 
     def test_decode_location(self):
         wanted_config = {


### PR DESCRIPTION
Hi,

There's a bit of confusion regarding FTP over TLS implementation in django-storages, and I'd like to propose a way to fix it here.

## Context 

So, there are 2 different ways of adding TLS to the FTP protocol ([wikipedia ref](https://en.wikipedia.org/wiki/FTPS)) : 

1. Implicit TLS : 

This is similar to what is done for HTTPS ; the client connects to a different port ([990 by default](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=ftps)), establishes a TLS connection, then establishes a normal FTP session inside the TLS tunnel.
This is what the `ftps` URL scheme represents.
This way of implementing TLS in FTP was never really standardized, and is nowadays considered deprecated

2. Explicit TLS : 

This method of implementation was specified in [RFC 4217](https://datatracker.ietf.org/doc/rfc4217/), and is the preferred method for securing FTP.
Here, the client initiates a plaintext FTP connexion to the normal port (21), and issues a command to upgrade the connection to TLS. Well-behaved clients would do this before sending anything else (especially sending the password), and secure servers would refuse any command before upgrading the connection.

As this method is part of the FTP protocol, and on the same port as plaintext FTP, no URL scheme is standardized.
It's however common for FTP clients and servers to accept the non-standard `ftpes` scheme to convey the idea that despite the connection being originally established in plaintext, upgrading to a secure connection is mandatory.

## Problem

Django-storages implements the second method, and yet uses the `ftps` scheme associated with the first one for enabling this behavior.

This is confusing.

## Proposed solution

* Add support for `ftpes` scheme, with the same behavior as already existing (done in this PR)
* Add a logging warning if initializing the connector with the `ftps` scheme (I can add it in this PR if it's fine with you)
* Removing the support for the `ftps` scheme at the next major version update

I'm of course open to discussion regarding the points 2 and 3, as one could argue that it's not worth making a breaking change, warning just might be enough ?

Also, documenting this is probably a good idea as well.
