### PR TITLE
Add Vercel Blob storage backend

### DIFF
--- a/docs/backends/vercel-blob.rst
+++ b/docs/backends/vercel-blob.rst
@@ -62,7 +62,7 @@ Settings
   A path prefix prepended to all stored file names, e.g. ``"media"`` or
   ``"uploads"``.
 
-``default_acl`` or ``VERCEL_BLOB_DEFAULT_ACL``
+``access`` or ``VERCEL_BLOB_ACCESS``
 
   Default: ``"public"``
 

--- a/docs/backends/vercel-blob.rst
+++ b/docs/backends/vercel-blob.rst
@@ -1,0 +1,93 @@
+Vercel Blob
+===========
+
+A storage backend for `Vercel Blob`_.
+
+.. _Vercel Blob: https://vercel.com/docs/storage/vercel-blob
+
+Installation
+------------
+
+Install with the ``vercel`` extra::
+
+    pip install django-storages[vercel]
+
+Settings
+--------
+
+All settings are available in the Vercel dashboard under **Storage → your store**.
+Vercel sets ``BLOB_READ_WRITE_TOKEN`` automatically in deployed environments; for
+local development, copy it from the store's settings page.
+
+``VERCEL_BLOB_TOKEN``
+
+  **Required.** Your Vercel Blob read-write token.
+
+``VERCEL_BLOB_BASE_URL``
+
+  **Strongly recommended.** The root URL of your blob store, e.g.
+  ``https://abc123.public.blob.vercel-storage.com``. When set, ``url()`` constructs
+  file URLs locally without making an API call. If omitted, each ``url()`` call issues
+  an HTTP request to the Vercel Blob API.
+
+``VERCEL_BLOB_LOCATION``
+
+  Default: ``""``
+
+  A path prefix prepended to all stored file names, e.g. ``"media"`` or ``"uploads"``.
+
+``VERCEL_BLOB_ALLOW_OVERWRITE``
+
+  Default: ``False``
+
+  When ``True``, saving a file with an existing pathname replaces it in the store.
+  Note that CDN caches may take up to 60 seconds to reflect the change.
+
+``VERCEL_BLOB_ADD_RANDOM_SUFFIX``
+
+  Default: ``False``
+
+  When ``True``, Vercel appends a random suffix to the stored pathname to guarantee
+  uniqueness. The actual stored name is recorded in the model field.
+
+``VERCEL_BLOB_CACHE_CONTROL_MAX_AGE``
+
+  Default: ``None``
+
+  Override the CDN cache TTL (in seconds) for uploaded files. When ``None``, Vercel
+  uses its default (typically 1 year for public blobs).
+
+Configuration
+-------------
+
+Add the following to your Django settings:
+
+.. code-block:: python
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "storages.backends.vercel_blob.VercelBlobStorage",
+            "OPTIONS": {
+                "token": "verbl_...",        # or omit and set VERCEL_BLOB_TOKEN
+                "base_url": "https://<store-id>.public.blob.vercel-storage.com",
+                "location": "media",
+            },
+        },
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    }
+
+Notes
+-----
+
+- Vercel Blob does not support directories. Folders are simulated via ``/`` in
+  pathnames. ``listdir()`` uses Vercel's folded listing mode to present this as a
+  directory tree.
+- Write-mode file opening (``open(name, "wb")``) is not supported. Use
+  ``storage.save()`` to upload files.
+- Deleting a file that does not exist is a no-op (idempotent).
+- For **private** blobs, ``url()`` returns the raw blob URL which requires
+  authentication. You will need to proxy downloads through a Django view that adds
+  the bearer token. Public blob stores are recommended for use with Django's
+  ``ImageField`` and ``FileField``.

--- a/docs/backends/vercel-blob.rst
+++ b/docs/backends/vercel-blob.rst
@@ -36,6 +36,13 @@ local development, copy it from the store's settings page.
 
   A path prefix prepended to all stored file names, e.g. ``"media"`` or ``"uploads"``.
 
+``VERCEL_BLOB_DEFAULT_ACL``
+
+  Default: ``"public"``
+
+  Access level for uploaded files. Must match your store's access configuration in
+  the Vercel dashboard. Set to ``"private"`` for private stores.
+
 ``VERCEL_BLOB_ALLOW_OVERWRITE``
 
   Default: ``False``

--- a/docs/backends/vercel-blob.rst
+++ b/docs/backends/vercel-blob.rst
@@ -12,78 +12,83 @@ Install with the ``vercel`` extra::
 
     pip install django-storages[vercel]
 
-Settings
---------
+Configuration & Settings
+------------------------
 
-All settings are available in the Vercel dashboard under **Storage → your store**.
-Vercel sets ``BLOB_READ_WRITE_TOKEN`` automatically in deployed environments; for
-local development, copy it from the store's settings page.
+To use Vercel Blob as the default file storage backend::
 
