### PR TITLE
[ftp] Add get_modified_time

### DIFF
--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -15,6 +15,7 @@
 # class FTPTest(models.Model):
 #     file = models.FileField(upload_to='a/b/c/', storage=fs)
 
+import datetime
 import ftplib
 import io
 import os
@@ -25,6 +26,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.utils.deconstruct import deconstructible
+from django.utils.timezone import make_naive
 
 from storages.base import BaseStorage
 from storages.utils import setting
@@ -190,6 +192,31 @@ class FTPStorage(BaseStorage):
         except ftplib.all_errors:
             raise FTPStorageException("Error getting listing for %s" % path)
 
+    def _get_file_last_modified_details(self, file_name):
+        """Returns the last modified timestamp (as a datetime) for the given file."""
+        # Connection must be open!
+        try:
+            # Get metadata for the requested file
+            # MLST specification: https://datatracker.ietf.org/doc/html/rfc3659#section-7
+            response = self._connection.sendcmd(f"MLST {file_name}")
+
+            if "modify=" not in response:
+                raise FTPStorageException(
+                    "Output of MLST is not in the expected format, "
+                    'or does not contain a "modify" attribute'
+                )
+
+            # Extract the timestamp between 'modify=' and the next ';'
+            last_modified = response.split("modify=")[1].split(";")[0]
+            return datetime.datetime.strptime(last_modified, "%Y%m%d%H%M%S").replace(
+                tzinfo=datetime.UTC
+            )
+
+        except ftplib.all_errors as error:
+            raise FTPStorageException(
+                f"Error getting listing for file {file_name}"
+            ) from error
+
     def listdir(self, path):
         self._start_connection()
         try:
@@ -241,6 +268,18 @@ class FTPStorage(BaseStorage):
         if self.base_url is None:
             raise ValueError("This file is not accessible via a URL.")
         return urllib.parse.urljoin(self.base_url, name).replace("\\", "/")
+
+    def get_modified_time(self, name):
+        """
+        Returns an (aware) datetime object containing the last modified time if
+        USE_TZ is True, otherwise returns a naive datetime in the local timezone.
+        """
+        self._start_connection()
+        last_modified = self._get_file_last_modified_details(name)
+        if setting("USE_TZ"):
+            return last_modified
+        else:
+            return make_naive(last_modified)
 
 
 class FTPStorageFile(File):

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -209,7 +209,7 @@ class FTPStorage(BaseStorage):
             # Extract the timestamp between 'modify=' and the next ';'
             last_modified = response.split("modify=")[1].split(";")[0]
             return datetime.datetime.strptime(last_modified, "%Y%m%d%H%M%S").replace(
-                tzinfo=datetime.UTC
+                tzinfo=datetime.timezone.utc
             )
 
         except ValueError as error:

--- a/storages/backends/ftp.py
+++ b/storages/backends/ftp.py
@@ -203,7 +203,7 @@ class FTPStorage(BaseStorage):
             if "modify=" not in response:
                 raise FTPStorageException(
                     "Output of MLST is not in the expected format, "
-                    'or does not contain a "modify" attribute'
+                    f'or does not contain a "modify" attribute for file {file_name}'
                 )
 
             # Extract the timestamp between 'modify=' and the next ';'
@@ -212,6 +212,10 @@ class FTPStorage(BaseStorage):
                 tzinfo=datetime.UTC
             )
 
