### PR TITLE
Feat: add suport for azure url override

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -184,6 +184,11 @@ class AzureStorage(BaseStorage):
                 DeprecationWarning,
             )
             options["api_version"] = self.api_version
+
+        # allow account url override for very custom azure instances/routing
+        if "account_url" in options:
+            return BlobServiceClient(credential=credential, **options)
+
         return BlobServiceClient(account_url, credential=credential, **options)
 
     @property

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -303,9 +303,7 @@ class AzureStorageTest(TestCase):
             client_mock = mock.MagicMock()
             bsc_mocked.return_value.get_container_client.return_value = client_mock
             self.assertEqual(storage.client, client_mock)
-            bsc_mocked.assert_called_once_with(
-                "https://bar.com", credential="foo_cred"
-            )
+            bsc_mocked.assert_called_once_with("https://bar.com", credential="foo_cred")
 
     def test_connection_string_can_have_missing(self):
         storage = azure_storage.AzureStorage(

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -293,6 +293,20 @@ class AzureStorageTest(TestCase):
                 "https://test.blob.core.windows.net", credential="foo_cred"
             )
 
+    def test_container_client_params_token_credential_and_super_custom_url(self):
+        storage = azure_storage.AzureStorage()
+        storage.token_credential = "foo_cred"
+        storage.client_options = {"account_url": "https://bar.com"}
+        with mock.patch(
+            "storages.backends.azure_storage.BlobServiceClient", autospec=True
+        ) as bsc_mocked:
+            client_mock = mock.MagicMock()
+            bsc_mocked.return_value.get_container_client.return_value = client_mock
+            self.assertEqual(storage.client, client_mock)
+            bsc_mocked.assert_called_once_with(
+                "https://bar.com", credential="foo_cred"
+            )
+
     def test_connection_string_can_have_missing(self):
         storage = azure_storage.AzureStorage(
             connection_string="AccountKey=abc;Foobar=xyz;"


### PR DESCRIPTION
This change allows the Azure backend to work with completely custom Blob Storage URLs.

The default implementation assumed that everyone sticks to Azures naming conventions, unfortunately not everyone does. This PR just extends the existing client_options parameter to prevent double passing the `account_url`, if it is specified as client_parameter.

While testing this I have found that the current implementation changes the `client_params` without creating a copy first, if you are interested in changes that address that let me know (would also make the implementation of these changes a little nicer). https://github.com/Gornoka/django-storages/tree/debug/quick/reduce_side_effects

This might also be a solution to this issue: #1503