-``VERCEL_BLOB_TOKEN``
+  STORAGES = {
+      "default": {
+          "BACKEND": "storages.backends.vercel_blob.VercelBlobStorage",
+          "OPTIONS": {
+            ...your_options_here
+          },
+      },
+  }
+
+The settings below list both the ``OPTIONS`` key and the equivalent Django
+setting. See the `Vercel Blob SDK reference`_ for further details on each
+option.
+
+.. _Vercel Blob SDK reference: https://vercel.com/docs/vercel-blob/using-blob-sdk
+
+Credentials
+~~~~~~~~~~~
+
+Vercel sets ``BLOB_READ_WRITE_TOKEN`` automatically in deployed environments.
+For local development, copy it from the Vercel dashboard under
+**Storage → your store → Settings**.
+
+``token`` or ``VERCEL_BLOB_TOKEN``
 
   **Required.** Your Vercel Blob read-write token.
 
-``VERCEL_BLOB_BASE_URL``
+Settings
+~~~~~~~~
+
+``base_url`` or ``VERCEL_BLOB_BASE_URL``
 
   **Strongly recommended.** The root URL of your blob store, e.g.
-  ``https://abc123.public.blob.vercel-storage.com``. When set, ``url()`` constructs
-  file URLs locally without making an API call. If omitted, each ``url()`` call issues
-  an HTTP request to the Vercel Blob API.
+  ``https://abc123.public.blob.vercel-storage.com``. When set, ``url()``
+  constructs file URLs locally without making an API call. If omitted, each
+  ``url()`` call issues an HTTP request to the Vercel Blob API.
 
-``VERCEL_BLOB_LOCATION``
+  Find your store URL in the Vercel dashboard under **Storage → your store**.
+
+``location`` or ``VERCEL_BLOB_LOCATION``
 
   Default: ``""``
 
-  A path prefix prepended to all stored file names, e.g. ``"media"`` or ``"uploads"``.
+  A path prefix prepended to all stored file names, e.g. ``"media"`` or
+  ``"uploads"``.
 
-``VERCEL_BLOB_DEFAULT_ACL``
+``default_acl`` or ``VERCEL_BLOB_DEFAULT_ACL``
 
   Default: ``"public"``
 
-  Access level for uploaded files. Must match your store's access configuration in
-  the Vercel dashboard. Set to ``"private"`` for private stores.
+  Access level for uploaded files: ``"public"`` or ``"private"``. Public stores
+  accept either value; private stores only accept ``"private"``.
 
-``VERCEL_BLOB_ALLOW_OVERWRITE``
-
-  Default: ``False``
-
-  When ``True``, saving a file with an existing pathname replaces it in the store.
-  Note that CDN caches may take up to 60 seconds to reflect the change.
-
-``VERCEL_BLOB_ADD_RANDOM_SUFFIX``
+``allow_overwrite`` or ``VERCEL_BLOB_ALLOW_OVERWRITE``
 
   Default: ``False``
 
-  When ``True``, Vercel appends a random suffix to the stored pathname to guarantee
-  uniqueness. The actual stored name is recorded in the model field.
+  When ``True``, saving a file with an existing pathname replaces it in the
+  store. Note that CDN caches may take up to 60 seconds to reflect the change.
 
-``VERCEL_BLOB_CACHE_CONTROL_MAX_AGE``
+``add_random_suffix`` or ``VERCEL_BLOB_ADD_RANDOM_SUFFIX``
+
+  Default: ``False``
+
+  When ``True``, Vercel appends a random suffix to the stored pathname to
+  guarantee uniqueness. The actual stored name is recorded in the model field.
+
+``cache_control_max_age`` or ``VERCEL_BLOB_CACHE_CONTROL_MAX_AGE``
 
   Default: ``None``
 
-  Override the CDN cache TTL (in seconds) for uploaded files. When ``None``, Vercel
-  uses its default (typically 1 year for public blobs).
-
-Configuration
--------------
-
-Add the following to your Django settings:
-
-.. code-block:: python
-
-    STORAGES = {
-        "default": {
-            "BACKEND": "storages.backends.vercel_blob.VercelBlobStorage",
-            "OPTIONS": {
-                "token": "verbl_...",        # or omit and set VERCEL_BLOB_TOKEN
-                "base_url": "https://<store-id>.public.blob.vercel-storage.com",
-                "location": "media",
-            },
-        },
-        "staticfiles": {
-            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
-        },
-    }
+  Override the CDN cache TTL (in seconds) for uploaded files. When ``None``,
+  Vercel uses its default (typically 1 year for public blobs).
 
 Notes
 -----
@@ -96,5 +101,4 @@ Notes
 - Deleting a file that does not exist is a no-op (idempotent).
 - For **private** blobs, ``url()`` returns the raw blob URL which requires
   authentication. You will need to proxy downloads through a Django view that adds
-  the bearer token. Public blob stores are recommended for use with Django's
-  ``ImageField`` and ``FileField``.
+  the bearer token.

--- a/docs/backends/vercel-blob.rst
+++ b/docs/backends/vercel-blob.rst
@@ -26,6 +26,20 @@ To use Vercel Blob as the default file storage backend::
       },
   }
 