+        except ValueError as error:
+            raise FTPStorageException(
+                f'MLST "modify" timestamp is in an unexpected format for {file_name}'
+            ) from error
         except ftplib.all_errors as error:
             raise FTPStorageException(
                 f"Error getting listing for file {file_name}"

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -19,8 +19,10 @@ LIST_FIXTURE = """drwxr-xr-x   2 ftp      nogroup      4096 Jul 27 09:46 dir
 -rw-r--r--   1 ftp      nogroup      1024 Jul 27 09:45 fi
 -rw-r--r--   1 ftp      nogroup      2048 Jul 27 09:50 fi2"""
 
-MLST_VALID = """250-Begin
- type=file;size=256;modify=20260101103015;UNIX.mode=0644;UNIX.uid=1000;UNIX.gid=1000;unique=123456789ab; file-name.ext
+MLST_FILE_NAME = "file-name.ext"
+
+MLST_VALID = f"""250-Begin
+ type=file;size=256;modify=20260101103015;UNIX.mode=0644;UNIX.uid=1000;UNIX.gid=1000;unique=123456789ab; {MLST_FILE_NAME}
 250 End.
 """  # noqa: E501
 
@@ -243,7 +245,7 @@ class FTPTest(TestCase):
         aware_date = datetime.datetime(2026, 1, 1, 10, 30, 15, tzinfo=datetime.UTC)
 
         with self.settings(TIME_ZONE="America/Montreal", USE_TZ=True):
-            last_modified = self.storage.get_modified_time("file-name.ext")
+            last_modified = self.storage.get_modified_time(MLST_FILE_NAME)
             self.assertTrue(timezone.is_aware(last_modified))
             self.assertEqual(aware_date, last_modified)
 
@@ -254,9 +256,43 @@ class FTPTest(TestCase):
 
         with self.settings(TIME_ZONE="America/Montreal", USE_TZ=False):
             naive_date = timezone.make_naive(aware_date)
-            last_modified = self.storage.get_modified_time("file-name.ext")
+            last_modified = self.storage.get_modified_time(MLST_FILE_NAME)
             self.assertTrue(timezone.is_naive(last_modified))
             self.assertEqual(naive_date, last_modified)
+
+    @patch(
+        "ftplib.FTP",
+        **{"return_value.sendcmd.return_value": MLST_VALID.replace("modify", "create")},
+    )
+    def test_get_modified_time_modify_missing(self, mock_ftp):
+        """An FTPStorageException is raised if the "modify" attribute is missing."""
+        with self.assertRaisesRegex(
+            ftp.FTPStorageException, 'does not contain a "modify" attribute'
+        ):
+            self.storage.get_modified_time(MLST_FILE_NAME)
+
+    @patch(
+        "ftplib.FTP",
+        **{
+            "return_value.sendcmd.return_value": MLST_VALID.replace(
+                "20260101103015", "20260101"
+            )
+        },
+    )
+    def test_get_modified_time_bad_timestamp(self, mock_ftp):
+        """An FTPStorageException is raised if the "modify" timestamp is invalid."""
+        with self.assertRaisesRegex(
+            ftp.FTPStorageException, '"modify" timestamp is in an unexpected format'
+        ):
+            self.storage.get_modified_time(MLST_FILE_NAME)
+
+    @patch("ftplib.FTP", **{"return_value.sendcmd.side_effect": OSError()})
+    def test_get_modified_time_ftp_error(self, mock_ftp):
+        """An FTPStorageException is raised if sendcmd encounters an FTP error."""
+        with self.assertRaisesRegex(
+            ftp.FTPStorageException, "Error getting listing for file"
+        ):
+            self.storage.get_modified_time(MLST_FILE_NAME)
 
 
 class FTPStorageFileTest(TestCase):

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 from unittest.mock import patch
 
@@ -5,6 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.core.files.base import File
 from django.test import TestCase
 from django.test import override_settings
+from django.utils import timezone
 
 from storages.backends import ftp
 
@@ -16,6 +18,11 @@ PORT = 2121
 LIST_FIXTURE = """drwxr-xr-x   2 ftp      nogroup      4096 Jul 27 09:46 dir
 -rw-r--r--   1 ftp      nogroup      1024 Jul 27 09:45 fi
 -rw-r--r--   1 ftp      nogroup      2048 Jul 27 09:50 fi2"""
+
+MLST_VALID = """250-Begin
+ type=file;size=256;modify=20260101103015;UNIX.mode=0644;UNIX.uid=1000;UNIX.gid=1000;unique=123456789ab; file-name.ext
+250 End.
+"""  # noqa: E501
 
 
 def geturl(scheme="ftp", pwd=PASSWORD):
@@ -229,6 +236,27 @@ class FTPTest(TestCase):
             self.storage.url("foo")
         self.storage = ftp.FTPStorage(location=URL, base_url="http://foo.bar/")
         self.assertEqual("http://foo.bar/foo", self.storage.url("foo"))
+
+    @patch("ftplib.FTP", **{"return_value.sendcmd.return_value": MLST_VALID})
+    def test_get_modified_time_aware(self, mock_ftp):
+        """The correct datetime is returned in a timezone-aware context."""
+        aware_date = datetime.datetime(2026, 1, 1, 10, 30, 15, tzinfo=datetime.UTC)
+
+        with self.settings(TIME_ZONE="America/Montreal", USE_TZ=True):
+            last_modified = self.storage.get_modified_time("file-name.ext")
+            self.assertTrue(timezone.is_aware(last_modified))
+            self.assertEqual(aware_date, last_modified)
+
+    @patch("ftplib.FTP", **{"return_value.sendcmd.return_value": MLST_VALID})
+    def test_get_modified_time_naive(self, mock_ftp):
+        """The correct datetime is returned in a timezone-naive context."""
+        aware_date = datetime.datetime(2026, 1, 1, 10, 30, 15, tzinfo=datetime.UTC)
+
+        with self.settings(TIME_ZONE="America/Montreal", USE_TZ=False):
+            naive_date = timezone.make_naive(aware_date)
+            last_modified = self.storage.get_modified_time("file-name.ext")
+            self.assertTrue(timezone.is_naive(last_modified))
+            self.assertEqual(naive_date, last_modified)
 
 
 class FTPStorageFileTest(TestCase):

--- a/tests/test_ftp.py
+++ b/tests/test_ftp.py
@@ -242,7 +242,9 @@ class FTPTest(TestCase):
     @patch("ftplib.FTP", **{"return_value.sendcmd.return_value": MLST_VALID})
     def test_get_modified_time_aware(self, mock_ftp):
         """The correct datetime is returned in a timezone-aware context."""
-        aware_date = datetime.datetime(2026, 1, 1, 10, 30, 15, tzinfo=datetime.UTC)
+        aware_date = datetime.datetime(
+            2026, 1, 1, 10, 30, 15, tzinfo=datetime.timezone.utc
+        )
 
         with self.settings(TIME_ZONE="America/Montreal", USE_TZ=True):
             last_modified = self.storage.get_modified_time(MLST_FILE_NAME)
@@ -252,7 +254,9 @@ class FTPTest(TestCase):
     @patch("ftplib.FTP", **{"return_value.sendcmd.return_value": MLST_VALID})
     def test_get_modified_time_naive(self, mock_ftp):
         """The correct datetime is returned in a timezone-naive context."""
-        aware_date = datetime.datetime(2026, 1, 1, 10, 30, 15, tzinfo=datetime.UTC)
+        aware_date = datetime.datetime(
+            2026, 1, 1, 10, 30, 15, tzinfo=datetime.timezone.utc
+        )
 
         with self.settings(TIME_ZONE="America/Montreal", USE_TZ=False):
             naive_date = timezone.make_naive(aware_date)


### PR DESCRIPTION
## Summary
Implemented `get_modified_time` in the `FTPStorage` class, from the `Storage` interface (via `BaseStorage`).

This function returns a file's last updated timestamp as a `datetime` value.

## What's Included

- `storages/backends/ftp.py` — `get_modified_time` function with helper function `_get_file_last_modified_details` (modeled on `_get_dir_details`). This function uses [MLST](https://datatracker.ietf.org/doc/html/rfc3659#section-7) to get last modified data for a given file.

- `tests/test_ftp.py` — Unit tests for success and error cases in the new function.

## Notes

- Unit tests of naive vs timezone-aware datetimes were modeled on those written by `scjody` in `tests/test_gcloud.py`.
- Tests and linting pass when running with changes from #1545.
- From reading the specification at https://datatracker.ietf.org/doc/html/rfc3659#section-2.3, it seems that time values are always expected to be provided in UTC server-side. Because of this, this implementation assumes UTC when reading timestamps from the MLST command. This relates to concerns raised in #1233 about knowing the timezone information for different backends.