### PR TITLE
Set sane defaults for checksum. Fixes #1482

### DIFF
--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -347,8 +347,8 @@ class S3Storage(CompressStorageMixin, BaseStorage):
                 s3={"addressing_style": self.addressing_style},
                 signature_version=self.signature_version,
                 proxies=self.proxies,
-                request_checksum_calculation='when_required',
-                response_checksum_validation='when_required',
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
             )
 
         if self.use_threads is False:

--- a/storages/backends/s3.py
+++ b/storages/backends/s3.py
@@ -347,6 +347,8 @@ class S3Storage(CompressStorageMixin, BaseStorage):
                 s3={"addressing_style": self.addressing_style},
                 signature_version=self.signature_version,
                 proxies=self.proxies,
+                request_checksum_calculation='when_required',
+                response_checksum_validation='when_required',
             )
 
         if self.use_threads is False:


### PR DESCRIPTION
I encountered the same issue described in #1482 when upgrading to a new version. The root cause is the lack of setting these attributes for the default configuration. They were described in the issue, and they function properly when a custom configuration is set.

However, in my case (and I think in most cases), we don't set a custom configuration, so this package should support the defaults.

This prevents someone without a custom configuration from using the package as it was before this change in boto.

Hopefully, this gets merged soon and a new package version is released.