### PR TITLE
Use Ruff instead of Black for formatting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,11 +38,10 @@ extras =
 
 [testenv:ruff]
 deps =
-	black
 	ruff
 commands =
-	ruff check .
-	black --check .
+	ruff check
+	ruff format --check
 skip_install = true
 
 [pytest]


### PR DESCRIPTION
Ruff is faster and now provides the same functionality as Black.