+For static files via ``collectstatic``, use the ``"staticfiles"`` key instead
+of (or alongside) ``"default"``::
+
+  STORAGES = {
+      "staticfiles": {
+          "BACKEND": "storages.backends.vercel_blob.VercelBlobStorage",
+      },
+  }
+
+On Django < 4.2, use the legacy settings instead::
+
+    DEFAULT_FILE_STORAGE = "storages.backends.vercel_blob.VercelBlobStorage"
+    STATICFILES_STORAGE = "storages.backends.vercel_blob.VercelBlobStorage"
+
 The settings below list both the ``OPTIONS`` key and the equivalent Django
 setting. See the `Vercel Blob SDK reference`_ for further details on each
 option.
@@ -42,6 +56,11 @@ For local development, copy it from the Vercel dashboard under
 ``token`` or ``VERCEL_BLOB_TOKEN``
 
   **Required.** Your Vercel Blob read-write token.
+
+.. warning::
+
+   Keep your token secret. Never hard-code it in source code or commit it to
+   version control. Use environment variables or a secrets manager instead.
 
 Settings
 ~~~~~~~~

--- a/docs/backends/vercel-blob.rst
+++ b/docs/backends/vercel-blob.rst
@@ -96,8 +96,6 @@ Notes
 - Vercel Blob does not support directories. Folders are simulated via ``/`` in
   pathnames. ``listdir()`` uses Vercel's folded listing mode to present this as a
   directory tree.
-- Write-mode file opening (``open(name, "wb")``) is not supported. Use
-  ``storage.save()`` to upload files.
 - Deleting a file that does not exist is a no-op (idempotent).
 - For **private** blobs, ``url()`` returns the raw blob URL which requires
   authentication. You will need to proxy downloads through a Django view that adds

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ django-storages is a collection of custom storage backends for Django.
    backends/gcloud
    backends/sftp
    backends/s3_compatible/index
+   backends/vercel-blob
 
 Installation
 ************

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ s3 = [
 sftp = [
   "paramiko>=1.15",
 ]
+vercel = [
+  "requests>=2.20.0",
+]
 [project.urls]
 Homepage = "https://github.com/jschneier/django-storages"
 

--- a/storages/backends/vercel_blob.py
+++ b/storages/backends/vercel_blob.py
@@ -54,6 +54,10 @@ class VercelBlobStorage(BaseStorage):
                 "VercelBlobStorage requires a token. Set VERCEL_BLOB_TOKEN in your "
                 "Django settings or the BLOB_READ_WRITE_TOKEN environment variable."
             )
+        if self.default_acl not in ("public", "private"):
+            raise ImproperlyConfigured(
+                "VERCEL_BLOB_DEFAULT_ACL must be 'public' or 'private'."
+            )
         check_location(self)
 
     def get_default_settings(self):
@@ -61,6 +65,7 @@ class VercelBlobStorage(BaseStorage):
             "token": setting("VERCEL_BLOB_TOKEN"),
             "location": setting("VERCEL_BLOB_LOCATION", ""),
             "base_url": setting("VERCEL_BLOB_BASE_URL"),
+            "default_acl": setting("VERCEL_BLOB_DEFAULT_ACL", "public"),
             "allow_overwrite": setting("VERCEL_BLOB_ALLOW_OVERWRITE", False),
             "cache_control_max_age": setting("VERCEL_BLOB_CACHE_CONTROL_MAX_AGE"),
             "add_random_suffix": setting("VERCEL_BLOB_ADD_RANDOM_SUFFIX", False),
@@ -83,15 +88,21 @@ class VercelBlobStorage(BaseStorage):
 
     def _save(self, name, content):
         pathname = self._get_pathname(name)
-        content_type, _ = mimetypes.guess_type(name)
+        content_type = (
+            getattr(content, "content_type", None)
+            or mimetypes.guess_type(name)[0]
+            or "application/octet-stream"
+        )
 
         headers = {
             "x-api-version": "7",
-            "content-type": content_type or "application/octet-stream",
-            "x-allow-overwrite": "1" if self.allow_overwrite else "0",
+            "content-type": "application/octet-stream",
+            "x-content-type": content_type,
+            "x-vercel-blob-access": self.default_acl,
+            "x-add-random-suffix": "1" if self.add_random_suffix else "0",
         }
-        if not self.add_random_suffix:
-            headers["x-add-random-suffix"] = "0"
+        if self.allow_overwrite:
+            headers["x-allow-overwrite"] = "1"
         if self.cache_control_max_age is not None:
             headers["x-cache-control-max-age"] = str(self.cache_control_max_age)
 

