### PR TITLE
Upgrade to AWS ListObjectsV2

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -602,7 +602,7 @@ class S3Storage(CompressStorageMixin, BaseStorage):
 
         directories = []
         files = []
-        paginator = self.connection.meta.client.get_paginator("list_objects")
+        paginator = self.connection.meta.client.get_paginator("list_objects_v2")
         pages = paginator.paginate(Bucket=self.bucket_name, Delimiter="/", Prefix=path)
         for page in pages:
             directories += [


### PR DESCRIPTION
This line now fails in django storage (listdir()) due to: 

**An error occurred (NoSuchKey) when calling the ListObjects operation: None**

ListObjects is to be deprecated: [source](https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html)

Boto3 shows the new list_objects_v2 as example: [source](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html)