### PR TITLE
Add support for reading files in text mode in GoogleCloudFile

### DIFF
--- a/storages/backends/gcloud.py
+++ b/storages/backends/gcloud.py
@@ -69,6 +69,19 @@ class GoogleCloudFile(CompressedFileMixin, File):
                 # This automatically decompresses the file
                 self.blob.download_to_file(self._file, checksum="crc32c")
                 self._file.seek(0)
+                if "b" not in self._mode:
+                    if hasattr(self._file, "readable"):
+                        # For versions > Python 3.10 compatibility
+                        # See SpooledTemporaryFile changes in 3.11 (https://docs.python.org/3/library/tempfile.html) # noqa: E501
+                        # Now fully implements the io.BufferedIOBase and io.TextIOBase abstract base classes allowing the file # noqa: E501
+                        # to be readable in the mode that it was specified (without accessing the underlying _file object). # noqa: E501
+                        # In this case, we need to wrap the file in a TextIOWrapper to ensure that the file is read as a text file. # noqa: E501
+                        self._file = io.TextIOWrapper(self._file, encoding="utf-8")
+                    else:
+                        # For versions <= Python 3.10 compatibility
+                        self._file = io.TextIOWrapper(
+                            self._file._file, encoding="utf-8"
+                        )
         return self._file
 
     def _set_file(self, value):

--- a/tests/test_gcloud.py
+++ b/tests/test_gcloud.py
@@ -578,6 +578,26 @@ class GCloudStorageTests(GCloudTestCase):
                 access_token=storage.credentials.token,
             )
 
+    def test_open_read_text_mode(self):
+        """
+        Test opening a file in text mode ('rt') returns strings, not bytes
+        """
+        data = b"This is some test text data."
+        expected_text = "This is some test text data."
+
+        with self.storage.open(self.filename, "rt") as f:
+            self.storage._client.bucket.assert_called_with(self.bucket_name)
+            self.storage._bucket.get_blob.assert_called_with(
+                self.filename, chunk_size=None
+            )
+
+            f.blob.download_to_file = lambda tmpfile, **kwargs: tmpfile.write(data)
+            content = f.read()
+
+            # Should return string, not bytes
+            self.assertIsInstance(content, str)
+            self.assertEqual(content, expected_text)
+
 
 class GoogleCloudGzipClientTests(GCloudTestCase):
     def setUp(self):


### PR DESCRIPTION
When opening a file with mode='rt', GoogleCloudFile was returning bytes instead of strings. 
This adds TextIOWrapper handling similar to the S3 backend to properly support text mode reading.

Fixes the issue where `storage.open('file.txt', mode='rt').read()` returned bytes instead of strings ([1504](https://github.com/jschneier/django-storages/issues/1504))