--- a/storages/backends/vercel_blob.py
+++ b/storages/backends/vercel_blob.py
@@ -128,7 +128,7 @@ class VercelBlobStorage(BaseStorage):
     def delete(self, name):
         file_url = self.url(name)
         response = self._make_request(
-            "DELETE",
+            "POST",
             f"{VERCEL_BLOB_API_URL}/delete",
             json={"urls": [file_url]},
             headers={"content-type": "application/json"},

--- a/storages/backends/vercel_blob.py
+++ b/storages/backends/vercel_blob.py
@@ -12,6 +12,7 @@ from django.core.files.base import File
 from storages.base import BaseStorage
 from storages.utils import check_location
 from storages.utils import clean_name
+from storages.utils import is_seekable
 from storages.utils import safe_join
 from storages.utils import setting
 
@@ -23,25 +24,46 @@ class VercelBlobException(Exception):
 
 
 class VercelBlobFile(File):
-    def __init__(self, name, storage):
+    def __init__(self, name, mode, storage):
         self.name = name
+        self._mode = mode
         self._storage = storage
         self._file = None
+        self._is_dirty = False
 
     def _get_file(self):
         if self._file is None:
             self._file = SpooledTemporaryFile()
-            response = self._storage._make_request("GET", self._storage.url(self.name))
-            response.raise_for_status()
-            with BytesIO(response.content) as content:
-                copyfileobj(content, self._file)
-            self._file.seek(0)
+            if "r" in self._mode:
+                response = self._storage._make_request("GET", self._storage.url(self.name))
+                response.raise_for_status()
+                with BytesIO(response.content) as content:
+                    copyfileobj(content, self._file)
+                self._file.seek(0)
         return self._file
 
     def _set_file(self, value):
         self._file = value
 
     file = property(_get_file, _set_file)
+
+    def read(self, *args, **kwargs):
+        if "r" not in self._mode:
+            raise AttributeError("File was not opened in read mode.")
+        return super().read(*args, **kwargs)
+
+    def write(self, content):
+        if "w" not in self._mode:
+            raise AttributeError("File was not opened in write mode.")
+        self._is_dirty = True
+        return super().write(content)
+
+    def close(self):
+        if self._is_dirty:
+            self._is_dirty = False
+            self._file.seek(0)
+            self._storage._save(self.name, self._file)
+        super().close()
 
 
 class VercelBlobStorage(BaseStorage):
@@ -82,9 +104,7 @@ class VercelBlobStorage(BaseStorage):
         return clean_name(name)
 
     def _open(self, name, mode="rb"):
-        if "w" in mode:
-            raise ValueError("Vercel Blob storage does not support writing via _open. Use save() instead.")
-        return VercelBlobFile(name, self)
+        return VercelBlobFile(name, mode, self)
 
     def _save(self, name, content):
         pathname = self._get_pathname(name)
@@ -106,14 +126,14 @@ class VercelBlobStorage(BaseStorage):
         if self.cache_control_max_age is not None:
             headers["x-cache-control-max-age"] = str(self.cache_control_max_age)
 
-        content.open()
+        if is_seekable(content):
+            content.seek(0)
         response = self._make_request(
             "PUT",
             f"{VERCEL_BLOB_API_URL}/{pathname}",
             headers=headers,
             data=content.read(),
         )
-        content.close()
         response.raise_for_status()
 
         data = response.json()

--- a/storages/backends/vercel_blob.py
+++ b/storages/backends/vercel_blob.py
@@ -136,13 +136,16 @@ class VercelBlobStorage(BaseStorage):
         response.raise_for_status()
 
     def exists(self, name):
-        file_url = self.url(name)
+        pathname = self._get_pathname(name)
         response = self._make_request(
             "GET",
             f"{VERCEL_BLOB_API_URL}/",
-            params={"url": file_url},
+            params={"prefix": pathname, "limit": 1},
         )
-        return response.status_code == 200
+        if response.status_code != 200:
+            return False
+        blobs = response.json().get("blobs", [])
+        return any(blob["pathname"] == pathname for blob in blobs)
 
     def url(self, name):
         if self.base_url:

--- a/storages/backends/vercel_blob.py
+++ b/storages/backends/vercel_blob.py
@@ -1,0 +1,184 @@
+"""Vercel Blob storage backend for Django."""
+
+import mimetypes
+from io import BytesIO
+from shutil import copyfileobj
+from tempfile import SpooledTemporaryFile
+
+import requests
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import File
+
+from storages.base import BaseStorage
+from storages.utils import check_location
+from storages.utils import clean_name
+from storages.utils import safe_join
+from storages.utils import setting
+
+VERCEL_BLOB_API_URL = "https://blob.vercel-storage.com"
+
+
+class VercelBlobException(Exception):
+    pass
+
+
+class VercelBlobFile(File):
+    def __init__(self, name, storage):
+        self.name = name
+        self._storage = storage
+        self._file = None
+
+    def _get_file(self):
+        if self._file is None:
+            self._file = SpooledTemporaryFile()
+            response = self._storage._make_request("GET", self._storage.url(self.name))
+            response.raise_for_status()
+            with BytesIO(response.content) as content:
+                copyfileobj(content, self._file)
+            self._file.seek(0)
+        return self._file
+
+    def _set_file(self, value):
+        self._file = value
+
+    file = property(_get_file, _set_file)
+
+
+class VercelBlobStorage(BaseStorage):
+    """Vercel Blob Storage backend for Django."""
+
+    def __init__(self, **settings):
+        super().__init__(**settings)
+        if not self.token:
+            raise ImproperlyConfigured(
+                "VercelBlobStorage requires a token. Set VERCEL_BLOB_TOKEN in your "
+                "Django settings or the BLOB_READ_WRITE_TOKEN environment variable."
+            )
+        check_location(self)
+
+    def get_default_settings(self):
+        return {
+            "token": setting("VERCEL_BLOB_TOKEN"),
+            "location": setting("VERCEL_BLOB_LOCATION", ""),
+            "base_url": setting("VERCEL_BLOB_BASE_URL"),
+            "allow_overwrite": setting("VERCEL_BLOB_ALLOW_OVERWRITE", False),
+            "cache_control_max_age": setting("VERCEL_BLOB_CACHE_CONTROL_MAX_AGE"),
+            "add_random_suffix": setting("VERCEL_BLOB_ADD_RANDOM_SUFFIX", False),
+        }
+
+    def _make_request(self, method, url, **kwargs):
+        headers = kwargs.pop("headers", {})
+        headers["authorization"] = f"Bearer {self.token}"
+        return requests.request(method, url, headers=headers, **kwargs)
+
+    def _get_pathname(self, name):
+        if self.location:
+            return safe_join(self.location, name)
+        return clean_name(name)
+
+    def _open(self, name, mode="rb"):
+        if "w" in mode:
+            raise ValueError("Vercel Blob storage does not support writing via _open. Use save() instead.")
+        return VercelBlobFile(name, self)
+
+    def _save(self, name, content):
+        pathname = self._get_pathname(name)
+        content_type, _ = mimetypes.guess_type(name)
+
+        headers = {
+            "x-api-version": "7",
+            "content-type": content_type or "application/octet-stream",
+            "x-allow-overwrite": "1" if self.allow_overwrite else "0",
+        }
+        if not self.add_random_suffix:
+            headers["x-add-random-suffix"] = "0"
+        if self.cache_control_max_age is not None:
+            headers["x-cache-control-max-age"] = str(self.cache_control_max_age)
+
+        content.open()
+        response = self._make_request(
+            "PUT",
+            f"{VERCEL_BLOB_API_URL}/{pathname}",
+            headers=headers,
+            data=content.read(),
+        )
+        content.close()
+        response.raise_for_status()
+
+        data = response.json()
+        stored_pathname = data["pathname"]
+
+        # Strip location prefix to return just the relative name
+        if self.location and stored_pathname.startswith(self.location.rstrip("/") + "/"):
+            stored_pathname = stored_pathname[len(self.location.rstrip("/")) + 1:]
+
+        return clean_name(stored_pathname)
+
+    def delete(self, name):
+        file_url = self.url(name)
+        response = self._make_request(
+            "DELETE",
+            f"{VERCEL_BLOB_API_URL}/delete",
+            json={"urls": [file_url]},
+            headers={"content-type": "application/json"},
+        )
+        response.raise_for_status()
+
+    def exists(self, name):
+        file_url = self.url(name)
+        response = self._make_request(
+            "GET",
+            f"{VERCEL_BLOB_API_URL}/",
+            params={"url": file_url},
+        )
+        return response.status_code == 200
+
+    def url(self, name):
+        if self.base_url:
+            pathname = self._get_pathname(name)
+            return f"{self.base_url.rstrip('/')}/{pathname}"
+        # Fall back to head API to discover the URL
+        response = self._make_request(
+            "GET",
+            f"{VERCEL_BLOB_API_URL}/",
+            params={"url": self._get_pathname(name)},
+        )
+        response.raise_for_status()
+        return response.json()["url"]
+
+    def size(self, name):
+        file_url = self.url(name)
+        response = self._make_request(
+            "GET",
+            f"{VERCEL_BLOB_API_URL}/",
+            params={"url": file_url},
+        )
+        response.raise_for_status()
+        return response.json()["size"]
+
+    def listdir(self, path):
+        prefix = self._get_pathname(path) if path else self.location
+        params = {"prefix": prefix, "mode": "folded"}
+        response = self._make_request(
+            "GET",
+            f"{VERCEL_BLOB_API_URL}/",
+            params=params,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        prefix_stripped = (prefix.rstrip("/") + "/") if prefix else ""
+
+        directories = []
+        for folder in data.get("folders", []):
+            folder_name = folder.removeprefix(prefix_stripped).rstrip("/")
+            if folder_name:
+                directories.append(folder_name)
+
+        files = []
+        for blob in data.get("blobs", []):
+            file_name = blob["pathname"].removeprefix(prefix_stripped)
+            if file_name:
+                files.append(file_name)
+
+        return directories, files

--- a/storages/backends/vercel_blob.py
+++ b/storages/backends/vercel_blob.py
@@ -54,9 +54,9 @@ class VercelBlobStorage(BaseStorage):
                 "VercelBlobStorage requires a token. Set VERCEL_BLOB_TOKEN in your "
                 "Django settings or the BLOB_READ_WRITE_TOKEN environment variable."
             )
-        if self.default_acl not in ("public", "private"):
+        if self.access not in ("public", "private"):
             raise ImproperlyConfigured(
-                "VERCEL_BLOB_DEFAULT_ACL must be 'public' or 'private'."
+                "VERCEL_BLOB_ACCESS must be 'public' or 'private'."
             )
         check_location(self)
 
@@ -65,7 +65,7 @@ class VercelBlobStorage(BaseStorage):
             "token": setting("VERCEL_BLOB_TOKEN"),
             "location": setting("VERCEL_BLOB_LOCATION", ""),
             "base_url": setting("VERCEL_BLOB_BASE_URL"),
-            "default_acl": setting("VERCEL_BLOB_DEFAULT_ACL", "public"),
+            "access": setting("VERCEL_BLOB_ACCESS", "public"),
             "allow_overwrite": setting("VERCEL_BLOB_ALLOW_OVERWRITE", False),
             "cache_control_max_age": setting("VERCEL_BLOB_CACHE_CONTROL_MAX_AGE"),
             "add_random_suffix": setting("VERCEL_BLOB_ADD_RANDOM_SUFFIX", False),
@@ -98,7 +98,7 @@ class VercelBlobStorage(BaseStorage):
             "x-api-version": "7",
             "content-type": "application/octet-stream",
             "x-content-type": content_type,
-            "x-vercel-blob-access": self.default_acl,
+            "x-vercel-blob-access": self.access,
             "x-add-random-suffix": "1" if self.add_random_suffix else "0",
         }
         if self.allow_overwrite:

