### PR TITLE
Remove TokenState import for backward compatibility

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -21,7 +21,6 @@ from storages.utils import to_bytes
 
 try:
     from google import auth
-    from google.auth.credentials import TokenState
     from google.auth.transport import requests
     from google.cloud.exceptions import NotFound
     from google.cloud.storage import Blob
@@ -356,7 +355,11 @@ class GoogleCloudStorage(BaseStorage):
         return super().get_available_name(name, max_length)
 
     def _get_iam_sign_blob_params(self):
-        if self.credentials.token_state != TokenState.FRESH:
+        # Check if credentials need refreshing before signing
+        # TokenState.FRESH = 1, STALE = 2, INVALID = 3
+        # We hardcode the value 1 (FRESH) to avoid importing TokenState,
+        # which was only added in google-auth 2.26.0, ensuring backward compatibility
+        if self.credentials.token_state != 1:  # Not FRESH
             self.credentials.refresh(requests.Request())
 
         try:

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -578,6 +578,23 @@ class GCloudStorageTests(GCloudTestCase):
                 access_token=storage.credentials.token,
             )
 
+    def test_iam_sign_blob_params_with_integer_token_state(self):
+        """
+        Test that _get_iam_sign_blob_params works with integer token_state values
+        (backward compatibility)
+        """
+        with override_settings(GS_IAM_SIGN_BLOB=True, GS_SA_EMAIL="test@example.com"):
+            storage = gcloud.GoogleCloudStorage()
+            storage.credentials = mock.MagicMock()
+            storage.credentials.token = "access_token_123"
+            storage.credentials.token_state = 2  # STALE - should refresh
+
+            email, token = storage._get_iam_sign_blob_params()
+
+            self.assertEqual(email, "test@example.com")
+            self.assertEqual(token, "access_token_123")
+            storage.credentials.refresh.assert_called_once()
+
 
 class GoogleCloudGzipClientTests(GCloudTestCase):
     def setUp(self):


### PR DESCRIPTION
Removes dependency on `google.auth.credentials.TokenState`, which was introduced in google-auth v2.26.0.
To maintain compatibility with earlier versions, replaces `TokenState.FRESH` with its equivalent hardcoded value `1`.

Reference: https://github.com/googleapis/google-auth-library-python/blob/7c61c7d0a42ceec3eab693065745a74f524acab0/google/auth/credentials.py#L520

Fixes:
Could not load Google Cloud Storage bindings error when using google-auth < 2.26.0 with django-storages >= 1.14.6.

I give @martey all the credit for the solution (issue [1449](https://github.com/jschneier/django-storages/issues/1499#issuecomment-2870035253))