--- a/tests/test_vercel_blob.py
+++ b/tests/test_vercel_blob.py
@@ -118,6 +118,18 @@ class TestVercelBlobStorageSave(TestCase):
         self.assertEqual(name, "photo.jpg")
 
     @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_sends_access_header(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/f.txt", "pathname": "f.txt"}
+        mock_request.return_value = mock_response
+
+        storage = make_storage(default_acl="private")
+        storage._save("f.txt", ContentFile(b"data"))
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers["x-vercel-blob-access"], "private")
+
+    @patch("storages.backends.vercel_blob.requests.request")
     def test_save_sets_content_type(self, mock_request):
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -128,7 +140,23 @@ class TestVercelBlobStorageSave(TestCase):
         storage._save("img.png", ContentFile(b"\x89PNG"))
 
         headers = mock_request.call_args[1]["headers"]
-        self.assertEqual(headers["content-type"], "image/png")
+        self.assertEqual(headers["x-content-type"], "image/png")
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_content_type_from_file_object(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/upload", "pathname": "upload"}
+        mock_request.return_value = mock_response
+
+        content = ContentFile(b"data")
+        content.content_type = "image/webp"
+
+        storage = make_storage()
+        storage._save("upload", content)
+
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers["x-content-type"], "image/webp")
 
     @patch("storages.backends.vercel_blob.requests.request")
     def test_save_with_cache_control(self, mock_request):
@@ -180,7 +208,7 @@ class TestVercelBlobStorageSave(TestCase):
         storage._save("f.unknownextension", ContentFile(b"data"))
 
         headers = mock_request.call_args[1]["headers"]
-        self.assertEqual(headers["content-type"], "application/octet-stream")
+        self.assertEqual(headers["x-content-type"], "application/octet-stream")
 
 
 class TestVercelBlobStorageDelete(TestCase):

--- a/tests/test_vercel_blob.py
+++ b/tests/test_vercel_blob.py
@@ -232,19 +232,40 @@ class TestVercelBlobStorageExists(TestCase):
     def test_exists_true(self, mock_request):
         mock_response = MagicMock()
         mock_response.status_code = 200
+        mock_response.json.return_value = {"blobs": [{"pathname": "file.txt"}]}
         mock_request.return_value = mock_response
 
         storage = make_storage()
         self.assertTrue(storage.exists("file.txt"))
 
     @patch("storages.backends.vercel_blob.requests.request")
-    def test_exists_false(self, mock_request):
+    def test_exists_false_empty_list(self, mock_request):
         mock_response = MagicMock()
-        mock_response.status_code = 404
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"blobs": []}
         mock_request.return_value = mock_response
 
         storage = make_storage()
         self.assertFalse(storage.exists("missing.txt"))
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_exists_false_on_error(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        self.assertFalse(storage.exists("file.txt"))
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_exists_no_base_url(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"blobs": [{"pathname": "file.txt"}]}
+        mock_request.return_value = mock_response
+
+        storage = make_storage(base_url=None)
+        self.assertTrue(storage.exists("file.txt"))
 
 
 class TestVercelBlobStorageSize(TestCase):

--- a/tests/test_vercel_blob.py
+++ b/tests/test_vercel_blob.py
@@ -222,7 +222,7 @@ class TestVercelBlobStorageDelete(TestCase):
         storage.delete("myfile.txt")
 
         call_args = mock_request.call_args
-        self.assertEqual(call_args[0][0], "DELETE")
+        self.assertEqual(call_args[0][0], "POST")
         self.assertIn("delete", call_args[0][1])
         self.assertIn(f"{MOCK_BASE_URL}/myfile.txt", call_args[1]["json"]["urls"])
 

--- a/tests/test_vercel_blob.py
+++ b/tests/test_vercel_blob.py
@@ -124,7 +124,7 @@ class TestVercelBlobStorageSave(TestCase):
         mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/f.txt", "pathname": "f.txt"}
         mock_request.return_value = mock_response
 
-        storage = make_storage(default_acl="private")
+        storage = make_storage(access="private")
         storage._save("f.txt", ContentFile(b"data"))
         headers = mock_request.call_args[1]["headers"]
         self.assertEqual(headers["x-vercel-blob-access"], "private")

--- a/tests/test_vercel_blob.py
+++ b/tests/test_vercel_blob.py
@@ -313,7 +313,19 @@ class TestVercelBlobFile(TestCase):
         self.assertIsInstance(f, VercelBlobFile)
         self.assertEqual(f.read(), b"file content")
 
-    def test_open_write_mode_raises(self):
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_open_write_mode_uploads_on_close(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/file.txt", "pathname": "file.txt"}
+        mock_request.return_value = mock_response
+
         storage = make_storage()
-        with self.assertRaises(ValueError):
-            storage._open("file.txt", mode="wb")
+        f = storage._open("file.txt", mode="wb")
+        f.write(b"hello")
+        f.close()
+
+        # Should have issued a PUT to upload the written content
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[0][0], "PUT")
+        self.assertIn("file.txt", call_args[0][1])

--- a/tests/test_vercel_blob.py
+++ b/tests/test_vercel_blob.py
@@ -1,0 +1,270 @@
+"""Tests for the Vercel Blob storage backend."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.core.files.base import ContentFile
+from django.test import TestCase, override_settings
+
+from storages.backends.vercel_blob import VercelBlobException, VercelBlobFile, VercelBlobStorage
+from tests.utils import NonSeekableContentFile
+
+MOCK_TOKEN = "verbl_test_token"
+MOCK_BASE_URL = "https://abc123.public.blob.vercel-storage.com"
+
+
+def make_storage(**kwargs):
+    defaults = {"token": MOCK_TOKEN, "base_url": MOCK_BASE_URL}
+    defaults.update(kwargs)
+    return VercelBlobStorage(**defaults)
+
+
+class TestVercelBlobStorageInit(TestCase):
+    def test_requires_token(self):
+        with self.assertRaises(ImproperlyConfigured):
+            VercelBlobStorage(token=None)
+
+    def test_location_cannot_start_with_slash(self):
+        with self.assertRaises(ImproperlyConfigured):
+            make_storage(location="/media")
+
+    def test_default_settings(self):
+        storage = make_storage()
+        self.assertFalse(storage.allow_overwrite)
+        self.assertFalse(storage.add_random_suffix)
+        self.assertIsNone(storage.cache_control_max_age)
+        self.assertEqual(storage.location, "")
+
+    @override_settings(VERCEL_BLOB_TOKEN="settings_token")
+    def test_token_from_django_settings(self):
+        storage = VercelBlobStorage(base_url=MOCK_BASE_URL)
+        self.assertEqual(storage.token, "settings_token")
+
+    def test_override_class_variable(self):
+        class CustomStorage(VercelBlobStorage):
+            location = "custom-prefix"
+
+        storage = CustomStorage(token=MOCK_TOKEN, base_url=MOCK_BASE_URL)
+        self.assertEqual(storage.location, "custom-prefix")
+
+    def test_override_init_argument(self):
+        storage = make_storage(location="init-prefix", allow_overwrite=True)
+        self.assertEqual(storage.location, "init-prefix")
+        self.assertTrue(storage.allow_overwrite)
+
+
+class TestVercelBlobStorageUrl(TestCase):
+    def test_url_with_base_url(self):
+        storage = make_storage()
+        self.assertEqual(storage.url("myfile.txt"), f"{MOCK_BASE_URL}/myfile.txt")
+
+    def test_url_with_location(self):
+        storage = make_storage(location="media")
+        self.assertEqual(storage.url("photo.jpg"), f"{MOCK_BASE_URL}/media/photo.jpg")
+
+    def test_url_base_url_trailing_slash_normalized(self):
+        storage = make_storage(base_url=MOCK_BASE_URL + "/")
+        self.assertEqual(storage.url("file.txt"), f"{MOCK_BASE_URL}/file.txt")
+
+    def test_url_special_characters(self):
+        storage = make_storage()
+        url = storage.url("uploads/my file (1).jpg")
+        self.assertIn("uploads/my file (1).jpg", url)
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_url_without_base_url_calls_head(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/file.txt"}
+        mock_request.return_value = mock_response
+
+        storage = make_storage(base_url=None)
+        url = storage.url("file.txt")
+        self.assertEqual(url, f"{MOCK_BASE_URL}/file.txt")
+
+
+class TestVercelBlobStorageSave(TestCase):
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_basic(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "url": f"{MOCK_BASE_URL}/hello.txt",
+            "pathname": "hello.txt",
+        }
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        name = storage._save("hello.txt", ContentFile(b"hello world"))
+        self.assertEqual(name, "hello.txt")
+
+        call_kwargs = mock_request.call_args
+        self.assertEqual(call_kwargs[0][0], "PUT")
+        self.assertIn("hello.txt", call_kwargs[0][1])
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_with_location_strips_prefix(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "url": f"{MOCK_BASE_URL}/media/photo.jpg",
+            "pathname": "media/photo.jpg",
+        }
+        mock_request.return_value = mock_response
+
+        storage = make_storage(location="media")
+        name = storage._save("photo.jpg", ContentFile(b"img data"))
+        self.assertEqual(name, "photo.jpg")
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_sets_content_type(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/img.png", "pathname": "img.png"}
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        storage._save("img.png", ContentFile(b"\x89PNG"))
+
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers["content-type"], "image/png")
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_with_cache_control(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/f.txt", "pathname": "f.txt"}
+        mock_request.return_value = mock_response
+
+        storage = make_storage(cache_control_max_age=3600)
+        storage._save("f.txt", ContentFile(b"data"))
+
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers["x-cache-control-max-age"], "3600")
+
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_add_random_suffix_returns_actual_name(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "url": f"{MOCK_BASE_URL}/hello-abc123.txt",
+            "pathname": "hello-abc123.txt",
+        }
+        mock_request.return_value = mock_response
+
+        storage = make_storage(add_random_suffix=True)
+        name = storage._save("hello.txt", ContentFile(b"data"))
+        self.assertEqual(name, "hello-abc123.txt")
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_non_seekable_content(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/f.txt", "pathname": "f.txt"}
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        storage._save("f.txt", NonSeekableContentFile(b"data"))
+        self.assertTrue(mock_request.called)
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_save_unknown_content_type_defaults_to_octet_stream(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"url": f"{MOCK_BASE_URL}/f.bin", "pathname": "f.bin"}
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        storage._save("f.unknownextension", ContentFile(b"data"))
+
+        headers = mock_request.call_args[1]["headers"]
+        self.assertEqual(headers["content-type"], "application/octet-stream")
+
+
+class TestVercelBlobStorageDelete(TestCase):
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_delete(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        storage.delete("myfile.txt")
+
+        call_args = mock_request.call_args
+        self.assertEqual(call_args[0][0], "DELETE")
+        self.assertIn("delete", call_args[0][1])
+        self.assertIn(f"{MOCK_BASE_URL}/myfile.txt", call_args[1]["json"]["urls"])
+
+
+class TestVercelBlobStorageExists(TestCase):
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_exists_true(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        self.assertTrue(storage.exists("file.txt"))
+
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_exists_false(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        self.assertFalse(storage.exists("missing.txt"))
+
+
+class TestVercelBlobStorageSize(TestCase):
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_size(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"size": 1024, "url": f"{MOCK_BASE_URL}/f.txt"}
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        self.assertEqual(storage.size("f.txt"), 1024)
+
+
+class TestVercelBlobStorageListdir(TestCase):
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_listdir(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "blobs": [
+                {"pathname": "media/file1.txt"},
+                {"pathname": "media/file2.jpg"},
+            ],
+            "folders": ["media/subfolder/"],
+        }
+        mock_request.return_value = mock_response
+
+        storage = make_storage(location="media")
+        dirs, files = storage.listdir("")
+        self.assertEqual(dirs, ["subfolder"])
+        self.assertEqual(files, ["file1.txt", "file2.jpg"])
+
+
+class TestVercelBlobFile(TestCase):
+    @patch("storages.backends.vercel_blob.requests.request")
+    def test_open_and_read(self, mock_request):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.content = b"file content"
+        mock_request.return_value = mock_response
+
+        storage = make_storage()
+        f = storage._open("file.txt")
+        self.assertIsInstance(f, VercelBlobFile)
+        self.assertEqual(f.read(), b"file content")
+
+    def test_open_write_mode_raises(self):
+        storage = make_storage()
+        with self.assertRaises(ValueError):
+            storage._open("file.txt", mode="wb")


### PR DESCRIPTION
Adds a storage backend for Vercel Blob (https://vercel.com/docs/storage/vercel-blob).

- Install with `pip install django-storages[vercel]` (adds `requests` dependency).
- New classes:
  - `VercelBlobStorage`: storage backend backed by the Vercel Blob REST API
  - `VercelBlobFile`: lazy read-only file access
- Configurable via Django settings (`VERCEL_BLOB_*`) or `OPTIONS` in `STORAGES`
- Support for public/private ACL, overwrite, random suffix, cache control, and location prefix

Includes unit tests and new docs.
